### PR TITLE
Not initializing lastX and lastY leads to NaN

### DIFF
--- a/src/viewer/scene/CameraControl/lib/handlers/MousePanRotateDollyHandler.js
+++ b/src/viewer/scene/CameraControl/lib/handlers/MousePanRotateDollyHandler.js
@@ -36,8 +36,8 @@ class MousePanRotateDollyHandler {
 
         const pickController = controllers.pickController;
 
-        let lastX;
-        let lastY;
+        let lastX = 0;
+        let lastY = 0;
         let lastXDown = 0;
         let lastYDown = 0;
         let xRotateDelta = 0;


### PR DESCRIPTION
After lines 238 and 239 computation, if lastX and lastY are not initialized (undefined), updates.rotateDeltaY and updates.rotateDeltaX equal NaN.

Example : 
![xeokitModelDisappearing](https://user-images.githubusercontent.com/22523482/85275505-b7c25000-b480-11ea-804f-967e27d6ebaf.gif)
