### PR TITLE
Fix bug

### DIFF
--- a/src/plugins/GLTFLoaderPlugin/GLTFDefaultDataSource.js
+++ b/src/plugins/GLTFLoaderPlugin/GLTFDefaultDataSource.js
@@ -96,7 +96,7 @@ function loadArraybuffer(glTFSrc, binarySrc, ok, err) {
             }, 0);
         }
     } else {
-        const basePath = getBasePath(glTFSrc);
+        const basePath = getBasePath(glTFSrc.basePath);
         const url = basePath + binarySrc;
         const request = new XMLHttpRequest();
         request.open('GET', url, true);


### PR DESCRIPTION
The bug happens when you try to load a GLTF model with material (`performance: false`)
https://xeokit.github.io/xeokit-sdk/docs/class/src/plugins/GLTFLoaderPlugin/GLTFLoaderPlugin.js~GLTFLoaderPlugin.html
![59630948-9fed1900-9114-11e9-9e75-da7ac88579d0](https://user-images.githubusercontent.com/13730281/61972969-e2760100-afb0-11e9-89bb-efab78e9d656.png)

Debugging step by step, found this bug
![Screenshot (5)](https://user-images.githubusercontent.com/13730281/61973006-fde10c00-afb0-11e9-9367-419f86c1e234.png)
