### PR TITLE
Remappable cameracontrol keys

### DIFF
--- a/examples/CameraControl_keyMap.html
+++ b/examples/CameraControl_keyMap.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=0">
+    <title>CameraControl Custom Keyboard Mapping</title>
+    <link href="css/styles.css" type="text/css" rel="stylesheet"/>
+
+    <style>
+
+        #myCanvas {
+            background: lightblue;
+        }
+
+    </style>
+
+</head>
+<body>
+
+<canvas id="myCanvas"></canvas>
+
+
+<div id="info">
+    <h1><a target="_other"
+           href="./../docs/class/src/viewer/scene/CameraControl/CameraControl.js~CameraControl.html">CameraControl</a> - Custom Keyboard Mapping</h1>
+    <br>
+    <ul>
+        <li>
+            <div id="time">Loading JavaScript modules...</div>
+        </li>
+        <li>
+            <a target="_other"
+               href="http://openifcmodel.cs.auckland.ac.nz/Model/Details/274">Model source</a>
+        </li>
+    </ul>
+</div>
+
+</body>
+
+<script type="module">
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Import the modules we need for this example
+    //------------------------------------------------------------------------------------------------------------------
+
+    import {Viewer} from "../src/viewer/Viewer.js";
+    import {XKTLoaderPlugin} from "../src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js";
+    import {Mesh} from "../src/viewer/scene/mesh/Mesh.js";
+    import {VBOGeometry} from "../src/viewer/scene/geometry/VBOGeometry.js";
+    import {buildGridGeometry} from "../src/viewer/scene/geometry/builders/buildGridGeometry.js";
+    import {PhongMaterial} from "../src/viewer/scene/materials/PhongMaterial.js";
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a Viewer, arrange the camera
+    //------------------------------------------------------------------------------------------------------------------
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas",
+        transparent: true
+    });
+
+    const cameraControl = viewer.cameraControl;
+    const scene = viewer.scene;
+    const cameraFlight = viewer.cameraFlight;
+    const camera = scene.camera;
+
+    viewer.camera.eye = [-8.23, 10.67, 35.26];
+    viewer.camera.look = [4.39, 3.72, 8.89];
+    viewer.camera.up = [0.10, 0.97, -0.20];
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Configure the CameraControl, binding some specific keys to CameraControl actions
+    //------------------------------------------------------------------------------------------------------------------
+
+    const input = scene.input;
+
+    cameraControl.navMode = "orbit";
+    cameraControl.followPointer = true;
+
+    const keyMap = {};
+
+    keyMap[cameraControl.PAN_LEFT] = [input.KEY_A];
+    keyMap[cameraControl.PAN_RIGHT] = [input.KEY_D];
+    keyMap[cameraControl.PAN_UP] = [input.KEY_Z];
+    keyMap[cameraControl.PAN_DOWN] = [input.KEY_X];
+    keyMap[cameraControl.PAN_BACKWARDS] = [input.KEY_S];
+    keyMap[cameraControl.PAN_FORWARDS] = [input.KEY_Z];
+    keyMap[cameraControl.DOLLY_FORWARDS] = [input.KEY_ADD];
+    keyMap[cameraControl.DOLLY_BACKWARDS] = [input.KEY_SUBTRACT];
+    keyMap[cameraControl.AXIS_VIEW_RIGHT] = [input.KEY_NUM_1];
+    keyMap[cameraControl.AXIS_VIEW_BACK] = [input.KEY_NUM_2];
+    keyMap[cameraControl.AXIS_VIEW_LEFT] = [input.KEY_NUM_3];
+    keyMap[cameraControl.AXIS_VIEW_FRONT] = [input.KEY_NUM_4];
+    keyMap[cameraControl.AXIS_VIEW_TOP] = [input.KEY_NUM_5];
+    keyMap[cameraControl.AXIS_VIEW_BOTTOM] = [input.KEY_NUM_6];
+
+    cameraControl.keyMap = keyMap;
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Load a model and fit it to view
+    //------------------------------------------------------------------------------------------------------------------
+
+    const xktLoader = new XKTLoaderPlugin(viewer);
+
+    const model = xktLoader.load({
+        id: "myModel",
+        src: "./models/xkt/duplex/duplex.xkt",
+        metaModelSrc: "./metaModels/duplex/metaModel.json",
+        edges: true
+    });
+
+    model.on("loaded", () => { // This synchronizes camera.ortho.scale to the model boundary
+        cameraFlight.flyTo(model);
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a mesh with grid
+    //------------------------------------------------------------------------------------------------------------------
+
+    new Mesh(viewer.scene, {
+        geometry: new VBOGeometry(viewer.scene, buildGridGeometry({
+            size: 300,
+            divisions: 60
+        })),
+        material: new PhongMaterial(viewer.scene, {
+            color: [0.0, 0.0, 0.0],
+            emissive: [0.4, 0.4, 0.4]
+        }),
+        position: [0, -1.6, 0],
+        collidable: false
+    });
+
+    const t0 = performance.now();
+    document.getElementById("time").innerHTML = "Loading model...";
+    model.on("loaded", function () {
+        const t1 = performance.now();
+        document.getElementById("time").innerHTML = "Model loaded in " + Math.floor(t1 - t0) / 1000.0 + " seconds";
+    });
+
+</script>
+</html>

--- a/examples/CameraControl_keyMap.html
+++ b/examples/CameraControl_keyMap.html
@@ -22,7 +22,8 @@
 
 <div id="info">
     <h1><a target="_other"
-           href="./../docs/class/src/viewer/scene/CameraControl/CameraControl.js~CameraControl.html">CameraControl</a> - Custom Keyboard Mapping</h1>
+           href="./../docs/class/src/viewer/scene/CameraControl/CameraControl.js~CameraControl.html">CameraControl</a> -
+        Custom Keyboard Mapping</h1>
     <br>
     <ul>
         <li>
@@ -83,10 +84,12 @@
     keyMap[cameraControl.PAN_RIGHT] = [input.KEY_D];
     keyMap[cameraControl.PAN_UP] = [input.KEY_Z];
     keyMap[cameraControl.PAN_DOWN] = [input.KEY_X];
-    keyMap[cameraControl.PAN_BACKWARDS] = [input.KEY_S];
-    keyMap[cameraControl.PAN_FORWARDS] = [input.KEY_Z];
-    keyMap[cameraControl.DOLLY_FORWARDS] = [input.KEY_ADD];
-    keyMap[cameraControl.DOLLY_BACKWARDS] = [input.KEY_SUBTRACT];
+    keyMap[cameraControl.DOLLY_FORWARDS] = [input.KEY_W, input.KEY_ADD];
+    keyMap[cameraControl.DOLLY_BACKWARDS] = [input.KEY_S, input.KEY_SUBTRACT];
+    keyMap[cameraControl.ROTATE_X_POS] = [input.KEY_DOWN_ARROW];
+    keyMap[cameraControl.ROTATE_X_NEG] = [input.KEY_UP_ARROW];
+    keyMap[cameraControl.ROTATE_Y_POS] = [input.KEY_LEFT_ARROW];
+    keyMap[cameraControl.ROTATE_Y_NEG] = [input.KEY_RIGHT_ARROW];
     keyMap[cameraControl.AXIS_VIEW_RIGHT] = [input.KEY_NUM_1];
     keyMap[cameraControl.AXIS_VIEW_BACK] = [input.KEY_NUM_2];
     keyMap[cameraControl.AXIS_VIEW_LEFT] = [input.KEY_NUM_3];

--- a/examples/index.html
+++ b/examples/index.html
@@ -275,6 +275,11 @@
             "ImagePlane_imageInSectionPlane"
         ],
 
+        "Shadows": [
+            "shadows_PointLight",
+            "shadows_DirLight"
+        ],
+
         "Spinner": [
             "spinner_custom"
         ],

--- a/examples/index.html
+++ b/examples/index.html
@@ -101,12 +101,16 @@
             "CameraControl_orbit_HolterTower",
             "CameraControl_firstPerson_Duplex",
             "CameraControl_firstPerson_HolterTower",
-            "CameraControl_planView_Schependomlaan"
+            "CameraControl_planView_Schependomlaan",
+
+            "#Custom keyboard mapping",
+            "CameraControl_keyMap"
         ],
 
         "Context Menus": [
             "ContextMenu_Canvas_TreeViewPlugin_Custom",
-            "ContextMenu_dynamicItemTitles"
+            "ContextMenu_dynamicItemTitles",
+            "ContextMenu_subItems"
         ],
 
         "Geometry": [

--- a/examples/shadows_DirLight.html
+++ b/examples/shadows_DirLight.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>DirLight Shadow Demo</title>
+    <link href="css/styles.css" type="text/css" rel="stylesheet"/>
+</head>
+
+<body>
+
+<canvas id="myCanvas"></canvas>
+<div id="info">
+    <h1>DirLight with Shadow</h1>
+    <br>
+    <br>
+    <ul>
+        <li>
+            <a target="_other"
+               href="./../docs/class/src/viewer/Viewer.js~Viewer.html">Viewer</a>
+            - xeokit Viewer
+        </li>
+        <li>
+            <a target="_other"
+               href="./../docs/class/src/viewer/scene/lights/DirLight.js~DirLight.html">DirLight</a>
+            - Directional light source
+        </li>
+    </ul>
+</div>
+</body>
+
+<script type="module" id="source">
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Import the modules we need for this example
+    //------------------------------------------------------------------------------------------------------------------
+
+    import {Viewer} from "../src/viewer/Viewer.js";
+    import {Mesh} from "../src/viewer/scene/mesh/Mesh.js";
+    import {buildSphereGeometry} from "../src/viewer/scene/geometry/builders/buildSphereGeometry.js";
+    import {buildPlaneGeometry} from "../src/viewer/scene/geometry/builders/buildPlaneGeometry.js";
+    import {ReadableGeometry} from "../src/viewer/scene/geometry/ReadableGeometry.js";
+    import {PhongMaterial} from "../src/viewer/scene/materials/PhongMaterial.js";
+    import {Texture} from "../src/viewer/scene/materials/Texture.js";
+    import {DirLight} from "../src/viewer/scene/lights/DirLight.js";
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a Viewer and arrange the camera
+    //------------------------------------------------------------------------------------------------------------------
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas"
+    });
+
+    viewer.scene.camera.eye = [0, 0, 15];
+    viewer.scene.camera.look = [0, 0, 0];
+    viewer.scene.camera.up = [0, 1, 0];
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Replace the Scene's default lights with custom DirLights, the first of which will cast our shadow
+    //------------------------------------------------------------------------------------------------------------------
+
+    viewer.scene.clearLights();
+
+    new DirLight(viewer.scene, {
+        dir: [0.2, -1.0, 0.8],
+        color: [1.0, 1.0, 1.0],
+        intensity: 1.0,
+        space: "world",
+        castsShadow: true // <<------------------- This light casts our shadow
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a sphere and ground plane
+    //------------------------------------------------------------------------------------------------------------------
+
+    new Mesh(viewer.scene, {
+        geometry: new ReadableGeometry(viewer.scene, buildSphereGeometry({
+            radius: 1.3
+        })),
+        material: new PhongMaterial(viewer.scene, {
+            diffuse: [0.7, 0.7, 0.7],
+            specular: [1.0, 1.0, 1.0],
+            emissive: [0, 0, 0],
+            alpha: 1.0,
+            ambient: [1, 1, 0],
+            diffuseMap: new Texture(viewer.scene, {
+                src: "textures/diffuse/uvGrid2.jpg"
+            })
+        })
+    });
+
+    new Mesh(viewer.scene, {
+        geometry: new ReadableGeometry(viewer.scene, buildPlaneGeometry({
+            xSize: 30,
+            zSize: 30
+        })),
+        material: new PhongMaterial(viewer.scene, {
+            diffuseMap: new Texture(viewer.scene, {
+                src: "textures/diffuse/uvGrid2.jpg"
+            }),
+            backfaces: true
+        }),
+        position: [0, -2.1, 0]
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Orbit camera
+    //------------------------------------------------------------------------------------------------------------------
+
+    viewer.scene.on("tick", function () {
+        viewer.scene.camera.orbitYaw(0.3);
+    });
+
+</script>
+</html>

--- a/examples/shadows_PointLight.html
+++ b/examples/shadows_PointLight.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>PointLight Shadow Demo</title>
+    <link href="css/styles.css" type="text/css" rel="stylesheet"/>
+</head>
+
+<body>
+
+<canvas id="myCanvas"></canvas>
+<div id="info">
+    <h1>PointLight with Shadow</h1>
+    <br>
+    <br>
+    <ul>
+        <li>
+            <a target="_other"
+               href="./../docs/class/src/viewer/Viewer.js~Viewer.html">Viewer</a>
+            - xeokit Viewer
+        </li>
+        <li>
+            <a target="_other"
+               href="./../docs/class/src/viewer/scene/lights/PointLight.js~PointLight.html">PointLight</a>
+            - Point light source
+        </li>
+    </ul>
+</div>
+</body>
+
+<script type="module" id="source">
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Import the modules we need for this example
+    //------------------------------------------------------------------------------------------------------------------
+
+    import {Viewer} from "../src/viewer/Viewer.js";
+    import {Mesh} from "../src/viewer/scene/mesh/Mesh.js";
+    import {buildSphereGeometry} from "../src/viewer/scene/geometry/builders/buildSphereGeometry.js";
+    import {buildPlaneGeometry} from "../src/viewer/scene/geometry/builders/buildPlaneGeometry.js";
+    import {ReadableGeometry} from "../src/viewer/scene/geometry/ReadableGeometry.js";
+    import {PhongMaterial} from "../src/viewer/scene/materials/PhongMaterial.js";
+    import {Texture} from "../src/viewer/scene/materials/Texture.js";
+    import {PointLight} from "../src/viewer/scene/lights/PointLight.js";
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a Viewer and arrange the camera
+    //------------------------------------------------------------------------------------------------------------------
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas"
+    });
+
+    viewer.scene.camera.eye = [0, 0, 15];
+    viewer.scene.camera.look = [0, 0, 0];
+    viewer.scene.camera.up = [0, 1, 0];
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Replace the Scene's default lights with custom PointLights, the first of which will cast our shadow
+    //------------------------------------------------------------------------------------------------------------------
+
+    viewer.scene.clearLights();
+    
+    new PointLight(viewer.scene, {
+        pos: [-80, 60, 80],
+        color: [1.0, 1.0, 1.0],
+        intensity: 1.0,
+        space: "world",
+        castsShadow: true // <<------------------- This light casts our shadow
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a sphere and ground plane
+    //------------------------------------------------------------------------------------------------------------------
+
+    new Mesh(viewer.scene, {
+        geometry: new ReadableGeometry(viewer.scene, buildSphereGeometry({
+            radius: 1.3
+        })),
+        material: new PhongMaterial(viewer.scene, {
+            diffuse: [0.7, 0.7, 0.7],
+            specular: [1.0, 1.0, 1.0],
+            emissive: [0, 0, 0],
+            alpha: 1.0,
+            ambient: [1, 1, 0],
+            diffuseMap: new Texture(viewer.scene, {
+                src: "textures/diffuse/uvGrid2.jpg"
+            })
+        })
+    });
+
+    new Mesh(viewer.scene, {
+        geometry: new ReadableGeometry(viewer.scene, buildPlaneGeometry({
+            xSize: 30,
+            zSize: 30
+        })),
+        material: new PhongMaterial(viewer.scene, {
+            diffuseMap: new Texture(viewer.scene, {
+                src: "textures/diffuse/uvGrid2.jpg"
+            }),
+            backfaces: true
+        }),
+        position: [0, -2.1, 0]
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Orbit camera
+    //------------------------------------------------------------------------------------------------------------------
+
+    viewer.scene.on("tick", function () {
+        viewer.scene.camera.orbitYaw(0.3);
+    });
+
+</script>
+</html>

--- a/src/viewer/scene/CameraControl/CameraControl.js
+++ b/src/viewer/scene/CameraControl/CameraControl.js
@@ -426,7 +426,7 @@ import {utils} from "../utils.js";
  *
  * We can customize````CameraControl```` key bindings as shown below.
  *
- * in this example, we'll just set the default bindings for a QWERTY keyboard.
+ * In this example, we'll just set the default bindings for a QWERTY keyboard.
  *
  * ````javascript
  * const input = myViewer.scene.input;

--- a/src/viewer/scene/CameraControl/CameraControl.js
+++ b/src/viewer/scene/CameraControl/CameraControl.js
@@ -45,6 +45,8 @@ import {TouchPickHandler} from "./lib/handlers/TouchPickHandler.js";
  *      + ["doublePickedSurface"](#---doublepickedsurface---)
  *      + ["doublePickedNothing"](#---doublepickednothing---)
  *      + ["rightClick"](#---rightclick---)
+ * * [Custom Keyboard Mappings](#custom-keyboard-mappings)
+ *
  * <br><br>
  *
  * # Overview
@@ -66,6 +68,7 @@ import {TouchPickHandler} from "./lib/handlers/TouchPickHandler.js";
  * * [First-Person Navigation - Duplex Model](https://xeokit.github.io/xeokit-sdk/examples/#CameraControl_firstPerson_Duplex)
  * * [First-Person Navigation - Holter Tower Model](https://xeokit.github.io/xeokit-sdk/examples/#CameraControl_firstPerson_HolterTower)
  * * [Plan-view Navigation - Schependomlaan Model](https://xeokit.github.io/xeokit-sdk/examples/#CameraControl_planView_Schependomlaan)
+ * * [Custom Keyboard Mapping](https://xeokit.github.io/xeokit-sdk/examples/#CameraControl_keyMap)
  * <br><br>
  *
  * # Orbit Mode
@@ -75,6 +78,7 @@ import {TouchPickHandler} from "./lib/handlers/TouchPickHandler.js";
  * To enable orbit mode:
  *
  * ````javascript
+ * const cameraControl = myViewer.cameraControl;
  * cameraControl.navMode = "orbit";
  * ````
  *
@@ -398,7 +402,7 @@ import {TouchPickHandler} from "./lib/handlers/TouchPickHandler.js";
  *
  * ## "doublePickedNothing"
  *
- * Wvent fired when we left-double-click or double-tap on empty space.
+ * Event fired when we left-double-click or double-tap on empty space.
  *
  * ````javascript
  * cameraControl.on("doublePickedNothing", (e) => {
@@ -416,6 +420,51 @@ import {TouchPickHandler} from "./lib/handlers/TouchPickHandler.js";
  *      const canvasPos = e.canvasPos;
  * });
  * ````
+ *
+ * ## Custom Keyboard Mappings
+ *
+ * We can customize````CameraControl```` key bindings as shown below.
+ *
+ * in this example, we'll just set the default bindings for a QWERTY keyboard.
+ *
+ * ````javascript
+ * const input = myViewer.scene.input;
+ *
+ * cameraControl.navMode = "orbit";
+ * cameraControl.followPointer = true;
+ *
+ * const keyMap = {};
+ *
+ * keyMap[cameraControl.PAN_LEFT] = [input.KEY_A];
+ * keyMap[cameraControl.PAN_RIGHT] = [input.KEY_D];
+ * keyMap[cameraControl.PAN_UP] = [input.KEY_Z];
+ * keyMap[cameraControl.PAN_DOWN] = [input.KEY_X];
+ * keyMap[cameraControl.PAN_BACKWARDS] = [input.KEY_S];
+ * keyMap[cameraControl.PAN_FORWARDS] = [input.KEY_Z];
+ * keyMap[cameraControl.DOLLY_FORWARDS] = [input.KEY_ADD];
+ * keyMap[cameraControl.DOLLY_BACKWARDS] = [input.KEY_SUBTRACT];
+ * keyMap[cameraControl.AXIS_VIEW_RIGHT] = [input.KEY_1];
+ * keyMap[cameraControl.AXIS_VIEW_BACK] = [input.KEY_1];
+ * keyMap[cameraControl.AXIS_VIEW_LEFT] = [input.KEY_1];
+ * keyMap[cameraControl.AXIS_VIEW_FRONT] = [input.KEY_1];
+ * keyMap[cameraControl.AXIS_VIEW_TOP] = [input.KEY_1];
+ * keyMap[cameraControl.AXIS_VIEW_BOTTOM] = [input.KEY_1];
+ *
+ * cameraControl.keyMap = keyMap;
+ * ````
+ *
+ * We can also just configure default bindings for a given keyboard layout, like this:
+ *
+ * ````javascript
+ * cameraControl.keyMap = "qwerty";
+ * ````
+ *
+ * Then {@link CameraControl#keyMap} will internally get set to a default key map for QWERTY layout.
+ *
+ * Supported layouts so far are:
+ *
+ * * ````"qwerty"````
+ * * ````"azerty"````
  */
 class CameraControl extends Component {
 
@@ -426,6 +475,134 @@ class CameraControl extends Component {
     constructor(owner, cfg = {}) {
 
         super(owner, cfg);
+
+        /**
+         * Identifies the XX action.
+         * @final
+         * @type {Number}
+         */
+        this.PAN_LEFT = 0;
+
+        /**
+         * Identifies the XX action.
+         * @final
+         * @type {Number}
+         */
+        this.PAN_RIGHT = 1;
+
+        /**
+         * Identifies the XX action.
+         * @final
+         * @type {Number}
+         */
+        this.PAN_UP = 2;
+
+        /**
+         * Identifies the XX action.
+         * @final
+         * @type {Number}
+         */
+        this.PAN_DOWN = 3;
+
+        /**
+         * Identifies the XX action.
+         * @final
+         * @type {Number}
+         */
+        this.PAN_FORWARDS = 4;
+
+        /**
+         * Identifies the XX action.
+         * @final
+         * @type {Number}
+         */
+        this.PAN_BACKWARDS = 5;
+
+        /**
+         * Identifies the XX action.
+         * @final
+         * @type {Number}
+         */
+        this.ROTATE_X_POS = 6;
+
+        /**
+         * Identifies the XX action.
+         * @final
+         * @type {Number}
+         */
+        this.ROTATE_X_NEG = 7;
+
+        /**
+         * Identifies the XX action.
+         * @final
+         * @type {Number}
+         */
+        this.ROTATE_Y_POS = 8;
+
+        /**
+         * Identifies the XX action.
+         * @final
+         * @type {Number}
+         */
+        this.ROTATE_Y_NEG = 9;
+
+        /**
+         * Identifies the XX action.
+         * @final
+         * @type {Number}
+         */
+        this.DOLLY_FORWARDS = 10;
+
+        /**
+         * Identifies the XX action.
+         * @final
+         * @type {Number}
+         */
+        this.DOLLY_BACKWARDS = 11;
+
+        /**
+         * Identifies the XX action.
+         * @final
+         * @type {Number}
+         */
+        this.AXIS_VIEW_RIGHT = 12;
+
+        /**
+         * Identifies the XX action.
+         * @final
+         * @type {Number}
+         */
+        this.AXIS_VIEW_BACK = 13;
+
+        /**
+         * Identifies the XX action.
+         * @final
+         * @type {Number}
+         */
+        this.AXIS_VIEW_LEFT = 14;
+
+        /**
+         * Identifies the XX action.
+         * @final
+         * @type {Number}
+         */
+        this.AXIS_VIEW_FRONT = 15;
+
+        /**
+         * Identifies the XX action.
+         * @final
+         * @type {Number}
+         */
+        this.AXIS_VIEW_TOP = 16;
+
+        /**
+         * Identifies the XX action.
+         * @final
+         * @type {Number}
+         */
+        this.AXIS_VIEW_BOTTOM = 17;
+
+        this._keyMap = {};
 
         this.scene.canvas.canvas.oncontextmenu = (e) => {
             e.preventDefault();
@@ -539,7 +716,11 @@ class CameraControl extends Component {
         this.planView = cfg.planView;
         this.navMode = cfg.navMode;
         this.constrainVertical = cfg.constrainVertical;
-        this.keyboardLayout = cfg.keyboardLayout;
+        if (cfg.keyboardLayout) {
+            this.keyboardLayout = cfg.keyboardLayout; // Deprecated
+        } else {
+            this.keyMap = cfg.keyMap;
+        }
         this.doublePickFlyTo = cfg.doublePickFlyTo;
         this.panRightClick = cfg.panRightClick;
         this.active = cfg.active;
@@ -556,6 +737,92 @@ class CameraControl extends Component {
         this.pointerEnabled = true;
         this.keyboardDollyRate = cfg.keyboardDollyRate;
         this.mouseWheelDollyRate = cfg.mouseWheelDollyRate;
+    }
+
+    /**
+     * Sets custom mappings of keys to {@link CameraControl} actions.
+     *
+     * See class docs for usage.
+     *
+     * @param {{Number:Number}|String} keyMap New key mappings.
+     */
+    set keyMap(keyMap) {
+        keyMap = keyMap || "qwerty";
+        if (utils.isString(keyMap)) {
+            switch (keyMap) {
+                case "azerty":
+                    keyMap[this.PAN_LEFT] = [input.KEY_A];
+                    keyMap[this.PAN_RIGHT] = [input.KEY_D];
+                    keyMap[this.PAN_UP] = [input.KEY_Z];
+                    keyMap[this.PAN_DOWN] = [input.KEY_X];
+                    keyMap[this.PAN_BACKWARDS] = [input.KEY_S];
+                    keyMap[this.PAN_FORWARDS] = [input.KEY_Z];
+                    keyMap[this.DOLLY_FORWARDS] = [input.KEY_ADD];
+                    keyMap[this.DOLLY_BACKWARDS] = [input.KEY_SUBTRACT];
+                    keyMap[this.AXIS_VIEW_RIGHT] = [input.KEY_NUM_1];
+                    keyMap[this.AXIS_VIEW_BACK] = [input.KEY_NUM_2];
+                    keyMap[this.AXIS_VIEW_LEFT] = [input.KEY_NUM_3];
+                    keyMap[this.AXIS_VIEW_FRONT] = [input.KEY_NUM_4];
+                    keyMap[this.AXIS_VIEW_TOP] = [input.KEY_NUM_5];
+                    keyMap[this.AXIS_VIEW_BOTTOM] = [input.KEY_NUM_6];
+                    this._keyMapAreDefaults = true;
+                    break;
+                case "qwerty":
+                default:
+                    keyMap[this.PAN_LEFT] = [input.KEY_A];
+                    keyMap[this.PAN_RIGHT] = [input.KEY_D];
+                    keyMap[this.PAN_UP] = [input.KEY_Z];
+                    keyMap[this.PAN_DOWN] = [input.KEY_X];
+                    keyMap[this.PAN_BACKWARDS] = [input.KEY_S];
+                    keyMap[this.PAN_FORWARDS] = [input.KEY_Z];
+                    keyMap[this.DOLLY_FORWARDS] = [input.KEY_ADD];
+                    keyMap[this.DOLLY_BACKWARDS] = [input.KEY_SUBTRACT];
+                    keyMap[this.AXIS_VIEW_RIGHT] = [input.KEY_NUM_1];
+                    keyMap[this.AXIS_VIEW_BACK] = [input.KEY_NUM_2];
+                    keyMap[this.AXIS_VIEW_LEFT] = [input.KEY_NUM_3];
+                    keyMap[this.AXIS_VIEW_FRONT] = [input.KEY_NUM_4];
+                    keyMap[this.AXIS_VIEW_TOP] = [input.KEY_NUM_5];
+                    keyMap[this.AXIS_VIEW_BOTTOM] = [input.KEY_NUM_6];
+                    this._keyMapAreDefaults = true;
+                    break;
+            }
+            this._keyMapAreDefaults = true;
+        } else {
+            this._keyMapAreDefaults = false;
+        }
+        this._keyMap = keyMap;
+    }
+
+    /**
+     * Gets custom mappings of keys to {@link CameraControl} actions.
+     *
+     * @returns {{Number:Number}} Current key mappings.
+     */
+    get keyMap() {
+        return this._keyMap;
+    }
+
+    /**
+     * Returns true if any keys configured for the given action are down.
+     * @param action
+     * @param keyDownMap
+     * @private
+     */
+    _isKeyDownForAction(action, keyDownMap) {
+        const keys = this._keyMap[action];
+        if (!keys) {
+            return false;
+        }
+        if (!keyDownMap) {
+            keyDownMap = this.scene.input.keyDown;
+        }
+        for (let i = 0, len = keys.length; i < len; i++) {
+            const key = keys[i];
+            if (keyDownMap[key]) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -985,7 +1252,7 @@ class CameraControl extends Component {
         this._configs.touchPanRate = (touchPanRate !== null && touchPanRate !== undefined) ? touchPanRate : 1.0;
     }
 
-     /**
+    /**
      * Gets how fast the {@link Camera} pans on touch panning
      *
      * Default is ````1.0````.
@@ -1224,6 +1491,7 @@ class CameraControl extends Component {
      * * ````"qwerty"```` (default)
      * * ````"azerty"````
      *
+     * @deprecated
      * @param {String} value Selects the keyboard layout.
      */
     set keyboardLayout(value) {
@@ -1233,6 +1501,7 @@ class CameraControl extends Component {
             value = "qwerty";
         }
         this._configs.keyboardLayout = value;
+        this.keyMap = this._configs.keyboardLayout;
     }
 
     /**
@@ -1243,6 +1512,7 @@ class CameraControl extends Component {
      * * ````"qwerty"```` (default)
      * * ````"azerty"````
      *
+     * @deprecated
      * @returns {String} The current keyboard layout.
      */
     get keyboardLayout() {

--- a/src/viewer/scene/CameraControl/lib/handlers/KeyboardAxisViewHandler.js
+++ b/src/viewer/scene/CameraControl/lib/handlers/KeyboardAxisViewHandler.js
@@ -20,8 +20,7 @@ class KeyboardAxisViewHandler {
     constructor(scene, controllers, configs, states, updates) {
 
         this._scene = scene;
-        const input = scene.input;
-
+        const cameraControl = controllers.cameraControl;
         const camera = scene.camera;
 
         document.addEventListener("keydown", this._documentKeyDownHandler = (e) => {
@@ -34,10 +33,14 @@ class KeyboardAxisViewHandler {
                 return;
             }
 
-            const keyCode = e.keyCode;
+            const axisViewRight = cameraControl._isKeyDownForAction(cameraControl.AXIS_VIEW_RIGHT);
+            const axisViewBack = cameraControl._isKeyDownForAction(cameraControl.AXIS_VIEW_BACK);
+            const axisViewLeft = cameraControl._isKeyDownForAction(cameraControl.AXIS_VIEW_LEFT);
+            const axisViewFront = cameraControl._isKeyDownForAction(cameraControl.AXIS_VIEW_FRONT);
+            const axisViewTop = cameraControl._isKeyDownForAction(cameraControl.AXIS_VIEW_TOP);
+            const axisViewBottom = cameraControl._isKeyDownForAction(cameraControl.AXIS_VIEW_BOTTOM);
 
-            if (keyCode !== input.KEY_NUM_1 && keyCode !== input.KEY_NUM_2 && keyCode !== input.KEY_NUM_3 &&
-                keyCode !== input.KEY_NUM_4 && keyCode !== input.KEY_NUM_5 && keyCode !== input.KEY_NUM_6) {
+            if ((!axisViewRight) && (!axisViewBack) && (!axisViewLeft) && (!axisViewFront) && (!axisViewTop) && (!axisViewBottom)) {
                 return;
             }
 
@@ -48,46 +51,41 @@ class KeyboardAxisViewHandler {
 
             const dist = Math.abs(diag / Math.tan(controllers.cameraFlight.fitFOV * math.DEGTORAD));
 
-            switch (keyCode) {
+            if (axisViewRight) {
 
-                case input.KEY_NUM_1: // Right
-                    tempCameraTarget.eye.set(math.addVec3(center, math.mulVec3Scalar(camera.worldRight, dist, tempVec3a), tempVec3d));
-                    tempCameraTarget.look.set(center);
-                    tempCameraTarget.up.set(camera.worldUp);
-                    break;
+                tempCameraTarget.eye.set(math.addVec3(center, math.mulVec3Scalar(camera.worldRight, dist, tempVec3a), tempVec3d));
+                tempCameraTarget.look.set(center);
+                tempCameraTarget.up.set(camera.worldUp);
 
-                case input.KEY_NUM_2: // Back
-                    tempCameraTarget.eye.set(math.addVec3(center, math.mulVec3Scalar(camera.worldForward, dist, tempVec3a), tempVec3d));
-                    tempCameraTarget.look.set(center);
-                    tempCameraTarget.up.set(camera.worldUp);
-                    break;
+            } else if (axisViewBack) {
 
-                case input.KEY_NUM_3: // Left
-                    tempCameraTarget.eye.set(math.addVec3(center, math.mulVec3Scalar(camera.worldRight, -dist, tempVec3a), tempVec3d));
-                    tempCameraTarget.look.set(center);
-                    tempCameraTarget.up.set(camera.worldUp);
-                    break;
+                tempCameraTarget.eye.set(math.addVec3(center, math.mulVec3Scalar(camera.worldForward, dist, tempVec3a), tempVec3d));
+                tempCameraTarget.look.set(center);
+                tempCameraTarget.up.set(camera.worldUp);
 
-                case input.KEY_NUM_4: // Front
-                    tempCameraTarget.eye.set(math.addVec3(center, math.mulVec3Scalar(camera.worldForward, -dist, tempVec3a), tempVec3d));
-                    tempCameraTarget.look.set(center);
-                    tempCameraTarget.up.set(camera.worldUp);
-                    break;
+            } else if (axisViewLeft) {
 
-                case input.KEY_NUM_5: // Top
-                    tempCameraTarget.eye.set(math.addVec3(center, math.mulVec3Scalar(camera.worldUp, dist, tempVec3a), tempVec3d));
-                    tempCameraTarget.look.set(center);
-                    tempCameraTarget.up.set(math.normalizeVec3(math.mulVec3Scalar(camera.worldForward, 1, tempVec3b), tempVec3c));
-                    break;
+                tempCameraTarget.eye.set(math.addVec3(center, math.mulVec3Scalar(camera.worldRight, -dist, tempVec3a), tempVec3d));
+                tempCameraTarget.look.set(center);
+                tempCameraTarget.up.set(camera.worldUp);
 
-                case input.KEY_NUM_6: // Bottom
-                    tempCameraTarget.eye.set(math.addVec3(center, math.mulVec3Scalar(camera.worldUp, -dist, tempVec3a), tempVec3d));
-                    tempCameraTarget.look.set(center);
-                    tempCameraTarget.up.set(math.normalizeVec3(math.mulVec3Scalar(camera.worldForward, -1, tempVec3b)));
-                    break;
+            } else if (axisViewFront) {
 
-                default:
-                    return;
+                tempCameraTarget.eye.set(math.addVec3(center, math.mulVec3Scalar(camera.worldForward, -dist, tempVec3a), tempVec3d));
+                tempCameraTarget.look.set(center);
+                tempCameraTarget.up.set(camera.worldUp);
+
+            } else if (axisViewTop) {
+
+                tempCameraTarget.eye.set(math.addVec3(center, math.mulVec3Scalar(camera.worldUp, dist, tempVec3a), tempVec3d));
+                tempCameraTarget.look.set(center);
+                tempCameraTarget.up.set(math.normalizeVec3(math.mulVec3Scalar(camera.worldForward, 1, tempVec3b), tempVec3c));
+
+            } else if (axisViewBottom) {
+
+                tempCameraTarget.eye.set(math.addVec3(center, math.mulVec3Scalar(camera.worldUp, -dist, tempVec3a), tempVec3d));
+                tempCameraTarget.look.set(center);
+                tempCameraTarget.up.set(math.normalizeVec3(math.mulVec3Scalar(camera.worldForward, -1, tempVec3b)));
             }
 
             if ((!configs.firstPerson) && configs.followPointer) {

--- a/src/viewer/scene/CameraControl/lib/handlers/KeyboardPanRotateDollyHandler.js
+++ b/src/viewer/scene/CameraControl/lib/handlers/KeyboardPanRotateDollyHandler.js
@@ -112,9 +112,9 @@ class KeyboardPanRotateDollyHandler {
                         controllers.pivotController.startPivot();
                     }
                     if (dollyForwards) {
-                        updates.dollyDelta += dollyDelta;
-                    } else if (dollyBackwards) {
                         updates.dollyDelta -= dollyDelta;
+                    } else if (dollyBackwards) {
+                        updates.dollyDelta += dollyDelta;
                     }
                 }
             }

--- a/src/viewer/scene/CameraControl/lib/handlers/KeyboardPanRotateDollyHandler.js
+++ b/src/viewer/scene/CameraControl/lib/handlers/KeyboardPanRotateDollyHandler.js
@@ -8,7 +8,7 @@ class KeyboardPanRotateDollyHandler {
         this._scene = scene;
         const input = scene.input;
 
-        const keyDown = [];
+        const keyDownMap = [];
 
         const canvas = scene.canvas.canvas;
 
@@ -20,7 +20,7 @@ class KeyboardPanRotateDollyHandler {
                 return;
             }
             const keyCode = e.keyCode;
-            keyDown[keyCode] = true;
+            keyDownMap[keyCode] = true;
 
             if (keyCode === input.KEY_SHIFT) {
                 canvas.style.cursor = "move";
@@ -35,7 +35,7 @@ class KeyboardPanRotateDollyHandler {
                 return;
             }
             const keyCode = e.keyCode;
-            keyDown[keyCode] = false;
+            keyDownMap[keyCode] = false;
 
             if (keyCode === input.KEY_SHIFT) {
                 canvas.style.cursor = "default";
@@ -52,7 +52,7 @@ class KeyboardPanRotateDollyHandler {
                 return;
             }
 
-
+            const cameraControl = controllers.cameraControl;
             const elapsedSecs = (e.deltaTime / 1000.0);
 
             //-------------------------------------------------------------------------------------------------
@@ -61,50 +61,32 @@ class KeyboardPanRotateDollyHandler {
 
             if (!configs.planView) {
 
-                const leftArrowKey = keyDown[input.KEY_LEFT_ARROW];
-                const rightArrowKey = keyDown[input.KEY_RIGHT_ARROW];
-                const upArrowKey = keyDown[input.KEY_UP_ARROW];
-                const downArrowKey = keyDown[input.KEY_DOWN_ARROW];
+
+                const rotateYPos = cameraControl._isKeyDownForAction(cameraControl.ROTATE_Y_POS, keyDownMap);
+                const rotateYNeg = cameraControl._isKeyDownForAction(cameraControl.ROTATE_Y_NEG, keyDownMap);
+                const rotateXPos = cameraControl._isKeyDownForAction(cameraControl.ROTATE_X_POS, keyDownMap);
+                const rotateXNeg = cameraControl._isKeyDownForAction(cameraControl.ROTATE_X_NEG, keyDownMap);
 
                 const orbitDelta = elapsedSecs * configs.keyboardRotationRate;
 
-                if (leftArrowKey || rightArrowKey || upArrowKey || downArrowKey) {
+                if (rotateYPos || rotateYNeg || rotateXPos || rotateXNeg) {
 
                     if ((!configs.firstPerson) && configs.followPointer) {
                         controllers.pivotController.startPivot();
                     }
-                    if (rightArrowKey) {
-                        updates.rotateDeltaY -= orbitDelta;
 
-                    } else if (leftArrowKey) {
+                    if (rotateYPos) {
                         updates.rotateDeltaY += orbitDelta;
+
+                    } else if (rotateYNeg) {
+                        updates.rotateDeltaY -= orbitDelta;
                     }
-                    if (downArrowKey) {
+
+                    if (rotateXPos) {
                         updates.rotateDeltaX += orbitDelta;
 
-                    } else if (upArrowKey) {
+                    } else if (rotateXNeg) {
                         updates.rotateDeltaX -= orbitDelta;
-                    }
-                }
-
-                let rotateLeft;
-                let rotateRight;
-
-                if (configs.keyboardLayout === 'azerty') {
-                    rotateLeft = keyDown[input.KEY_A];
-                    rotateRight = keyDown[input.KEY_E];
-
-                } else {
-                    rotateLeft = keyDown[input.KEY_Q];
-                    rotateRight = keyDown[input.KEY_E];
-                }
-
-                if (rotateRight || rotateLeft) {
-                    if (rotateLeft) {
-                        updates.rotateDeltaY += orbitDelta;
-
-                    } else if (rotateRight) {
-                        updates.rotateDeltaY -= orbitDelta;
                     }
 
                     if ((!configs.firstPerson) && configs.followPointer) {
@@ -117,78 +99,59 @@ class KeyboardPanRotateDollyHandler {
             // Keyboard panning
             //-------------------------------------------------------------------------------------------------
 
-            if (!keyDown[input.KEY_CTRL] && !keyDown[input.KEY_ALT]) {
+            if (!keyDownMap[input.KEY_CTRL] && !keyDownMap[input.KEY_ALT]) {
 
-                const addKey = keyDown[input.KEY_ADD];
-                const subtractKey = keyDown[input.KEY_SUBTRACT];
+                const dollyBackwards = cameraControl._isKeyDownForAction(cameraControl.DOLLY_BACKWARDS, keyDownMap);
+                const dollyForwards = cameraControl._isKeyDownForAction(cameraControl.DOLLY_FORWARDS, keyDownMap);
 
-                if (addKey || subtractKey) {
+                if (dollyBackwards || dollyForwards) {
 
                     const dollyDelta = elapsedSecs * configs.keyboardDollyRate;
 
                     if ((!configs.firstPerson) && configs.followPointer) {
                         controllers.pivotController.startPivot();
                     }
-                    if (subtractKey) {
+                    if (dollyForwards) {
                         updates.dollyDelta += dollyDelta;
-                    } else if (addKey) {
+                    } else if (dollyBackwards) {
                         updates.dollyDelta -= dollyDelta;
                     }
                 }
             }
 
-            let panForwardKey;
-            let panBackKey;
-            let panLeftKey;
-            let panRightKey;
-            let panUpKey;
-            let panDownKey;
+            const panForwards = cameraControl._isKeyDownForAction(cameraControl.PAN_FORWARDS, keyDownMap);
+            const panBackwards = cameraControl._isKeyDownForAction(cameraControl.PAN_BACKWARDS, keyDownMap);
+            const panLeft = cameraControl._isKeyDownForAction(cameraControl.PAN_LEFT, keyDownMap);
+            const panRight = cameraControl._isKeyDownForAction(cameraControl.PAN_RIGHT, keyDownMap);
+            const panUp = cameraControl._isKeyDownForAction(cameraControl.PAN_UP, keyDownMap);
+            const panDown = cameraControl._isKeyDownForAction(cameraControl.PAN_DOWN, keyDownMap);
 
-            const panDelta = (keyDown[input.KEY_ALT] ? 0.3 : 1.0) * elapsedSecs * configs.keyboardPanRate; // ALT for slower pan rate
+            const panDelta = (keyDownMap[input.KEY_ALT] ? 0.3 : 1.0) * elapsedSecs * configs.keyboardPanRate; // ALT for slower pan rate
 
-            if (configs.keyboardLayout === 'azerty') {
-
-                panForwardKey = keyDown[input.KEY_Z];
-                panBackKey = keyDown[input.KEY_S];
-                panLeftKey = keyDown[input.KEY_Q];
-                panRightKey = keyDown[input.KEY_D];
-                panUpKey = keyDown[input.KEY_W];
-                panDownKey = keyDown[input.KEY_X];
-
-            } else {
-
-                panForwardKey = keyDown[input.KEY_W];
-                panBackKey = keyDown[input.KEY_S];
-                panLeftKey = keyDown[input.KEY_A];
-                panRightKey = keyDown[input.KEY_D];
-                panUpKey = keyDown[input.KEY_Z];
-                panDownKey = keyDown[input.KEY_X];
-            }
-
-            if (panForwardKey || panBackKey || panLeftKey || panRightKey || panUpKey || panDownKey) {
+            if (panForwards || panBackwards || panLeft || panRight || panUp || panDown) {
 
                 if ((!configs.firstPerson) && configs.followPointer) {
                     controllers.pivotController.startPivot();
                 }
 
-                if (panDownKey) {
+                if (panDown) {
                     updates.panDeltaY += panDelta;
 
-                } else if (panUpKey) {
+                } else if (panUp) {
                     updates.panDeltaY += -panDelta;
                 }
 
-                if (panRightKey) {
+                if (panRight) {
                     updates.panDeltaX += -panDelta;
 
-                } else if (panLeftKey) {
+                } else if (panLeft) {
                     updates.panDeltaX += panDelta;
                 }
 
-                if (panBackKey) {
+                if (panBackwards) {
                     updates.panDeltaZ += panDelta;
 
-                } else if (panForwardKey) {
+                } else if (panForwards) {
                     updates.panDeltaZ += -panDelta;
                 }
             }

--- a/src/viewer/scene/PerformanceModel/PerformanceModel.js
+++ b/src/viewer/scene/PerformanceModel/PerformanceModel.js
@@ -1089,7 +1089,12 @@ class PerformanceModel extends Component {
      *
      * @type {Boolean}
      */
-    set castsShadow(castsShadow) { // TODO
+    set castsShadow(castsShadow) {
+        castsShadow = (castsShadow !== false);
+        if (castsShadow !== this._castsShadow) {
+            this._castsShadow = castsShadow;
+            this.glRedraw();
+        }
     }
 
     /**
@@ -1097,8 +1102,8 @@ class PerformanceModel extends Component {
      *
      * @type {Boolean}
      */
-    get castsShadow() { // TODO
-        return false;
+    get castsShadow() {
+        return this._castsShadow;
     }
 
     /**
@@ -1106,7 +1111,12 @@ class PerformanceModel extends Component {
      *
      * @type {Boolean}
      */
-    set receivesShadow(receivesShadow) { // TODO
+    set receivesShadow(receivesShadow) {
+        receivesShadow = (receivesShadow !== false);
+        if (receivesShadow !== this._receivesShadow) {
+            this._receivesShadow = receivesShadow;
+            this.glRedraw();
+        }
     }
 
     /**
@@ -1114,8 +1124,8 @@ class PerformanceModel extends Component {
      *
      * @type {Boolean}
      */
-    get receivesShadow() { // TODO
-        return false;
+    get receivesShadow() {
+        return this._receivesShadow;
     }
 
     /**
@@ -1515,6 +1525,27 @@ class PerformanceModel extends Component {
         }
         for (var i = 0, len = this._layerList.length; i < len; i++) {
             this._layerList[i].drawOcclusion(frameCtx);
+        }
+    }
+
+    /**
+     * @private
+     */
+    drawShadow(frameCtx) {
+        if (this.numVisibleLayerPortions === 0) {
+            return;
+        }
+        if (frameCtx.backfaces !== this.backfaces) {
+            const gl = this.scene.canvas.gl;
+            if (this.backfaces) {
+                gl.disable(gl.CULL_FACE);
+            } else {
+                gl.enable(gl.CULL_FACE);
+            }
+            frameCtx.backfaces = this.backfaces;
+        }
+        for (let i = 0, len = this._layerList.length; i < len; i++) {
+            this._layerList[i].drawShadow(frameCtx);
         }
     }
 

--- a/src/viewer/scene/PerformanceModel/lib/batching/BatchingLayer.js
+++ b/src/viewer/scene/PerformanceModel/lib/batching/BatchingLayer.js
@@ -888,6 +888,17 @@ class BatchingLayer {
         }
     }
 
+    //---- SHADOWS -----------------------------------------------------------------------------------------------------
+
+    drawShadow(frameCtx) {
+        if (this._numCulledLayerPortions === this._numPortions || this._numVisibleLayerPortions === 0) {
+            return;
+        }
+        if (this._batchingRenderers.shadowRenderer) {
+            this._batchingRenderers.shadowRenderer.drawLayer(frameCtx, this);
+        }
+    }
+
     destroy() {
         const state = this._state;
         if (state.positionsBuf) {

--- a/src/viewer/scene/PerformanceModel/lib/batching/BatchingRenderers.js
+++ b/src/viewer/scene/PerformanceModel/lib/batching/BatchingRenderers.js
@@ -7,6 +7,7 @@ import {BatchingPickNormalsRenderer} from "./pick/BatchingPickNormalsRenderer.js
 import {BatchingOcclusionRenderer} from "./occlusion/BatchingOcclusionRenderer.js";
 import {BatchingDepthRenderer} from "./depth/BatchingDepthRenderer.js";
 import {BatchingNormalsRenderer} from "./normals/BatchingNormalsRenderer.js";
+import {BatchingShadowRenderer} from "./shadow/BatchingShadowRenderer.js";
 
 /**
  * @private
@@ -58,6 +59,10 @@ class BatchingRenderers {
             this.occlusionRenderer.destroy();
             this.occlusionRenderer = null;
         }
+        if (this.shadowRenderer && (!this.shadowRenderer.getValid())) {
+            this.shadowRenderer.destroy();
+            this.shadowRenderer = null;
+        }
         this._createRenderers();
     }
 
@@ -93,6 +98,9 @@ class BatchingRenderers {
         if (!this.normalsRenderer) {
             this.normalsRenderer = new BatchingNormalsRenderer(this._scene);
         }
+        if (!this.shadowRenderer) {
+            this.shadowRenderer = new BatchingShadowRenderer(this._scene);
+        }
     }
 
     _destroy() {
@@ -125,6 +133,9 @@ class BatchingRenderers {
         }
         if (this.occlusionRenderer) {
             this.occlusionRenderer.destroy();
+        }
+        if (this.shadowRenderer) {
+            this.shadowRenderer.destroy();
         }
     }
 }

--- a/src/viewer/scene/PerformanceModel/lib/batching/shadow/BatchingShadowRenderer.js
+++ b/src/viewer/scene/PerformanceModel/lib/batching/shadow/BatchingShadowRenderer.js
@@ -1,0 +1,131 @@
+import {Program} from "../../../../webgl/Program.js";
+import {BatchingShadowShaderSource} from "./BatchingShadowShaderSource.js";
+
+/**
+ * Renders BatchingLayer fragment depths to a shadow map.
+ *
+ * @private
+ */
+class BatchingShadowRenderer {
+
+    constructor(scene) {
+        this._scene = scene;
+        this._hash = this._getHash();
+        this._shaderSource = new BatchingShadowShaderSource(this._scene);
+        this._allocate();
+    }
+
+    getValid() {
+        return this._hash === this._getHash();
+    };
+
+    _getHash() {
+        return this._scene._sectionPlanesState.getHash();
+    }
+
+    drawLayer(frameCtx, layer) {
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+        const state = layer._state;
+        if (!this._program) {
+            this._allocate();
+        }
+        if (frameCtx.lastProgramId !== this._program.id) {
+            frameCtx.lastProgramId = this._program.id;
+            this._bindProgram(frameCtx);
+        }
+        gl.uniformMatrix4fv(this._uPositionsDecodeMatrix, false, layer._state.positionsDecodeMatrix);
+        this._aPosition.bindArrayBuffer(state.positionsBuf);
+        if (this._aColor) { // Needed for masking out transparent entities using alpha channel
+            this._aColor.bindArrayBuffer(state.colorsBuf);
+        }
+        if (this._aFlags) {
+            this._aFlags.bindArrayBuffer(state.flagsBuf);
+        }
+        if (this._aFlags2) {
+            this._aFlags2.bindArrayBuffer(state.flags2Buf);
+        }
+        if (this._aOffset) {
+            this._aOffset.bindArrayBuffer(state.offsetsBuf);
+        }
+        state.indicesBuf.bind();
+        gl.drawElements(state.primitive, state.indicesBuf.numItems, state.indicesBuf.itemType, 0);
+    }
+
+    _allocate() {
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+        const sectionPlanesState = scene._sectionPlanesState;
+        this._program = new Program(gl, this._shaderSource);
+        if (this._program.errors) {
+            this.errors = this._program.errors;
+            return;
+        }
+        const program = this._program;
+        this._uPositionsDecodeMatrix = program.getLocation("positionsDecodeMatrix");
+        this._uShadowViewMatrix = program.getLocation("shadowViewMatrix");
+        this._uShadowProjMatrix = program.getLocation("shadowProjMatrix");
+        this._uSectionPlanes = [];
+        const sectionPlanes = sectionPlanesState.sectionPlanes;
+        for (let i = 0, len = sectionPlanes.length; i < len; i++) {
+            this._uSectionPlanes.push({
+                active: program.getLocation("sectionPlaneActive" + i),
+                pos: program.getLocation("sectionPlanePos" + i),
+                dir: program.getLocation("sectionPlaneDir" + i)
+            });
+        }
+        this._aPosition = program.getAttribute("position");
+        this._aOffset = program.getAttribute("offset");
+        this._aColor = program.getAttribute("color");
+        this._aFlags = program.getAttribute("flags");
+        this._aFlags2 = program.getAttribute("flags2");
+    }
+
+    _bindProgram(frameCtx) {
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+        const program = this._program;
+        const sectionPlanesState = scene._sectionPlanesState;
+        program.bind();
+        gl.uniformMatrix4fv(this._uShadowViewMatrix, false, frameCtx.shadowViewMatrix);
+        gl.uniformMatrix4fv(this._uShadowProjMatrix, false, frameCtx.shadowProjMatrix);
+        if (sectionPlanesState.sectionPlanes.length > 0) {
+            const sectionPlanes = scene._sectionPlanesState.sectionPlanes;
+            let sectionPlaneUniforms;
+            let uSectionPlaneActive;
+            let sectionPlane;
+            let uSectionPlanePos;
+            let uSectionPlaneDir;
+            for (let i = 0, len = this._uSectionPlanes.length; i < len; i++) {
+                sectionPlaneUniforms = this._uSectionPlanes[i];
+                uSectionPlaneActive = sectionPlaneUniforms.active;
+                sectionPlane = sectionPlanes[i];
+                if (uSectionPlaneActive) {
+                    gl.uniform1i(uSectionPlaneActive, sectionPlane.active);
+                }
+                uSectionPlanePos = sectionPlaneUniforms.pos;
+                if (uSectionPlanePos) {
+                    gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);
+                }
+                uSectionPlaneDir = sectionPlaneUniforms.dir;
+                if (uSectionPlaneDir) {
+                    gl.uniform3fv(sectionPlaneUniforms.dir, sectionPlane.dir);
+                }
+            }
+        }
+        this._lastLightId = null;
+    }
+
+    webglContextRestored() {
+        this._program = null;
+    }
+
+    destroy() {
+        if (this._program) {
+            this._program.destroy();
+        }
+        this._program = null;
+    }
+}
+
+export {BatchingShadowRenderer};

--- a/src/viewer/scene/PerformanceModel/lib/batching/shadow/BatchingShadowShaderSource.js
+++ b/src/viewer/scene/PerformanceModel/lib/batching/shadow/BatchingShadowShaderSource.js
@@ -1,0 +1,96 @@
+/**
+ * @private
+ * @constructor
+ */
+const BatchingShadowShaderSource = function (scene, withSAO) {
+    this.vertex = buildVertex(scene);
+    this.fragment = buildFragment(scene, withSAO);
+};
+
+function buildVertex(scene) {
+    const clipping = scene._sectionPlanesState.sectionPlanes.length > 0;
+    const src = [];
+    src.push("// Batched geometry shadow vertex shader");
+    src.push("attribute vec3 position;");
+    src.push("attribute vec3 offset;");
+    src.push("attribute vec4 color;");
+    src.push("attribute vec4 flags;");
+    src.push("attribute vec4 flags2;");
+    src.push("uniform mat4 shadowViewMatrix;");
+    src.push("uniform mat4 shadowProjMatrix;");
+    src.push("uniform mat4 positionsDecodeMatrix;");
+    if (clipping) {
+        src.push("varying vec4 vWorldPosition;");
+        src.push("varying vec4 vFlags2;");
+    }
+    src.push("varying vec4 vViewPosition;");
+    src.push("void main(void) {");
+    src.push("  bool visible        = (float(flags.x) > 0.0);");
+    src.push("  bool transparent    = ((float(color.a) / 255.0) < 1.0);");
+    src.push(`  if (!visible || transparent) {`);
+    src.push("      gl_Position = vec4(0.0, 0.0, 0.0, 0.0);");
+    src.push("  } else {");
+    src.push("      vec4 worldPosition = positionsDecodeMatrix * vec4(position, 1.0); ");
+    src.push("      worldPosition.xyz = worldPosition.xyz + offset;");
+    src.push("      vec4 viewPosition  = shadowViewMatrix * worldPosition; ");
+    if (clipping) {
+        src.push("      vWorldPosition = worldPosition;");
+        src.push("      vFlags2 = flags2;");
+    }
+    src.push("      vViewPosition = viewPosition;");
+    src.push("      gl_Position = shadowProjMatrix * viewPosition;");
+    src.push("  }");
+    src.push("}");
+    return src;
+}
+
+function buildFragment(scene) {
+    const sectionPlanesState = scene._sectionPlanesState;
+    const clipping = (sectionPlanesState.sectionPlanes.length > 0);
+    const src = [];
+    src.push("// Batched geometry shadow fragment shader");
+    src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
+    src.push("precision highp float;");
+    src.push("precision highp int;");
+    src.push("#else");
+    src.push("precision mediump float;");
+    src.push("precision mediump int;");
+    src.push("#endif");
+    if (clipping) {
+        src.push("varying vec4 vWorldPosition;");
+        src.push("varying vec4 vFlags2;");
+        for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
+            src.push("uniform bool sectionPlaneActive" + i + ";");
+            src.push("uniform vec3 sectionPlanePos" + i + ";");
+            src.push("uniform vec3 sectionPlaneDir" + i + ";");
+        }
+    }
+    src.push("varying vec4 vViewPosition;");
+
+    src.push("vec4 encodeFloat( const in float v ) {");
+    src.push("  const vec4 bitShift = vec4(256 * 256 * 256, 256 * 256, 256, 1.0);");
+    src.push("  const vec4 bitMask = vec4(0, 1.0 / 256.0, 1.0 / 256.0, 1.0 / 256.0);");
+    src.push("  vec4 comp = fract(depth * bitShift);");
+    src.push("  comp -= comp.xxyz * bitMask;");
+    src.push("  return comp;");
+    src.push("}");
+
+    src.push("void main(void) {");
+    if (clipping) {
+        src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+        src.push("  if (clippable) {");
+        src.push("      float dist = 0.0;");
+        for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
+            src.push("      if (sectionPlaneActive" + i + ") {");
+            src.push("          dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
+            src.push("      }");
+        }
+        src.push("      if (dist > 0.0) { discard; }");
+        src.push("  }");
+    }
+    src.push("    gl_FragColor = encodeFloat( gl_FragCoord.z); ");
+    src.push("}");
+    return src;
+}
+
+export {BatchingShadowShaderSource};

--- a/src/viewer/scene/PerformanceModel/lib/instancing/InstancingLayer.js
+++ b/src/viewer/scene/PerformanceModel/lib/instancing/InstancingLayer.js
@@ -831,6 +831,17 @@ class InstancingLayer {
         }
     }
 
+    //---- SHADOWS -----------------------------------------------------------------------------------------------------
+
+    drawShadow(frameCtx) {
+        if (this._numCulledLayerPortions === this._numPortions || this._numVisibleLayerPortions === 0) {
+            return;
+        }
+        if (this._instancingRenderers.shadowRenderer) {
+            this._instancingRenderers.shadowRenderer.drawLayer(frameCtx, this);
+        }
+    }
+
     destroy() {
         const state = this._state;
         if (state.positionsBuf) {

--- a/src/viewer/scene/PerformanceModel/lib/instancing/InstancingRenderers.js
+++ b/src/viewer/scene/PerformanceModel/lib/instancing/InstancingRenderers.js
@@ -7,6 +7,7 @@ import {InstancingPickNormalsRenderer} from "./pick/InstancingPickNormalsRendere
 import {InstancingOcclusionRenderer} from "./occlusion/InstancingOcclusionRenderer.js";
 import {InstancingDepthRenderer} from "./depth/InstancingDepthRenderer.js";
 import {InstancingNormalsRenderer} from "./normals/InstancingNormalsRenderer.js";
+import {InstancingShadowRenderer} from "./shadow/InstancingShadowRenderer.js";
 
 /**
  * @private
@@ -58,6 +59,10 @@ class InstancingRenderers {
             this.occlusionRenderer.destroy();
             this.occlusionRenderer = null;
         }
+        if (this.shadowRenderer && (!this.shadowRenderer.getValid())) {
+            this.shadowRenderer.destroy();
+            this.shadowRenderer = null;
+        }
         this._createRenderers();
     }
 
@@ -93,6 +98,9 @@ class InstancingRenderers {
         if (!this.normalsRenderer) {
             this.normalsRenderer = new InstancingNormalsRenderer(this._scene);
         }
+        if (!this.shadowRenderer) {
+            this.shadowRenderer = new InstancingShadowRenderer(this._scene);
+        }
     }
 
     _destroy() {
@@ -125,6 +133,9 @@ class InstancingRenderers {
         }
         if (this.occlusionRenderer) {
             this.occlusionRenderer.destroy();
+        }
+        if (this.shadowRenderer) {
+            this.shadowRenderer.destroy();
         }
     }
 }

--- a/src/viewer/scene/PerformanceModel/lib/instancing/draw/InstancingDrawRenderer.js
+++ b/src/viewer/scene/PerformanceModel/lib/instancing/draw/InstancingDrawRenderer.js
@@ -198,7 +198,6 @@ class InstancingDrawRenderer {
         const lightsState = scene._lightsState;
         const sectionPlanesState = scene._sectionPlanesState;
         const lights = lightsState.lights;
-
         let light;
         program.bind();
         const camera = scene.camera;

--- a/src/viewer/scene/PerformanceModel/lib/instancing/shadow/InstancingShadowRenderer.js
+++ b/src/viewer/scene/PerformanceModel/lib/instancing/shadow/InstancingShadowRenderer.js
@@ -1,0 +1,169 @@
+import {Program} from "../../../../webgl/Program.js";
+import {InstancingShadowShaderSource} from "./InstancingShadowShaderSource.js";
+
+/**
+ * Renders InstancingLayer fragment depths to a shadow map.
+ *
+ * @private
+ */
+class InstancingShadowRenderer {
+
+    constructor(scene) {
+        this._scene = scene;
+        this._hash = this._getHash();
+        this._lastLightId = null;
+        this._shaderSource = new InstancingShadowShaderSource(this._scene);
+        this._allocate();
+    }
+
+    getValid() {
+        return this._hash === this._getHash();
+    };
+
+    _getHash() {
+        return this._scene._sectionPlanesState.getHash();
+    }
+
+    drawLayer(frameCtx, layer) {
+        const model = layer.model;
+        const scene = model.scene;
+        const gl = scene.canvas.gl;
+        const state = layer._state;
+        const instanceExt = this._instanceExt;
+
+        if (!this._program) {
+            this._allocate();
+            if (this.errors) {
+                return;
+            }
+        }
+
+        if (frameCtx.lastProgramId !== this._program.id) {
+            frameCtx.lastProgramId = this._program.id;
+            this._bindProgram(frameCtx);
+        }
+
+        gl.uniformMatrix4fv(this._uPositionsDecodeMatrix, false, layer._state.positionsDecodeMatrix);
+
+        this._aModelMatrixCol0.bindArrayBuffer(state.modelMatrixCol0Buf);
+        this._aModelMatrixCol1.bindArrayBuffer(state.modelMatrixCol1Buf);
+        this._aModelMatrixCol2.bindArrayBuffer(state.modelMatrixCol2Buf);
+
+        instanceExt.vertexAttribDivisorANGLE(this._aModelMatrixCol0.location, 1);
+        instanceExt.vertexAttribDivisorANGLE(this._aModelMatrixCol1.location, 1);
+        instanceExt.vertexAttribDivisorANGLE(this._aModelMatrixCol2.location, 1);
+
+        this._aPosition.bindArrayBuffer(state.positionsBuf);
+
+        this._aOffset.bindArrayBuffer(state.offsetsBuf);
+        instanceExt.vertexAttribDivisorANGLE(this._aOffset.location, 1);
+
+        this._aColor.bindArrayBuffer(state.colorsBuf);
+        instanceExt.vertexAttribDivisorANGLE(this._aColor.location, 1);
+
+        this._aFlags.bindArrayBuffer(state.flagsBuf);
+        instanceExt.vertexAttribDivisorANGLE(this._aFlags.location, 1);
+
+        if (this._aFlags2) {
+            this._aFlags2.bindArrayBuffer(state.flags2Buf);
+            instanceExt.vertexAttribDivisorANGLE(this._aFlags2.location, 1);
+        }
+
+        state.indicesBuf.bind();
+
+        instanceExt.drawElementsInstancedANGLE(state.primitive, state.indicesBuf.numItems, state.indicesBuf.itemType, 0, state.numInstances);
+
+        instanceExt.vertexAttribDivisorANGLE(this._aModelMatrixCol0.location, 0);
+        instanceExt.vertexAttribDivisorANGLE(this._aModelMatrixCol1.location, 0);
+        instanceExt.vertexAttribDivisorANGLE(this._aModelMatrixCol2.location, 0);
+        instanceExt.vertexAttribDivisorANGLE(this._aColor.location, 0);
+        instanceExt.vertexAttribDivisorANGLE(this._aFlags.location, 0);
+
+        if (this._aFlags2) { // Won't be in shader when not clipping
+            instanceExt.vertexAttribDivisorANGLE(this._aFlags2.location, 0);
+        }
+        instanceExt.vertexAttribDivisorANGLE(this._aOffset.location, 0);
+    }
+
+    _allocate() {
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+        const sectionPlanesState = scene._sectionPlanesState;
+        this._program = new Program(gl, this._shaderSource);
+        if (this._program.errors) {
+            this.errors = this._program.errors;
+            return;
+        }
+        this._instanceExt = gl.getExtension("ANGLE_instanced_arrays");
+        const program = this._program;
+        this._uPositionsDecodeMatrix = program.getLocation("positionsDecodeMatrix");
+        this._uShadowViewMatrix = program.getLocation("shadowViewMatrix");
+        this._uShadowProjMatrix = program.getLocation("shadowProjMatrix");
+        this._uSectionPlanes = [];
+        const clips = sectionPlanesState.sectionPlanes;
+        for (let i = 0, len = clips.length; i < len; i++) {
+            this._uSectionPlanes.push({
+                active: program.getLocation("sectionPlaneActive" + i),
+                pos: program.getLocation("sectionPlanePos" + i),
+                dir: program.getLocation("sectionPlaneDir" + i)
+            });
+        }
+        this._aPosition = program.getAttribute("position");
+        this._aOffset = program.getAttribute("offset");
+        this._aColor = program.getAttribute("color");
+        this._aFlags = program.getAttribute("flags");
+        this._aFlags2 = program.getAttribute("flags2");
+        this._aModelMatrixCol0 = program.getAttribute("modelMatrixCol0");
+        this._aModelMatrixCol1 = program.getAttribute("modelMatrixCol1");
+        this._aModelMatrixCol2 = program.getAttribute("modelMatrixCol2");
+    }
+
+    _bindProgram(frameCtx) {
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+        const program = this._program;
+        const sectionPlanesState = scene._sectionPlanesState;
+        const projectState = scene.camera.project._state;
+        program.bind();
+        gl.uniformMatrix4fv(this._uShadowViewMatrix, false, frameCtx.shadowViewMatrix);
+        gl.uniformMatrix4fv(this._uShadowProjMatrix, false, frameCtx.shadowProjMatrix);
+        if (sectionPlanesState.sectionPlanes.length > 0) {
+            const clips = scene._sectionPlanesState.sectionPlanes;
+            let sectionPlaneUniforms;
+            let uSectionPlaneActive;
+            let sectionPlane;
+            let uSectionPlanePos;
+            let uSectionPlaneDir;
+            for (var i = 0, len = this._uSectionPlanes.length; i < len; i++) {
+                sectionPlaneUniforms = this._uSectionPlanes[i];
+                uSectionPlaneActive = sectionPlaneUniforms.active;
+                sectionPlane = clips[i];
+                if (uSectionPlaneActive) {
+                    gl.uniform1i(uSectionPlaneActive, sectionPlane.active);
+                }
+                uSectionPlanePos = sectionPlaneUniforms.pos;
+                if (uSectionPlanePos) {
+                    gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);
+                }
+                uSectionPlaneDir = sectionPlaneUniforms.dir;
+                if (uSectionPlaneDir) {
+                    gl.uniform3fv(sectionPlaneUniforms.dir, sectionPlane.dir);
+                }
+            }
+        }
+        this._lastLightId = null;
+    }
+
+    webglContextRestored() {
+        this._program = null;
+    }
+
+    destroy() {
+        if (this._program) {
+            this._program.destroy();
+        }
+        this._program = null;
+    }
+}
+
+export {InstancingShadowRenderer};

--- a/src/viewer/scene/PerformanceModel/lib/instancing/shadow/InstancingShadowShaderSource.js
+++ b/src/viewer/scene/PerformanceModel/lib/instancing/shadow/InstancingShadowShaderSource.js
@@ -1,0 +1,105 @@
+/**
+ * @private
+ */
+const InstancingShadowShaderSource = function (scene) {
+    this.vertex = buildVertex(scene);
+    this.fragment = buildFragment(scene);
+};
+
+function buildVertex(scene) {
+    const sectionPlanesState = scene._sectionPlanesState;
+    const clipping = sectionPlanesState.sectionPlanes.length > 0;
+    const src = [];
+    src.push("// Instancing geometry shadow drawing vertex shader");
+    src.push("attribute vec3 position;");
+    src.push("attribute vec3 offset;");
+    src.push("attribute vec4 color;");
+    src.push("attribute vec4 flags;");
+    src.push("attribute vec4 flags2;");
+    src.push("attribute vec4 modelMatrixCol0;");
+    src.push("attribute vec4 modelMatrixCol1;");
+    src.push("attribute vec4 modelMatrixCol2;");
+    src.push("uniform mat4 shadowViewMatrix;");
+    src.push("uniform mat4 shadowProjMatrix;");
+    src.push("uniform mat4 positionsDecodeMatrix;");
+    if (clipping) {
+        src.push("varying vec4 vWorldPosition;");
+        src.push("varying vec4 vFlags2;");
+    }
+    src.push("varying vec4 vViewPosition;");
+    src.push("void main(void) {");
+    src.push("bool visible      = (float(flags.x) > 0.0);");
+    src.push("bool transparent  = ((float(color.a) / 255.0) < 1.0);");
+    src.push(`if (!visible || transparent) {`);
+    src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
+    src.push("} else {");
+    src.push("  vec4 worldPosition = positionsDecodeMatrix * vec4(position, 1.0); ");
+    src.push("  worldPosition = vec4(dot(worldPosition, modelMatrixCol0), dot(worldPosition, modelMatrixCol1), dot(worldPosition, modelMatrixCol2), 1.0);");
+    src.push("  worldPosition.xyz = worldPosition.xyz + offset;");
+    src.push("  vec4 viewPosition  = shadowViewMatrix * worldPosition; ");
+
+    if (clipping) {
+        src.push("vWorldPosition = worldPosition;");
+        src.push("vFlags2 = flags2;");
+    }
+    src.push("  vViewPosition = viewPosition;");
+    src.push("  gl_Position = shadowProjMatrix * viewPosition;");
+    src.push("}");
+    src.push("}");
+    return src;
+}
+
+function buildFragment(scene) {
+    const sectionPlanesState = scene._sectionPlanesState;
+    let i;
+    let len;
+    const clipping = sectionPlanesState.sectionPlanes.length > 0;
+    const src = [];
+    src.push("// Instancing geometry shadow drawing fragment shader");
+
+    src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
+    src.push("precision highp float;");
+    src.push("precision highp int;");
+    src.push("#else");
+    src.push("precision mediump float;");
+    src.push("precision mediump int;");
+    src.push("#endif");
+
+    if (clipping) {
+        src.push("varying vec4 vWorldPosition;");
+        src.push("varying vec4 vFlags2;");
+        for (i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
+            src.push("uniform bool sectionPlaneActive" + i + ";");
+            src.push("uniform vec3 sectionPlanePos" + i + ";");
+            src.push("uniform vec3 sectionPlaneDir" + i + ";");
+        }
+    }
+    src.push("varying vec4 vViewPosition;");
+
+    src.push("vec4 encodeFloat( const in float v ) {");
+    src.push("  const vec4 bitShift = vec4(256 * 256 * 256, 256 * 256, 256, 1.0);");
+    src.push("  const vec4 bitMask = vec4(0, 1.0 / 256.0, 1.0 / 256.0, 1.0 / 256.0);");
+    src.push("  vec4 comp = fract(depth * bitShift);");
+    src.push("  comp -= comp.xxyz * bitMask;");
+    src.push("  return comp;");
+    src.push("}");
+
+    src.push("void main(void) {");
+    if (clipping) {
+        src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+        src.push("  if (clippable) {");
+        src.push("  float dist = 0.0;");
+        for (i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
+            src.push("if (sectionPlaneActive" + i + ") {");
+            src.push("   dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
+            src.push("}");
+        }
+        src.push("if (dist > 0.0) { discard; }");
+        src.push("}");
+    }
+    src.push("    gl_FragColor = encodeFloat( gl_FragCoord.z); ");
+    src.push("}");
+    return src;
+}
+
+export {InstancingShadowShaderSource};

--- a/src/viewer/scene/lights/DirLight.js
+++ b/src/viewer/scene/lights/DirLight.js
@@ -123,55 +123,68 @@ class DirLight extends Light {
 
         super(owner, cfg);
 
-        const self = this;
-
         this._shadowRenderBuf = null;
         this._shadowViewMatrix = null;
         this._shadowProjMatrix = null;
         this._shadowViewMatrixDirty = true;
         this._shadowProjMatrixDirty = true;
 
+        const camera = this.scene.camera;
+        const canvas = this.scene.canvas;
+
+        this._onCameraViewMatrix = camera.on("viewMatrix", () => {
+            this._shadowViewMatrixDirty = true;
+        });
+
+        this._onCameraProjMatrix = camera.on("projMatrix", () => {
+            this._shadowProjMatrixDirty = true;
+        });
+
+        this._onCanvasBoundary = canvas.on("boundary", () => {
+            this._shadowProjMatrixDirty = true;
+        });
+
         this._state = new RenderState({
+
             type: "dir",
             dir: math.vec3([1.0, 1.0, 1.0]),
             color: math.vec3([0.7, 0.7, 0.8]),
             intensity: 1.0,
             space: cfg.space || "view",
             castsShadow: false,
-            shadowDirty: true,
 
-            getShadowViewMatrix: (function () {
-                const look = math.vec3();
-                const up = math.vec3([0, 1, 0]);
-                return function () {
-                    if (self._shadowViewMatrixDirty) {
-                        if (!self._shadowViewMatrix) {
-                            self._shadowViewMatrix = math.identityMat4();
-                        }
-                        const dir = self._state.dir;
-                        math.lookAtMat4v([-dir[0], -dir[1], -dir[2]], [0, 0, 0], up, self._shadowViewMatrix);
-                        self._shadowViewMatrixDirty = false;
+            getShadowViewMatrix: () => {
+                if (this._shadowViewMatrixDirty) {
+                    if (!this._shadowViewMatrix) {
+                        this._shadowViewMatrix = math.identityMat4();
                     }
-                    return self._shadowViewMatrix;
-                };
-            })(),
-
-            getShadowProjMatrix: function () {
-                if (self._shadowProjMatrixDirty) { // TODO: Set when canvas resizes
-                    if (!self._shadowProjMatrix) {
-                        self._shadowProjMatrix = math.identityMat4();
-                    }
-                    math.orthoMat4c(-10, 10, -10, 10, 0, 500.0, self._shadowProjMatrix);
-                    self._shadowProjMatrixDirty = false;
+                    const camera = this.scene.camera;
+                    const dir = this._state.dir;
+                    const look = camera.look;
+                    const eye = [look[0] - dir[0], look[1] - dir[1], look[2] - dir[2]];
+                    const up = [0, 1, 0];
+                    math.lookAtMat4v(eye, look, up, this._shadowViewMatrix);
+                    this._shadowViewMatrixDirty = false;
                 }
-                return self._shadowProjMatrix;
+                return this._shadowViewMatrix;
             },
 
-            getShadowRenderBuf: function () {
-                if (!self._shadowRenderBuf) {
-                    self._shadowRenderBuf = new RenderBuffer(self.scene.canvas.canvas, self.scene.canvas.gl, {size: [1024, 1024]});
+            getShadowProjMatrix: () => {
+                if (this._shadowProjMatrixDirty) { // TODO: Set when canvas resizes
+                    if (!this._shadowProjMatrix) {
+                        this._shadowProjMatrix = math.identityMat4();
+                    }
+                    math.orthoMat4c(-40, 40, -40, 40, -40.0, 80, this._shadowProjMatrix);  // left, right, bottom, top, near, far, dest
+                    this._shadowProjMatrixDirty = false;
                 }
-                return self._shadowRenderBuf;
+                return this._shadowProjMatrix;
+            },
+
+            getShadowRenderBuf: () => {
+                if (!this._shadowRenderBuf) {
+                    this._shadowRenderBuf = new RenderBuffer(this.scene.canvas.canvas, this.scene.canvas.gl, {size: [1024, 1024]}); // Super old mobile devices have a limit of 1024x1024 textures
+                }
+                return this._shadowRenderBuf;
             }
         });
 
@@ -179,6 +192,7 @@ class DirLight extends Light {
         this.color = cfg.color;
         this.intensity = cfg.intensity;
         this.castsShadow = cfg.castsShadow;
+
         this.scene._lightCreated(this);
     }
 
@@ -285,6 +299,13 @@ class DirLight extends Light {
      * Destroys this DirLight.
      */
     destroy() {
+
+        const camera = this.scene.camera;
+        const canvas = this.scene.canvas;
+        camera.off(this._onCameraViewMatrix);
+        camera.off(this._onCameraProjMatrix);
+        canvas.off(this._onCanvasBoundary);
+
         super.destroy();
         this._state.destroy();
         if (this._shadowRenderBuf) {

--- a/src/viewer/scene/lights/Shadow.js
+++ b/src/viewer/scene/lights/Shadow.js
@@ -73,11 +73,14 @@ class Shadow extends Component {
     }
 
     constructor(owner, cfg={}) {
+
         super(owner, cfg);
+
         this._state = {
             resolution: math.vec3([1000, 1000]),
             intensity: 1.0
         };
+
         this.resolution = cfg.resolution;
         this.intensity = cfg.intensity;
     }
@@ -98,13 +101,6 @@ class Shadow extends Component {
         this._state.resolution.set(value || [1000.0, 1000.0]);
 
         this.glRedraw();
-
-        /**
-         Fired whenever this Shadow's  {@link Shadow/resolution} property changes.
-         @event resolution
-         @param value The property's new value
-         */
-        this.fire("resolution", this._state.resolution);
     }
 
     get resolution() {
@@ -127,13 +123,6 @@ class Shadow extends Component {
         this._state.intensity = value;
 
         this.glRedraw();
-
-        /**
-         * Fired whenever this Shadow's  {@link Shadow/intensity} property changes.
-         * @event intensity
-         * @param value The property's new value
-         */
-        this.fire("intensity", this._state.intensity);
     }
 
     get intensity() {

--- a/src/viewer/scene/mesh/Mesh.js
+++ b/src/viewer/scene/mesh/Mesh.js
@@ -13,6 +13,7 @@ import {EmphasisEdgesRenderer} from "./emphasis/EmphasisEdgesRenderer.js";
 import {PickMeshRenderer} from "./pick/PickMeshRenderer.js";
 import {PickTriangleRenderer} from "./pick/PickTriangleRenderer.js";
 import {OcclusionRenderer} from "./occlusion/OcclusionRenderer.js";
+import {ShadowRenderer} from "./shadow/ShadowRenderer.js";
 
 import {geometryCompressionUtils} from '../math/geometryCompressionUtils.js';
 
@@ -372,7 +373,7 @@ class Mesh extends Component {
             this._state.drawHash = drawHash;
             this._putDrawRenderers();
             this._drawRenderer = DrawRenderer.get(this);
-            // this._shadowRenderer = ShadowRenderer.get(this);
+           // this._shadowRenderer = ShadowRenderer.get(this);
             this._emphasisFillRenderer = EmphasisFillRenderer.get(this);
             this._emphasisEdgesRenderer = EmphasisEdgesRenderer.get(this);
         }
@@ -876,7 +877,6 @@ class Mesh extends Component {
         }
     }
 
-
     //------------------------------------------------------------------------------------------------------------------
     // Entity members
     //------------------------------------------------------------------------------------------------------------------
@@ -1238,14 +1238,13 @@ class Mesh extends Component {
      * @type {Boolean}
      */
     set receivesShadow(value) {
-        this._state.receivesShadow = false; // Disables shadows for now
-        // value = value !== false;
-        // if (value === this._state.receivesShadow) {
-        //     return;
-        // }
-        // this._state.receivesShadow = value;
-        // this._state.hash = value ? "/mod/rs;" : "/mod;";
-        // this.fire("dirty", this); // Now need to (re)compile objectRenderers to include/exclude shadow mapping
+        value = value !== false;
+        if (value === this._state.receivesShadow) {
+            return;
+        }
+        this._state.receivesShadow = value;
+        this._state.hash = value ? "/mod/rs;" : "/mod;";
+        this.fire("dirty", this); // Now need to (re)compile objectRenderers to include/exclude shadow mapping
     }
 
     /**
@@ -1733,6 +1732,13 @@ class Mesh extends Component {
     drawOcclusion(frameCtx) {
         if (this._occlusionRenderer || (this._occlusionRenderer = OcclusionRenderer.get(this))) {
             this._occlusionRenderer.drawMesh(frameCtx, this);
+        }
+    }
+
+    /** @private  */
+    drawShadow(frameCtx) {
+        if (this._shadowRenderer || (this._shadowRenderer = ShadowRenderer.get(this))) {
+            this._shadowRenderer.drawMesh(frameCtx, this);
         }
     }
 

--- a/src/viewer/scene/mesh/draw/DrawShaderSource.js
+++ b/src/viewer/scene/mesh/draw/DrawShaderSource.js
@@ -418,7 +418,8 @@ function buildVertexDraw(mesh) {
     if (receivesShadow) {
         src.push("const mat4 texUnitConverter = mat4(0.5, 0.0, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.0, 0.5, 0.0, 0.5, 0.5, 0.5, 1.0);");
         for (i = 0, len = lightsState.lights.length; i < len; i++) { // Light sources
-            if (lightsState.lights[i].castsShadow) {
+            const light = lightsState.lights[i];
+            if (light.castsShadow) {
                 src.push("uniform mat4 shadowViewMatrix" + i + ";");
                 src.push("uniform mat4 shadowProjMatrix" + i + ";");
                 src.push("varying vec4 vShadowPosFromLight" + i + ";");
@@ -513,11 +514,11 @@ function buildVertexDraw(mesh) {
     }
     src.push("   vViewPosition = viewPosition.xyz;");
     src.push("   gl_Position = projMatrix * viewPosition;");
-    src.push("const mat4 texUnitConverter = mat4(0.5, 0.0, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.0, 0.5, 0.0, 0.5, 0.5, 0.5, 1.0);");
+    src.push("   const mat4 texUnitConverter = mat4(0.5, 0.0, 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.0, 0.5, 0.0, 0.5, 0.5, 0.5, 1.0);");
     if (receivesShadow) {
-        src.push("vec4 tempx; ");
         for (i = 0, len = lightsState.lights.length; i < len; i++) { // Light sources
-            if (lightsState.lights[i].castsShadow) {
+            const light = lightsState.lights[i];
+            if (light.castsShadow) {
                 src.push("vShadowPosFromLight" + i + " = texUnitConverter * shadowProjMatrix" + i + " * (shadowViewMatrix" + i + " * worldPosition); ");
             }
         }
@@ -559,9 +560,9 @@ function buildFragmentDraw(mesh) {
     src.push("precision " + getFragmentFloatPrecision(gl) + " float;");
 
     if (receivesShadow) {
-        src.push("float unpackDepth (vec4 color) {");
-        src.push("  const vec4 bitShift = vec4(1.0, 1.0/256.0, 1.0/(256.0 * 256.0), 1.0/(256.0*256.0*256.0));");
-        src.push("  return dot(color, bitShift);");
+        src.push("float decodeFloat (vec4 value) {");
+        src.push("  const vec4 bitShift = vec4(1.0 / (256.0 * 256.0 * 256.0), 1.0 / (256.0 * 256.0), 1.0 / 256.0, 1.0);");
+        src.push("  return dot(value, bitShift);");
         src.push("}");
     }
 
@@ -1048,20 +1049,20 @@ function buildFragmentDraw(mesh) {
     if (receivesShadow) {
 
         // Variance castsShadow mapping filter
+        /*
+                src.push("float linstep(float low, float high, float v){");
+                src.push("      return clamp((v-low)/(high-low), 0.0, 1.0);");
+                src.push("}");
 
-        // src.push("float linstep(float low, float high, float v){");
-        // src.push("      return clamp((v-low)/(high-low), 0.0, 1.0);");
-        // src.push("}");
-        //
-        // src.push("float VSM(sampler2D depths, vec2 uv, float compare){");
-        // src.push("      vec2 moments = texture2D(depths, uv).xy;");
-        // src.push("      float p = smoothstep(compare-0.02, compare, moments.x);");
-        // src.push("      float variance = max(moments.y - moments.x*moments.x, -0.001);");
-        // src.push("      float d = compare - moments.x;");
-        // src.push("      float p_max = linstep(0.2, 1.0, variance / (variance + d*d));");
-        // src.push("      return clamp(max(p, p_max), 0.0, 1.0);");
-        // src.push("}");
-
+                src.push("float VSM(sampler2D shadowMap, vec2 uv, float compare){");
+                src.push("      vec2 moments = texture2D(shadowMap, uv).xy;");
+                src.push("      float p = smoothstep(compare - 0.02, compare, moments.x);");
+                src.push("      float variance = max(moments.y - moments.x*moments.x, -0.001);");
+                src.push("      float d = compare - moments.x;");
+                src.push("      float p_max = linstep(0.2, 1.0, variance / (variance + (d * d)));");
+                src.push("      return clamp(max(p, p_max), 0.0, 1.0);");
+                src.push("}");
+        */
         for (i = 0, len = lightsState.lights.length; i < len; i++) { // Light sources
             if (lightsState.lights[i].castsShadow) {
                 src.push("varying vec4 vShadowPosFromLight" + i + ";");
@@ -1400,27 +1401,8 @@ function buildFragmentDraw(mesh) {
 
         // LIGHT SOURCE SHADING
 
-        src.push("float shadow = 1.0;");
-
-        // if (receivesShadow) {
-        //
-        //     src.push("float lightDepth2 = clamp(length(lightPos)/40.0, 0.0, 1.0);");
-        //     src.push("float illuminated = VSM(sLightDepth, lightUV, lightDepth2);");
-        //
-        src.push("float shadowAcneRemover = 0.007;");
-        src.push("vec3 fragmentDepth;");
-        src.push("float texelSize = 1.0 / 1024.0;");
-        src.push("float amountInLight = 0.0;");
-        src.push("vec3 shadowCoord;");
-        src.push('vec4 rgbaDepth;');
-        src.push("float depth;");
-        // }
-
-        const numShadows = 0;
         for (i = 0, len = lightsState.lights.length; i < len; i++) {
-
             light = lightsState.lights[i];
-
             if (light.type === "ambient") {
                 continue;
             }
@@ -1428,85 +1410,110 @@ function buildFragmentDraw(mesh) {
                 src.push("viewLightDir = -normalize(lightDir" + i + ");");
             } else if (light.type === "point" && light.space === "view") {
                 src.push("viewLightDir = normalize(lightPos" + i + " - vViewPosition);");
-                //src.push("tmpVec3 = lightPos" + i + ".xyz - viewPosition.xyz;");
-                //src.push("lightDist = abs(length(tmpVec3));");
             } else {
                 src.push("viewLightDir = normalize(vViewLightReverseDirAndDist" + i + ".xyz);"); // If normal mapping, the fragment->light vector will be in tangent space
             }
-
-            if (receivesShadow && light.castsShadow) {
-
-                // if (true) {
-                //     src.push('shadowCoord = (vShadowPosFromLight' + i + '.xyz/vShadowPosFromLight' + i + '.w)/2.0 + 0.5;');
-                //     src.push("lightDepth2 = clamp(length(vec3[0.0, 20.0, 20.0])/40.0, 0.0, 1.0);");
-                //     src.push("castsShadow *= VSM(shadowMap' + i + ', shadowCoord, lightDepth2);");
-                // }
-                //
-                // if (false) {
-                //
-                // PCF
-
-                src.push("shadow = 0.0;");
-
-                src.push("fragmentDepth = vShadowPosFromLight" + i + ".xyz;");
-                src.push("fragmentDepth.z -= shadowAcneRemover;");
-                src.push("for (int x = -3; x <= 3; x++) {");
-                src.push("  for (int y = -3; y <= 3; y++) {");
-                src.push("      float texelDepth = unpackDepth(texture2D(shadowMap" + i + ", fragmentDepth.xy + vec2(x, y) * texelSize));");
-                src.push("      if (fragmentDepth.z < texelDepth) {");
-                src.push("          shadow += 1.0;");
-                src.push("      }");
-                src.push("  }");
-                src.push("}");
-
-                src.push("shadow = shadow / 9.0;");
-
-                src.push("light.color =  lightColor" + i + ".rgb * (lightColor" + i + ".a * shadow);"); // a is intensity
-                //
-                // }
-                //
-                // if (false){
-                //
-                //     src.push("shadow = 1.0;");
-                //
-                //     src.push('shadowCoord = (vShadowPosFromLight' + i + '.xyz/vShadowPosFromLight' + i + '.w)/2.0 + 0.5;');
-                //
-                //     src.push('shadow -= (shadowCoord.z > unpackDepth(texture2D(shadowMap' + i + ', shadowCoord.xy + vec2( -0.94201624, -0.39906216 ) / 700.0)) + 0.0015) ? 0.2 : 0.0;');
-                //     src.push('shadow -= (shadowCoord.z > unpackDepth(texture2D(shadowMap' + i + ', shadowCoord.xy + vec2( 0.94558609, -0.76890725 ) / 700.0)) + 0.0015) ? 0.2 : 0.0;');
-                //     src.push('shadow -= (shadowCoord.z > unpackDepth(texture2D(shadowMap' + i + ', shadowCoord.xy + vec2( -0.094184101, -0.92938870 ) / 700.0)) + 0.0015) ? 0.2 : 0.0;');
-                //     src.push('shadow -= (shadowCoord.z > unpackDepth(texture2D(shadowMap' + i + ', shadowCoord.xy + vec2( 0.34495938, 0.29387760 ) / 700.0)) + 0.0015) ? 0.2 : 0.0;');
-                //
-                //     src.push("light.color =  lightColor" + i + ".rgb * (lightColor" + i + ".a * shadow);");
-                // }
-            } else {
-                src.push("light.color =  lightColor" + i + ".rgb * (lightColor" + i + ".a );"); // a is intensity
-            }
-
-            src.push("light.direction = viewLightDir;");
-
-            if (phongMaterial) {
-                src.push("computePhongLighting(light, geometry, material, reflectedLight);");
-            }
-
-            if (specularMaterial || metallicMaterial) {
-                src.push("computePBRLighting(light, geometry, material, reflectedLight);");
-            }
         }
 
-        if (numShadows > 0) {
-            //src.push("shadow /= " + (9 * numShadows) + ".0;");
-        }
+        if (receivesShadow) {
 
-        //src.push("reflectedLight.diffuse *= shadow;");
+            src.push("float shadowAcneRemover = 0.007;");
+            src.push("vec3  fragmentDepth;");
+            src.push("float texelSize = 1.0 / 1024.0;");
+            src.push("float amountInLight;");
+            src.push("float amountInLightTotal = 0.0;");
+            src.push("vec3  shadowCoord;");
+            src.push('vec4  rgbaDepth;');
+            src.push("float depth;");
+
+            let numShadows = 0;
+
+            for (i = 0, len = lightsState.lights.length; i < len; i++) {
+
+                light = lightsState.lights[i];
+
+                if (light.type === "ambient") {
+                    continue;
+                }
+
+                if (light.castsShadow) {
+
+                    // if (true) {
+                    //     src.push('shadowCoord = (vShadowPosFromLight' + i + '.xyz/vShadowPosFromLight' + i + '.w)/2.0 + 0.5;');
+                    //     src.push("lightDepth2 = clamp(length(vec3[0.0, 20.0, 20.0])/40.0, 0.0, 1.0);");
+                    //     src.push("castsShadow *= VSM(shadowMap' + i + ', shadowCoord, lightDepth2);");
+                    // }
+                    //
+                    // if (false) {
+                    //
+                    // PCF
+
+                    src.push("amountInLight = 0.0;");
+
+                    src.push("fragmentDepth = vShadowPosFromLight" + i + ".xyz;");
+
+                    src.push("fragmentDepth.z -= shadowAcneRemover;");
+
+                    src.push("for (int x = -3; x <= 3; x++) {");
+                    src.push("  for (int y = -3; y <= 3; y++) {");
+                    src.push("      float texelDepth = decodeFloat(texture2D(shadowMap" + i + ", fragmentDepth.xy + vec2(x, y) * texelSize));");
+                    src.push("      if (fragmentDepth.z < texelDepth) {");
+                    src.push("          amountInLight += 1.0;");
+                    src.push("      }");
+                    src.push("  }");
+                    src.push("}");
+
+                    src.push("amountInLightTotal += (amountInLight / 9.0);");
+
+                    src.push("light.color = lightColor" + i + ".rgb * (lightColor" + i + ".a * (amountInLight / 9.0));"); // a is intensity
+//                src.push("light.color =  lightColor" + i + ".rgb;"); // a is intensity
+
+                    // }
+                    //
+                    // if (false){
+                    //
+                    //     src.push("shadow = 1.0;");
+                    //
+                    //     src.push('shadowCoord = (vShadowPosFromLight' + i + '.xyz/vShadowPosFromLight' + i + '.w)/2.0 + 0.5;');
+                    //
+                    //     src.push('shadow -= (shadowCoord.z > decodeFloat(texture2D(shadowMap' + i + ', shadowCoord.xy + vec2( -0.94201624, -0.39906216 ) / 700.0)) + 0.0015) ? 0.2 : 0.0;');
+                    //     src.push('shadow -= (shadowCoord.z > decodeFloat(texture2D(shadowMap' + i + ', shadowCoord.xy + vec2( 0.94558609, -0.76890725 ) / 700.0)) + 0.0015) ? 0.2 : 0.0;');
+                    //     src.push('shadow -= (shadowCoord.z > decodeFloat(texture2D(shadowMap' + i + ', shadowCoord.xy + vec2( -0.094184101, -0.92938870 ) / 700.0)) + 0.0015) ? 0.2 : 0.0;');
+                    //     src.push('shadow -= (shadowCoord.z > decodeFloat(texture2D(shadowMap' + i + ', shadowCoord.xy + vec2( 0.34495938, 0.29387760 ) / 700.0)) + 0.0015) ? 0.2 : 0.0;');
+                    //
+                    //     src.push("light.color =  lightColor" + i + ".rgb * (lightColor" + i + ".a * shadow);");
+                    // }
+
+                    numShadows++;
+
+                } else {
+
+                    src.push("light.color =  lightColor" + i + ".rgb * (lightColor" + i + ".a );"); // a is intensity
+                }
+
+                src.push("light.direction = viewLightDir;");
+
+                if (phongMaterial) {
+                    src.push("computePhongLighting(light, geometry, material, reflectedLight);");
+                }
+
+                if (specularMaterial || metallicMaterial) {
+                    src.push("computePBRLighting(light, geometry, material, reflectedLight);");
+                }
+            }
+
+            if (numShadows > 1) {
+                src.push("amountInLightTotal /= " + numShadows + ".0;");
+            }
+
+            // src.push("reflectedLight.diffuse *= amountInLightTotal;");
+        }
 
         // COMBINE TERMS
 
         if (phongMaterial) {
-
             src.push("ambientColor *= (lightAmbient.rgb * lightAmbient.a);");
-
             src.push("vec3 outgoingLight =  ((occlusion * (( reflectedLight.diffuse + reflectedLight.specular)))) + emissiveColor;");
-
         } else {
             src.push("vec3 outgoingLight = (occlusion * (reflectedLight.diffuse)) + (occlusion * reflectedLight.specular) + emissiveColor;");
         }
@@ -1518,7 +1525,6 @@ function buildFragmentDraw(mesh) {
         //--------------------------------------------------------------------------------
 
         src.push("ambientColor *= (lightAmbient.rgb * lightAmbient.a);");
-
         src.push("vec3 outgoingLight = emissiveColor + ambientColor;");
     }
 

--- a/src/viewer/scene/scene/Scene.js
+++ b/src/viewer/scene/scene/Scene.js
@@ -1208,6 +1208,7 @@ class Scene extends Component {
                 this._compilables[id].compile();
             }
         }
+        this._renderer.shadowsDirty();
         this.fire("compile", this, true);
     }
 

--- a/src/viewer/scene/webgl/Drawable.js
+++ b/src/viewer/scene/webgl/Drawable.js
@@ -284,6 +284,15 @@ class Drawable {
      */
     drawOcclusion(frameCtx) {
     }
+
+    /**
+     * Renders depths to a shadow map buffer..
+     *
+     * @param {FrameContext} frameCtx Renderer frame context.
+     * @abstract
+     */
+    drawShadow(frameCtx) {
+    }
 }
 
 export {Drawable};

--- a/src/viewer/scene/webgl/RenderBuffer.js
+++ b/src/viewer/scene/webgl/RenderBuffer.js
@@ -66,12 +66,14 @@ class RenderBuffer {
 
         const texture = gl.createTexture();
         gl.bindTexture(gl.TEXTURE_2D, texture);
-        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
 
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
         gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
 
         const renderbuf = gl.createRenderbuffer();
         gl.bindRenderbuffer(gl.RENDERBUFFER, renderbuf);
@@ -230,7 +232,7 @@ class RenderBuffer {
 
     getTexture() {
         const self = this;
-        return {
+        return this._texture || (this._texture = {
             renderBuffer: this,
             bind: function (unit) {
                 if (self.buffer && self.buffer.texture) {
@@ -246,7 +248,7 @@ class RenderBuffer {
                     self.gl.bindTexture(self.gl.TEXTURE_2D, null);
                 }
             }
-        };
+        });
     }
 
     destroy() {
@@ -260,6 +262,7 @@ class RenderBuffer {
             this.bound = false;
         }
         this._imageDataCache = null;
+        this._texture = null;
     }
 }
 


### PR DESCRIPTION
## Custom Keyboard Mappings
 
* Allows us to customize````CameraControl```` key bindings
* Deprecates ````CameraControl#keyboardLayout````

## Example

TODO

## Usage 

In this example, we'll just set the default bindings for a QWERTY keyboard.

````javascript
const input = myViewer.scene.input;

cameraControl.navMode = "orbit";
cameraControl.followPointer = true;

const keyMap = {};

keyMap[cameraControl.PAN_LEFT] = [input.KEY_A];
keyMap[cameraControl.PAN_RIGHT] = [input.KEY_D];
keyMap[cameraControl.PAN_UP] = [input.KEY_Z];
keyMap[cameraControl.PAN_DOWN] = [input.KEY_X];
keyMap[cameraControl.DOLLY_FORWARDS] = [input.KEY_W, input.KEY_ADD];
keyMap[cameraControl.DOLLY_BACKWARDS] = [input.KEY_S, input.KEY_SUBTRACT];
keyMap[cameraControl.ROTATE_X_POS] = [input.KEY_DOWN_ARROW];
keyMap[cameraControl.ROTATE_X_NEG] = [input.KEY_UP_ARROW];
keyMap[cameraControl.ROTATE_Y_POS] = [input.KEY_LEFT_ARROW];
keyMap[cameraControl.ROTATE_Y_NEG] = [input.KEY_RIGHT_ARROW];
keyMap[cameraControl.AXIS_VIEW_RIGHT] = [input.KEY_NUM_1];
keyMap[cameraControl.AXIS_VIEW_BACK] = [input.KEY_NUM_2];
keyMap[cameraControl.AXIS_VIEW_LEFT] = [input.KEY_NUM_3];
keyMap[cameraControl.AXIS_VIEW_FRONT] = [input.KEY_NUM_4];
keyMap[cameraControl.AXIS_VIEW_TOP] = [input.KEY_NUM_5];
keyMap[cameraControl.AXIS_VIEW_BOTTOM] = [input.KEY_NUM_6];

cameraControl.keyMap = keyMap;
````

We can also just configure default bindings for a specified keyboard layout, like this:

````javascript
cameraControl.keyMap = "qwerty";
````

Then, ````CameraControl```` will internally set ````CameraControl#keyMap```` to the default key map for the QWERTY
layout (which is the same set of mappings we set in the previous example). In other words, if we subsequently
read ````CameraControl#keyMap````, it will now be a key map, instead of the "qwerty" string value we set it to.

Supported layouts are, so far:

 * ````"qwerty"````
 * ````"azerty"````