### PR TITLE
Remove default cursor style on canvas

### DIFF
--- a/src/viewer/scene/camera/CameraControl.js
+++ b/src/viewer/scene/camera/CameraControl.js
@@ -1034,7 +1034,7 @@ class CameraControl extends Component {
                         default:
                             break;
                     }
-                    self.scene.canvas.canvas.style.cursor = "default";
+                    self.scene.canvas.canvas.style.removeProperty("cursor");
                     down = false;
                     xDelta = 0;
                     yDelta = 0;


### PR DESCRIPTION
At startup, there is no cursor style on the canvas but after a move (pan or pivot), a "default" cursor style is added on it. Removing this not relevant style make it more easy to customize it (like a global cursor on the body for example).