### PR TITLE
panRightClick config option misplaced

### DIFF
--- a/src/viewer/scene/camera/CameraControl.js
+++ b/src/viewer/scene/camera/CameraControl.js
@@ -1078,15 +1078,13 @@ class CameraControl extends Component {
                         return;
                     }
 
-                    const panning = shiftDown || mouseDownRight;
+                    const panning = shiftDown || (self.panRightClick && mouseDownRight);
 
                     if (panning) {
 
                         // Panning
-                        if (self.panRightClick) {
-                            panVx = xDelta * mousePanRate;
-                            panVy = yDelta * mousePanRate;
-                        }
+                        panVx = xDelta * mousePanRate;
+                        panVy = yDelta * mousePanRate;
 
                     } else {
 


### PR DESCRIPTION
With the current change, it is impossible to pan with SHIFT if panRightClick is false.