### PR TITLE
setViewpoint not immediate

### DIFF
--- a/src/plugins/BCFViewpointsPlugin/BCFViewpointsPlugin.js
+++ b/src/plugins/BCFViewpointsPlugin/BCFViewpointsPlugin.js
@@ -335,6 +335,7 @@ class BCFViewpointsPlugin extends Plugin {
      * @param {*} [options] Options for setting the viewpoint.
      * @param {Boolean} [options.rayCast=true] When ````true```` (default), will attempt to set {@link Camera#look} to the closest
      * point of surface intersection with a ray fired from the BCF ````camera_view_point```` in the direction of ````camera_direction````.
+     * @param {Boolean} [options.immediate] When ````true```` (default), immediatly set camera position.
      * @param {Boolean} [options.duration] Flight duration in seconds.  Overrides {@link CameraFlightAnimation#duration}.
      */
     setViewpoint(bcfViewpoint, options = {}) {
@@ -347,6 +348,7 @@ class BCFViewpointsPlugin extends Plugin {
         const scene = viewer.scene;
         const camera = scene.camera;
         const rayCast = (options.rayCast !== false);
+        const immediate = (options.immediate !== false);
 
         scene.clearSectionPlanes();
 
@@ -424,8 +426,14 @@ class BCFViewpointsPlugin extends Plugin {
             } else {
                 look = math.addVec3(eye, look, tempVec3);
             }
-
-            viewer.cameraFlight.flyTo({ eye, look, up, duration: options.duration });
+            
+            if (immediate) {
+                camera.eye = eye;
+                camera.look = look;
+                camera.up = up;
+            } else {
+                viewer.cameraFlight.flyTo({ eye, look, up, duration: options.duration });
+            }
         }
     }
 

--- a/src/plugins/BCFViewpointsPlugin/BCFViewpointsPlugin.js
+++ b/src/plugins/BCFViewpointsPlugin/BCFViewpointsPlugin.js
@@ -335,6 +335,7 @@ class BCFViewpointsPlugin extends Plugin {
      * @param {*} [options] Options for setting the viewpoint.
      * @param {Boolean} [options.rayCast=true] When ````true```` (default), will attempt to set {@link Camera#look} to the closest
      * point of surface intersection with a ray fired from the BCF ````camera_view_point```` in the direction of ````camera_direction````.
+     * @param {Boolean} [options.duration] Flight duration in seconds.  Overrides {@link CameraFlightAnimation#duration}.
      */
     setViewpoint(bcfViewpoint, options = {}) {
 
@@ -414,23 +415,17 @@ class BCFViewpointsPlugin extends Plugin {
             }
 
             if (rayCast) {
-
                 const hit = scene.pick({
                     pickSurface: true,  // <<------ This causes picking to find the intersection point on the entity
                     origin: eye,
                     direction: look
                 });
-
-                camera.eye = eye;
-                camera.look = (hit ? hit.worldPos : math.addVec3(eye, look, tempVec3));
-                camera.up = up;
-
+                look = (hit ? hit.worldPos : math.addVec3(eye, look, tempVec3));
             } else {
-
-                camera.eye = eye;
-                camera.look = math.addVec3(eye, look, tempVec3);
-                camera.up = up;
+                look = math.addVec3(eye, look, tempVec3);
             }
+
+            viewer.cameraFlight.flyTo({ eye, look, up, duration: options.duration });
         }
     }
 


### PR DESCRIPTION
instead of setting camera properties, setViewpoint method of BCFViewpointsPlugin could use cameraFlight.flyTo to make the process smoother.

Warning : i did not test cameraFlight presence before calling flyTo (line 428). If cameraFlight can be absent on viewer, this should be updated.