### PR TITLE
Fixed pako import to work with bundlers.

### DIFF
--- a/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
+++ b/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
@@ -3,7 +3,8 @@ import {PerformanceModel} from "../../viewer/scene/PerformanceModel/PerformanceM
 import {Plugin} from "../../viewer/Plugin.js";
 import {XKTDefaultDataSource} from "./XKTDefaultDataSource.js";
 import {IFCObjectDefaults} from "../../viewer/metadata/IFCObjectDefaults.js";
-import "./lib/pako.js";
+import * as p from "./lib/pako.js";
+const pako = window.pako || p;
 
 const XKT_VERSION = 1; // XKT format version supported by this XKTLoaderPlugin
 


### PR DESCRIPTION
Please see https://github.com/xeokit/xeokit-sdk/issues/118 for details.

FYI, I tested it in a browser and bundler environment alike and both of them seem to have worked just fine. However, since all your examples are in a browser env, I'd strongly urge you to obviously test these changes yourself before merging this PR.