### PR TITLE
Screenshots

### DIFF
--- a/examples/canvas_screenshots_png_getSnapshot.html
+++ b/examples/canvas_screenshots_png_getSnapshot.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Capturing PNG Screenshots</title>
+    <link href="css/styles.css" type="text/css" rel="stylesheet"/>
+
+    <style>
+        #myCanvas {
+            background: lightblue;
+        }
+
+        #screenshots {
+            margin-top: 20px;
+            overflow-y: scroll;
+            height: 600px;
+            pointer-events: all;
+        }
+
+        #info {
+            position: absolute;
+            top: 0;
+            z-index: 200000;
+            float: right;
+            right: 0;
+            padding: 10px;
+            height: auto;
+            text-align: left;
+            pointer-events: none;
+            background: RGBA(0, 0, 0, 0.4);
+            max-width: 500px;
+            color: white;
+        }
+
+    </style>
+
+
+</head>
+<body>
+
+<canvas id="myCanvas"></canvas>
+
+<div id="info">
+    <h1>Capturing PNG Screenshots</h1>
+    <p>Using viewer.scene.canvas.getSnapahsot()</p>
+    <ul>
+        <li>
+            <a target="_other"
+               href="./../docs/class/src/plugins/GLTFLoaderPlugin/GLTFLoaderPlugin.js~GLTFLoaderPlugin.html">GLTFLoaderPlugin</a>
+            - Loads model and IFC data from file system
+        </li>
+        <li>
+            <a target="_other"
+               href="https://github.com/openBIMstandards/DataSetSchependomlaan">Model source</a>
+        </li>
+        <li>
+            <a target="_other" href="https://github.com/xeolabs/xeokit-sdk/wiki/Plan-Views">User Guide</a>
+        </li>
+    </ul>
+    <div id="screenshots"></div>
+</div>
+
+</body>
+
+<script type="module">
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Import the modules we need for this example
+    //------------------------------------------------------------------------------------------------------------------
+
+    import {Viewer} from "../src/viewer/Viewer.js";
+    import {GLTFLoaderPlugin} from "../src/plugins/GLTFLoaderPlugin/GLTFLoaderPlugin.js";
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a Viewer, arrange the camera
+    //------------------------------------------------------------------------------------------------------------------
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas",
+        transparent: true, // Default
+        preserveDrawingBuffer: true // Default - needed true for canvas screenshots
+    });
+
+    viewer.camera.eye = [-3.933, 2.855, 27.018];
+    viewer.camera.look = [4.400, 3.724, 8.899];
+    viewer.camera.up = [-0.018, 0.999, 0.039];
+
+    //----------------------------------------------------------------------------------------------------------------------
+    // Load a model and fit it to view
+    //----------------------------------------------------------------------------------------------------------------------
+
+    const gltfLoader = new GLTFLoaderPlugin(viewer);
+
+    const model = gltfLoader.load({
+        id: "myModel",
+        src: "./models/gltf/duplex/scene.gltf",
+        metaModelSrc: "./metaModels/duplex/metaModel.json", // Creates a MetaObject instances in scene.metaScene.metaObjects
+        edges: true
+    });
+
+    var canvas = viewer.scene.canvas;
+
+    //------------------------------------------------------------------------------------------------------------------
+    // When model loaded, start capturing PNG screenshots
+    //------------------------------------------------------------------------------------------------------------------
+
+    model.on("loaded", function () {
+
+        const screenshotsDiv = document.getElementById("screenshots");
+        var numScreenshots = 0;
+
+        setInterval(() => {
+
+            if (numScreenshots++ > 5) {
+                return;
+            }
+
+            viewer.camera.orbitYaw(10);
+
+            const canvas = viewer.scene.canvas;
+            const canvasElement = canvas.canvas;
+            const aspect = canvasElement.height / canvasElement.width;
+            const width = 200;
+            const height = Math.floor(width * aspect);
+
+            const imageData = canvas.getSnapshot({
+                format: "png",
+                width: width,
+                height: height
+            });
+
+            const img = document.createElement("img");
+
+            img.src = imageData;
+            img.style.border = "1px solid #000000";
+            img.style.background = "lightblue";
+
+            screenshotsDiv.appendChild(img);
+
+        }, 1000);
+    });
+
+</script>
+</html>

