### PR TITLE
simplify BCF plugin

### DIFF
--- a/src/plugins/BCFViewpointsPlugin/BCFViewpointsPlugin.js
+++ b/src/plugins/BCFViewpointsPlugin/BCFViewpointsPlugin.js
@@ -427,12 +427,15 @@ class BCFViewpointsPlugin extends Plugin {
 
                 const objectId = entity.id;
                 const originalSystemId = entity.originalSystemId;
-
-                coloringMap[color].push({
+                const component = {
                     ifc_guid: originalSystemId,
-                    authoring_tool_id: objectId,
                     originating_system: this.originatingSystem
-                });
+                };
+                if (originalSystemId !== objectId) {
+                    component.authoring_tool_id = objectId;
+                }
+
+                coloringMap[color].push(component);
 
                 return coloringMap;
 
@@ -477,11 +480,14 @@ class BCFViewpointsPlugin extends Plugin {
             const objectId = objectIds[i];
             const entity = scene.objects[objectId];
             if (entity) {
-                components.push({
+                const component = {
                     ifc_guid: entity.originalSystemId,
-                    authoring_tool_id: objectId,
                     originating_system: this.originatingSystem
-                });
+                };
+                if (entity.originalSystemId !== objectId) {
+                    component.authoring_tool_id = objectId;
+                }
+                components.push(component);
             }
         }
         return components;


### PR DESCRIPTION
If `objectId !== originalSystemId`, no ifc_guid was defined, so no other BCF tools could use the viewpoint.

Now, `ifc_guid` is always defined and `authoring_tool_id` is defined if it provides more information.