### PR TITLE
Fixed BCF selection reset.

### DIFF
--- a/src/plugins/BCFViewpointsPlugin/BCFViewpointsPlugin.js
+++ b/src/plugins/BCFViewpointsPlugin/BCFViewpointsPlugin.js
@@ -345,8 +345,8 @@ class BCFViewpointsPlugin extends Plugin {
         }
 
         if (bcfViewpoint.components.selection) {
-            scene.setObjectsSelected(scene.selectedObjects, false);
-            Object.keys(scene.models).forEach((id) => {
+            scene.setObjectsSelected(scene.selectedObjectIds, false);
+            Object.keys(scene.models).forEach(() => {
                 bcfViewpoint.components.selection.forEach(x => scene.setObjectsSelected(x.ifc_guid, true));
             });
         }


### PR DESCRIPTION
Fixes the issue described in https://github.com/xeokit/xeokit-sdk/issues/139

The issue was that `setObjectsSelected` expects an array of IDs rather than entire objects, as described in the docs here: https://xeokit.github.io/xeokit-sdk/docs/class/src/viewer/scene/scene/Scene.js~Scene.html#instance-method-setObjectsSelected