--- a/examples/canvas_screenshots_png_toDataURL.html
+++ b/examples/canvas_screenshots_png_toDataURL.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Capturing PNG Screenshots</title>
+    <link href="css/styles.css" type="text/css" rel="stylesheet"/>
+
+    <style>
+        #myCanvas {
+            background: lightblue;
+        }
+
+        #screenshots {
+            margin-top: 20px;
+            overflow-y: scroll;
+            height: 600px;
+            pointer-events: all;
+        }
+
+        #info {
+            position: absolute;
+            top: 0;
+            z-index: 200000;
+            float: right;
+            right: 0;
+            padding: 10px;
+            height: auto;
+            text-align: left;
+            pointer-events: none;
+            background: RGBA(0, 0, 0, 0.4);
+            max-width: 500px;
+            color: white;
+        }
+
+    </style>
+
+
+</head>
+<body>
+
+<canvas id="myCanvas"></canvas>
+
+<div id="info">
+    <h1>Capturing PNG Screenshots</h1>
+    <p>Using viewer.scene.canvas.canvas.toDataURL()</p>
+    <ul>
+        <li>
+            <a target="_other"
+               href="./../docs/class/src/plugins/GLTFLoaderPlugin/GLTFLoaderPlugin.js~GLTFLoaderPlugin.html">GLTFLoaderPlugin</a>
+            - Loads model and IFC data from file system
+        </li>
+        <li>
+            <a target="_other"
+               href="https://github.com/openBIMstandards/DataSetSchependomlaan">Model source</a>
+        </li>
+        <li>
+            <a target="_other" href="https://github.com/xeolabs/xeokit-sdk/wiki/Plan-Views">User Guide</a>
+        </li>
+    </ul>
+    <div id="screenshots"></div>
+</div>
+
+</body>
+
+<script type="module">
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Import the modules we need for this example
+    //------------------------------------------------------------------------------------------------------------------
+
+    import {Viewer} from "../src/viewer/Viewer.js";
+    import {GLTFLoaderPlugin} from "../src/plugins/GLTFLoaderPlugin/GLTFLoaderPlugin.js";
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a Viewer, arrange the camera
+    //------------------------------------------------------------------------------------------------------------------
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas",
+        transparent: true, // Default
+        preserveDrawingBuffer: true // Default - needed true for canvas screenshots
+    });
+
+    viewer.camera.eye = [-3.933, 2.855, 27.018];
+    viewer.camera.look = [4.400, 3.724, 8.899];
+    viewer.camera.up = [-0.018, 0.999, 0.039];
+
+    //----------------------------------------------------------------------------------------------------------------------
+    // Load a model and fit it to view
+    //----------------------------------------------------------------------------------------------------------------------
+
+    const gltfLoader = new GLTFLoaderPlugin(viewer);
+
+    const model = gltfLoader.load({
+        id: "myModel",
+        src: "./models/gltf/duplex/scene.gltf",
+        metaModelSrc: "./metaModels/duplex/metaModel.json", // Creates a MetaObject instances in scene.metaScene.metaObjects
+        edges: true
+    });
+
+    var canvas = viewer.scene.canvas;
+
+    //------------------------------------------------------------------------------------------------------------------
+    // When model loaded, start capturing PNG screenshots
+    //------------------------------------------------------------------------------------------------------------------
+
+    model.on("loaded", function () {
+
+        const screenshotsDiv = document.getElementById("screenshots");
+        var numScreenshots = 0;
+
+        setInterval(() => {
+
+            if (numScreenshots++ > 5) {
+                return;
+            }
+
+            viewer.camera.orbitYaw(10);
+
+            const canvas = viewer.scene.canvas;
+            const canvasElement = canvas.canvas;
+            const imageData = canvasElement.toDataURL();
+            const img = document.createElement("img");
+            const aspect = canvasElement.height / canvasElement.width;
+            const width = 200;
+            const height = Math.floor(width * aspect);
+
+            img.src = imageData;
+            img.style.border = "1px solid #000000";
+            img.style.width = width + "px";
+            img.style.height = height + "px";
+            img.style.background = "lightblue";
+            img.width = width + "px";
+            img.height = height + "px";
+
+            screenshotsDiv.appendChild(img);
+
+        }, 1000);
+    });
+
+</script>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -70,6 +70,11 @@
             "camera_fitToModel"
         ],
 
+        "Canvas": [
+            "canvas_screenshots_png_getSnapshot",
+            "canvas_screenshots_png_toDataURL"
+        ],
+
         "Geometry": [
 
             "#Geometry components",

--- a/src/viewer/Viewer.js
+++ b/src/viewer/Viewer.js
@@ -27,10 +27,11 @@ class Viewer {
      * @param {String} [cfg.canvasId]  ID of existing HTML5 canvas for the {@link Viewer#scene} - creates a full-page canvas automatically if this is omitted
      * @param {Number} [cfg.passes=1] The number of times the {@link Viewer#scene} renders per frame.
      * @param {Boolean} [cfg.clearEachPass=false] When doing multiple passes per frame, specifies if to clear the canvas before each pass (true) or just before the first pass (false).
-     * @param {Boolean} [cfg.transparent=false]  Whether or not the canvas is transparent.
+     * @param {Boolean} [cfg.preserveDrawingBuffer=true]  Whether or not to preserve the WebGL drawing buffer. This needs to be ````true```` for canvas snapshots to work.
+     * @param {Boolean} [cfg.transparent=true]  Whether or not the canvas is transparent.
      * @param {Number[]} [cfg.backgroundColor]  RGBA color for canvas background, when canvas is not transparent. Overridden by backgroundImage.
      * @param {String} [cfg.backgroundImage]  URL of an image to show as the canvas background, when canvas is not transparent. Overrides backgroundImage.
-     * @param {Boolean} [cfg.gammaInput=false]  When true, expects that all textures and colors are premultiplied gamma.
+     * @param {Boolean} [cfg.gammaInput=true]  When true, expects that all textures and colors are premultiplied gamma.
      * @param {Boolean}[cfg.gammaOutput=true]  Whether or not to render with pre-multiplied gama.
      * @param  {Number}[cfg.gammaFactor=2.2] The gamma factor to use when rendering with pre-multiplied gamma.
      */
@@ -53,7 +54,7 @@ class Viewer {
             canvasId: cfg.canvasId,
             webgl2: false,
             contextAttr: {
-                preserveDrawingBuffer: false
+                preserveDrawingBuffer: cfg.preserveDrawingBuffer !== false
             },
             transparent: cfg.transparent !== false,
             gammaInput: true,


### PR DESCRIPTION
- Adds ability to configure WebGL ````preserveDrawingBuffer````, which allows a screenshot to be captured without forcing a redraw.
- Adds two examples of screenshot capture, one directly from canvas, other via ````Canvas#getScreenshot()````, which internally uses 3rd-party ````Canvas2Image```` to resize image as captured.