### PR TITLE
Fix initializing BatchingLayer.colorsBuf

### DIFF
--- a/src/viewer/scene/PerformanceModel/lib/batching/BatchingLayer.js
+++ b/src/viewer/scene/PerformanceModel/lib/batching/BatchingLayer.js
@@ -367,7 +367,7 @@ class BatchingLayer {
         }
         if (buffer.lenColors > 0) {
             let normalized = false;
-            state.colorsBuf = new ArrayBuf(gl, gl.ARRAY_BUFFER, buffer.colors.slice(0, buffer.Colors), buffer.lenColors, 4, gl.DYNAMIC_DRAW, normalized);
+            state.colorsBuf = new ArrayBuf(gl, gl.ARRAY_BUFFER, buffer.colors.slice(0, buffer.lenColors), buffer.lenColors, 4, gl.DYNAMIC_DRAW, normalized);
         }
         if (buffer.lenFlags > 0) {
             let normalized = true;


### PR DESCRIPTION
`buffer.Colors` is always(?) `undefined`, but presumably it should be `buffer.lenColors`.

This change does not seem(?) to have any functional effect, because Array.slice() does not happen to mind `undefined` as the second parameter and `ArrayBuf.constructor()` itself slices the data that is given to it.

This change does end up modifying `colorsBuf.numItems` and `colorsBuf.length` values from max values to the actual numItems and length.