### PR TITLE
Implement real-world coordinates and z-up camera for BCF compliance

### DIFF
--- a/src/viewer/scene/scene/Scene.js
+++ b/src/viewer/scene/scene/Scene.js
@@ -497,11 +497,11 @@ class Scene extends Component {
         this.reflectionMaps = {};
 
         /**
-         * The real world offset in this Scene
+         * The real world offset for this Scene
          *
          * @type {Number[]}
          */
-        this.realWorldOffset = cfg.realWorldOffset || [0, 0, 0];
+        this.realWorldOffset = cfg.realWorldOffset || new Float64Array([0, 0, 0]);
 
         /**
          * Manages the HTML5 canvas for this Scene.

--- a/src/viewer/scene/scene/Scene.js
+++ b/src/viewer/scene/scene/Scene.js
@@ -497,6 +497,13 @@ class Scene extends Component {
         this.reflectionMaps = {};
 
         /**
+         * The real world offset in this Scene
+         *
+         * @type {Number[]}
+         */
+        this.realWorldOffset = cfg.realWorldOffset || [0, 0, 0];
+
+        /**
          * Manages the HTML5 canvas for this Scene.
          *
          * @type {Canvas}


### PR DESCRIPTION
BCF requires z-up coordinates and real-world coordinates in meters.

If you used Y-up models and stored viewpoints in a database, they'll become invalid (the BCFViewpointsPlugin only accepts Z-Up viewpoints now).
You can update your old `viewpoint.perspective_camera.camera_view_point`'s [X, Y, Z] to [X, -Z, Y] and the BCFViewpointsPlugin will load them correctly.

Fixes https://github.com/xeokit/xeokit-sdk/issues/106