### PR TITLE
Remove cursor style on document mouseup event

### DIFF
--- a/src/viewer/scene/camera/CameraControl.js
+++ b/src/viewer/scene/camera/CameraControl.js
@@ -1057,6 +1057,7 @@ class CameraControl extends Component {
                         default:
                             break;
                     }
+                    self.scene.canvas.canvas.style.removeProperty("cursor");
                     down = false;
                     xDelta = 0;
                     yDelta = 0;


### PR DESCRIPTION
Cursor style is only removed on canvas mouseup event. When clicking and moving on section plane arrows for example, the cursor is 'stuck' on move instead of going back to unset.
This change removes cursor style on document mouseup event like it is done on the canvas.