### PR TITLE
arguments in wrong order in GLTFLoaderPlugin

### DIFF
--- a/src/plugins/GLTFLoaderPlugin/GLTFPerformanceLoader.js
+++ b/src/plugins/GLTFLoaderPlugin/GLTFPerformanceLoader.js
@@ -34,7 +34,7 @@ class GLTFPerformanceLoader {
 
     parse(plugin, performanceModel, gltf, options, ok, error) {
         options = options || {};
-        parseGLTF(plugin, gltf, "", options, performanceModel, function () {
+        parseGLTF(gltf, "", options, plugin, performanceModel, function () {
                 performanceModel.scene.fire("modelLoaded", performanceModel.id); // FIXME: Assumes listeners know order of these two events
                 performanceModel.fire("loaded", true, true);
                 if (ok) {


### PR DESCRIPTION
As in GLTFQualityLoader.js, parseGLTF is called with arguments in the wrong order in GLTFPerformanceLoader.js.