### PR TITLE
remove shownControlId when section plane destroyed

### DIFF
--- a/src/plugins/SectionPlanesPlugin/SectionPlanesPlugin.js
+++ b/src/plugins/SectionPlanesPlugin/SectionPlanesPlugin.js
@@ -306,6 +306,10 @@ class SectionPlanesPlugin extends Plugin {
         }
         this._sectionPlaneDestroyed(sectionPlane);
         sectionPlane.destroy();
+        
+        if (id === this._shownControlId) {
+            this._shownControlId = null;
+        }
     }
 
     _sectionPlaneDestroyed(sectionPlane) {


### PR DESCRIPTION
When a section plane is destroyed, the shown control id is not checked. If a section plane control is shown and the corresponding section plane is deleted, calling getShownControl will give us the destroyed section plane id even so it does not exist anymore.

Maybe the right place for this code is not in destroySectionPlane but in _sectionPlaneDestroyed ... ?