### PR TITLE
Consider publishing package to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
     "esdoc": "^1.1.0",
     "esdoc-standard-plugin": "^1.0.0",
     "eslint": "^5.16.0"
-  }
+  },
+  "files": [
+    "/src"
+  ]
 }


### PR DESCRIPTION
Dear Lindsay,

Please consider publishing your package to the npm registry. We are actively looking at contributing React.js components to the xeokit-sdk. A simple install and integration workflow via npm would be a most welcome change for us. See https://docs.npmjs.com/packages-and-modules/contributing-packages-to-the-registry for reference.

With the change proposed here, only the src folder would be pulled in when someone installs your package from npm, leading to a much leaner output in size.

If, for any reason, you should wish to further customise what to include in your package, please refer to: https://docs.npmjs.com/files/package.json#files

Cheers,

Barna