### PR TITLE
Added support for BIMServer 1.5.180

### DIFF
--- a/src/plugins/BIMServerLoaderPlugin/lib/BIMServerPerformanceGeometryLoader.js
+++ b/src/plugins/BIMServerLoaderPlugin/lib/BIMServerPerformanceGeometryLoader.js
@@ -37,7 +37,7 @@ function BIMServerPerformanceGeometryLoader(bimServerClient, bimServerClientMode
         if (messageType === 0) {
         	if (!readStart(stream)) {
 				return false;
-			}
+        	}
         } else if (messageType === 6) {
             readEnd(stream);
         } else {
@@ -57,10 +57,10 @@ function BIMServerPerformanceGeometryLoader(bimServerClient, bimServerClientMode
             if (type == 0) {
             	while (processMessage(stream)) {
 
-                }
-			} else if (type == 1) {
-				// End of stream
-			}
+            	}
+            } else if (type == 1) {
+            	// End of stream
+            }
             data = todo.shift();
         }
     };
@@ -225,8 +225,8 @@ function BIMServerPerformanceGeometryLoader(bimServerClient, bimServerClientMode
             performanceModelBuilder.error("Unimplemented protocol version");
             return false;
         } else {
-			currentState.version = protocolVersion;
-		}
+        	currentState.version = protocolVersion;
+        }
         if (protocolVersion > 15) {
             o.multiplierToMm = data.readFloat();
         }


### PR DESCRIPTION
2 major changes which makes this support possible
	- 1) Addition of new bit in the binary format
		- Compared BIMServerPerformanceGeometryLoader.js in Xeokit
		- with GeometryLoader.js in BIMVie.ws( They have the same function)
  		- and found out that the new BIMServer protocol ( used in BIMvie.ws
that comes with BIMServer 1.5.180 ) for downloading an IFC
		- invoked via ServiceInterface.download
		- has added a new Long bit for each unit of binary to be decoded in
it's binary format after the first Long ( check changed code )
		- this new long was given the name type, i guess it means the type of
message.
		- this new Long bit was the reason Xeokit was failing to parse the
rest of the data.
	  - 2) GeometryLoader.js in BIMVie.ws supports a new geometry type 3,
the code for this new geometry type was ported to Xeokit, but
incompatible lines were commented. So all in all geometry type 3 is
still not supported