### PR TITLE
Improve CameraControl touch dolly/pan

### DIFF
--- a/src/viewer/scene/CameraControl/lib/CameraUpdater.js
+++ b/src/viewer/scene/CameraControl/lib/CameraUpdater.js
@@ -73,14 +73,7 @@ class CameraUpdater {
                 countDown = SCALE_DOLLY_EACH_FRAME;
 
                 if (updates.dollyDelta !== 0) {
-
                     if (updates.rotateDeltaY === 0 && updates.rotateDeltaX === 0) {
-
-                        pickController.pickCursorPos = states.pointerCanvasPos;
-                        pickController.schedulePickSurface = true;
-
-                        pickController.update();
-
                         if (pickController.pickResult && pickController.pickResult.worldPos) {
                             const worldPos = pickController.pickResult.worldPos;
                             pivotController.setPivotPos(worldPos);

--- a/src/viewer/scene/CameraControl/lib/handlers/KeyboardPanRotateDollyHandler.js
+++ b/src/viewer/scene/CameraControl/lib/handlers/KeyboardPanRotateDollyHandler.js
@@ -12,6 +12,8 @@ class KeyboardPanRotateDollyHandler {
 
         const canvas = scene.canvas.canvas;
 
+        const pickController = controllers.pickController;
+
         document.addEventListener("keydown", this._documentKeyDownHandler = (e) => {
             if (!(configs.active && configs.pointerEnabled) || (!scene.input.keyboardEnabled)) {
                 return;
@@ -116,6 +118,9 @@ class KeyboardPanRotateDollyHandler {
                     } else if (dollyBackwards) {
                         updates.dollyDelta += dollyDelta;
                     }
+                    pickController.pickCursorPos = states.pointerCanvasPos;
+                    pickController.schedulePickSurface = true;
+                    pickController.update();
                 }
             }
 

--- a/src/viewer/scene/CameraControl/lib/handlers/MousePanRotateDollyHandler.js
+++ b/src/viewer/scene/CameraControl/lib/handlers/MousePanRotateDollyHandler.js
@@ -339,6 +339,10 @@ class MousePanRotateDollyHandler {
             }
             const normalizedDelta = delta / Math.abs(delta);
             updates.dollyDelta += -normalizedDelta * secsElapsed * configs.mouseWheelDollyRate;
+            pickController.pickCursorPos = states.pointerCanvasPos;
+            pickController.schedulePickSurface = true;
+            pickController.update();
+
             e.preventDefault();
         });
     }

--- a/src/viewer/scene/math/math.js
+++ b/src/viewer/scene/math/math.js
@@ -371,6 +371,24 @@ const math = {
     },
 
     /**
+     * Get the geometric mean of the vectors.
+     * @method geometricMeanVec2
+     * @static
+     * @param {...Array(Number)} vectors Vec2 to mean
+     * @return {Array(Number)} The geometric mean vec2
+     */
+    geometricMeanVec2(...vectors) {
+        const geometricMean = new Float32Array(vectors[0]);
+        for (let i = 1; i < vectors.length; i++) {
+            geometricMean[0] += vectors[i][0];
+            geometricMean[1] += vectors[i][1];
+        }
+        geometricMean[0] /= vectors.length;
+        geometricMean[1] /= vectors.length;
+        return geometricMean;
+    },
+
+    /**
      * Subtracts a scalar value from each element of a four-element vector.
      * @method subVec4Scalar
      * @static


### PR DESCRIPTION
But when doing a zoom, a pick is done at each tick, and the pick costs ~60% of the time (cf. flame graph).
![Capture d’écran de 2020-08-14 16-54-15](https://user-images.githubusercontent.com/1349751/90263018-5e0e4e80-de4f-11ea-8856-49466ba36e80.png)

Checking the distance only once when the two fingers are touching the screen and keeping it until a finger leaves the screen seems a good UX and is more performant.

cameraUpdater doesn't pick anything itself anymore, each handler must explicitly pick before a dolly.

Touch events were triggered for every pixel, implying 150 updates of 1 pixel instead of 1 update of 150px. This led to very slow dolly.

I retored my `viewer.cameraControl.touchDollyRate = 0.2;` to avoid too fast dolly.


Pan and dolly can also be done simultaneously: it's way more smooth and a better UX overall.