### PR TITLE
Add pan rate config for touch

### DIFF
--- a/src/viewer/scene/CameraControl/CameraControl.js
+++ b/src/viewer/scene/CameraControl/CameraControl.js
@@ -464,6 +464,7 @@ class CameraControl extends Component {
             // Panning
 
             keyboardPanRate: 1.0,
+            touchPanRate: 1.0,
             panInertia: 0.5,
 
             // Dollying
@@ -545,6 +546,7 @@ class CameraControl extends Component {
         this.followPointer = cfg.followPointer;
         this.rotationInertia = cfg.rotationInertia;
         this.keyboardPanRate = cfg.keyboardPanRate;
+        this.touchPanRate = cfg.touchPanRate;
         this.keyboardRotationRate = cfg.keyboardRotationRate;
         this.dragRotationRate = cfg.dragRotationRate;
         this.dollyInertia = cfg.dollyInertia;
@@ -971,6 +973,27 @@ class CameraControl extends Component {
      */
     set keyboardPanRate(keyboardPanRate) {
         this._configs.keyboardPanRate = (keyboardPanRate !== null && keyboardPanRate !== undefined) ? keyboardPanRate : 5.0;
+    }
+
+
+    /**
+     * Sets how fast the camera pans on touch panning
+     *
+     * @param {Number} touchPanRate The new touch pan rate.
+     */
+    set touchPanRate(touchPanRate) {
+        this._configs.touchPanRate = (touchPanRate !== null && touchPanRate !== undefined) ? touchPanRate : 1.0;
+    }
+
+     /**
+     * Gets how fast the {@link Camera} pans on touch panning
+     *
+     * Default is ````1.0````.
+     *
+     * @returns {Number} The current touch pan rate.
+     */
+    get touchPanRate() {
+        return this._configs.touchPanRate;
     }
 
     /**

--- a/src/viewer/scene/CameraControl/lib/handlers/TouchPanRotateAndDollyHandler.js
+++ b/src/viewer/scene/CameraControl/lib/handlers/TouchPanRotateAndDollyHandler.js
@@ -162,13 +162,13 @@ class TouchPanRotateAndDollyHandler {
                         const depth = Math.abs(touchPicked ? math.lenVec3(math.subVec3(pickedWorldPos, scene.camera.eye, [])) : scene.camera.eyeLookDist);
                         const targetDistance = depth * Math.tan((camera.perspective.fov / 2) * Math.PI / 180.0);
 
-                        updates.panDeltaX += (xPanDelta * targetDistance / canvasHeight);
-                        updates.panDeltaY += (yPanDelta * targetDistance / canvasHeight);
+                        updates.panDeltaX += (xPanDelta * targetDistance / canvasHeight) * configs.touchPanRate;
+                        updates.panDeltaY += (yPanDelta * targetDistance / canvasHeight) * configs.touchPanRate;
 
                     } else {
 
-                        updates.panDeltaX += 0.5 * camera.ortho.scale * (xPanDelta / canvasHeight);
-                        updates.panDeltaY += 0.5 * camera.ortho.scale * (yPanDelta / canvasHeight);
+                        updates.panDeltaX += 0.5 * camera.ortho.scale * (xPanDelta / canvasHeight) * configs.touchPanRate;
+                        updates.panDeltaY += 0.5 * camera.ortho.scale * (yPanDelta / canvasHeight) * configs.touchPanRate;
                     }
                 }
 


### PR DESCRIPTION
Panning sensitivity with touch devices is dependent on the screen size. The pan speed can be too slow on tablet size devices for example.

Added a configuration similar to `keyboardPanRate` but for touch: `touchPanRate`

It controls the rate (sensitivity) of the touch panning event.