### PR TITLE
Preserve edge emphasis with SAO

### DIFF
--- a/src/viewer/scene/PerformanceModel/lib/batching/draw/batchingDrawShaderSource.js
+++ b/src/viewer/scene/PerformanceModel/lib/batching/draw/batchingDrawShaderSource.js
@@ -157,6 +157,21 @@ function buildFragment(layer) {
     src.push("// Batched geometry drawing fragment shader");
     src.push("precision mediump float;");
     src.push("precision mediump int;");
+
+    src.push("uniform bool      uSAOEnabled;");
+    src.push("uniform sampler2D uOcclusionTexture;");
+    src.push("uniform vec4      uSAOParams;");
+
+    src.push("const float       packUpscale = 256. / 255.;");
+    src.push("const float       unpackDownScale = 255. / 256.;");
+
+    src.push("const vec3        packFactors = vec3( 256. * 256. * 256., 256. * 256.,  256. );");
+    src.push("const vec4        unPackFactors = unpackDownScale / vec4( packFactors, 1. );");
+
+    src.push("float unpackRGBAToDepth( const in vec4 v ) {");
+    src.push("    return dot( v, unPackFactors );");
+    src.push("}");
+
     if (clipping) {
         src.push("varying vec4 vWorldPosition;");
         src.push("varying vec4 vFlags2;");
@@ -180,7 +195,21 @@ function buildFragment(layer) {
         src.push("  if (dist > 0.0) { discard; }");
         src.push("}");
     }
-    src.push("gl_FragColor = vColor;");
+
+    // Doing SAO blend in the main solid fill draw shader just so that edge lines can be drawn over the top
+    // Would be more efficient to defer this, then render lines later, using same depth buffer for Z-reject
+
+    src.push("  if (uSAOEnabled) {");
+    src.push("      float viewportWidth     = uSAOParams[0];");
+    src.push("      float viewportHeight    = uSAOParams[1];");
+    src.push("      float occlusionCutoff   = uSAOParams[2];");
+    src.push("      float occlusionScale    = uSAOParams[3];");
+    src.push("      vec2 uv                 = vec2(gl_FragCoord.x / viewportWidth, gl_FragCoord.y / viewportHeight);");
+    src.push("      float ambient           = smoothstep(occlusionCutoff, 1.0, unpackRGBAToDepth(texture2D(uOcclusionTexture, uv))) * occlusionScale;");
+    src.push("      gl_FragColor            = vec4(vColor.rgb * ambient, vColor.a);");
+    src.push("  } else {");
+    src.push("      gl_FragColor = vColor;");
+    src.push("  }");
     src.push("}");
     return src;
 }

--- a/src/viewer/scene/webgl/Renderer.js
+++ b/src/viewer/scene/webgl/Renderer.js
@@ -42,7 +42,6 @@ const Renderer = function (scene, options) {
     const saoDepthBuffer = new RenderBuffer(canvas, gl);
     const occlusionBuffer1 = new RenderBuffer(canvas, gl);
     const occlusionBuffer2 = new RenderBuffer(canvas, gl);
-    const colorBuffer = new RenderBuffer(canvas, gl);
 
     const pickBuffer = new RenderBuffer(canvas, gl);
     const readPixelBuffer = new RenderBuffer(canvas, gl);
@@ -82,7 +81,6 @@ const Renderer = function (scene, options) {
         saoDepthBuffer.webglContextRestored(gl);
         occlusionBuffer1.webglContextRestored(gl);
         occlusionBuffer2.webglContextRestored(gl);
-        colorBuffer.webglContextRestored(gl);
 
         saoOcclusionRenderer.init();
         saoBlurRenderer.init();
@@ -335,22 +333,9 @@ const Renderer = function (scene, options) {
                 saoBlurRenderer.render(saoDepthBuffer.getTexture(), occlusionBuffer2.getTexture(), 1);
                 occlusionBuffer1.unbind();
             }
-
-            // Render color buffer
-
-            colorBuffer.bind();
-            colorBuffer.clear();
-            drawColor(params);
-            colorBuffer.unbind();
-
-            // Blend color buffer with occlusion buffer 1
-
-            saoBlendRenderer.render(colorBuffer.getTexture(), occlusionBuffer1.getTexture());
-
-        } else {
-
-            drawColor(params);
         }
+
+        drawColor(params);
     };
 
     const drawDepth = (function () {
@@ -460,6 +445,9 @@ const Renderer = function (scene, options) {
             gl.depthMask(true);
             gl.lineWidth(1);
             frameCtx.lineWidth = 1;
+
+            const sao = scene.sao;
+            frameCtx.occlusionTexture = (sao.enabled && sao.supported) ? occlusionBuffer1.getTexture() : null;
 
             let i;
             let len;
@@ -1149,7 +1137,6 @@ const Renderer = function (scene, options) {
         saoDepthBuffer.destroy();
         occlusionBuffer1.destroy();
         occlusionBuffer2.destroy();
-        colorBuffer.destroy();
 
         saoOcclusionRenderer.destroy();
         saoBlurRenderer.destroy();

--- a/src/viewer/scene/webgl/sao/SAOOcclusionRenderer.js
+++ b/src/viewer/scene/webgl/sao/SAOOcclusionRenderer.js
@@ -2,6 +2,8 @@ import {Program} from "./../Program.js";
 import {ArrayBuf} from "./../ArrayBuf.js";
 import {math} from "../../math/math.js";
 
+const tempVec2 = math.vec2();
+
 /**
  * SAO implementation inspired from previous SAO work in THREE.js by ludobaka / ludobaka.github.io and bhouston
  * @private
@@ -93,7 +95,7 @@ class SAOOcclusionRenderer {
                 uniform float       uBias;
                 uniform float       uKernelRadius;
                 uniform float       uMinResolution;
-                uniform vec2        uSize;
+                uniform vec2        uViewport;
                 uniform float       uRandomSeed;
 
                 float pow2( const in float x ) { return x*x; }
@@ -181,7 +183,7 @@ class SAOOcclusionRenderer {
                 	vec3 centerViewNormal = getViewNormal( centerViewPosition, vUV );
 
                 	float angle = rand( vUV + uRandomSeed ) * PI2;
-                	vec2 radius = vec2( uKernelRadius * INV_NUM_SAMPLES ) / uSize;
+                	vec2 radius = vec2( uKernelRadius * INV_NUM_SAMPLES ) / uViewport;
                 	vec2 radiusStep = radius;
 
                 	float occlusionSum = 0.0;
@@ -254,7 +256,7 @@ class SAOOcclusionRenderer {
         this._uBias = this._program.getLocation("uBias");
         this._uKernelRadius = this._program.getLocation("uKernelRadius");
         this._uMinResolution = this._program.getLocation("uMinResolution");
-        this._uSize = this._program.getLocation("uSize");
+        this._uViewport = this._program.getLocation("uViewport");
         this._uRandomSeed = this._program.getLocation("uRandomSeed");
 
         this._aPosition = this._program.getAttribute("aPosition");
@@ -296,8 +298,10 @@ class SAOOcclusionRenderer {
         const projectionMatrix = projectState.matrix;
         const inverseProjectionMatrix = this._getInverseProjectMat();
         const randomSeed = Math.random();
-        const size = new Float32Array([canvasWidth, canvasHeight]);
         const perspective = (scene.camera.projection === "perspective");
+
+        tempVec2[0] = canvasWidth;
+        tempVec2[1] = canvasHeight;
 
         gl.getExtension("OES_standard_derivatives");
 
@@ -323,7 +327,7 @@ class SAOOcclusionRenderer {
         gl.uniform1f(this._uBias, sao.bias);
         gl.uniform1f(this._uKernelRadius, sao.kernelRadius);
         gl.uniform1f(this._uMinResolution, sao.minResolution);
-        gl.uniform2fv(this._uSize, size);
+        gl.uniform2fv(this._uViewport, tempVec2);
         gl.uniform1f(this._uRandomSeed, randomSeed);
 
         program.bindTexture(this._uDepthTexture, depthTexture, 0);


### PR DESCRIPTION
Fixes the way SAO obliterates edge enhancement by blending the occlusion buffer within the main opaque fill render pass. This does mean that, within the opaque fill render, the occlusion buffer is sampled for Z-rejected fragments, so is not as efficient as the previous fully-deferred solution. We can return to that later.
 
https://github.com/xeokit/xeokit-sdk/issues/247