### PR TITLE
add default params for createSectionPlane

### DIFF
--- a/src/plugins/SectionPlanesPlugin/SectionPlanesPlugin.js
+++ b/src/plugins/SectionPlanesPlugin/SectionPlanesPlugin.js
@@ -216,7 +216,7 @@ class SectionPlanesPlugin extends Plugin {
      * @param {Boolean} [params.active=true] Whether the {@link SectionPlane} is initially active. Only clips while this is true.
      * @returns {SectionPlane} The new {@link SectionPlane}.
      */
-    createSectionPlane(params) {
+    createSectionPlane(params = {}) {
 
         if (params.id !== undefined && params.id !== null && this.viewer.scene.components[params.id]) {
             this.error("Viewer component with this ID already exists: " + params.id);


### PR DESCRIPTION
According to the doc, all params properties are optional. But it is currently not possible to call the method with no arguments. We have to put at least an empty object.

This fix allow to call the method without any arguments.