### PR TITLE
Remove default cursor style.

### DIFF
--- a/docs/file/src/viewer/scene/CameraControl/lib/handlers/KeyboardPanRotateDollyHandler.js.html
+++ b/docs/file/src/viewer/scene/CameraControl/lib/handlers/KeyboardPanRotateDollyHandler.js.html
@@ -188,7 +188,7 @@ class KeyboardPanRotateDollyHandler {
             keyDownMap[keyCode] = false;
 
             if (keyCode === input.KEY_SHIFT) {
-                canvas.style.cursor = &quot;default&quot;;
+                canvas.style.cursor = null;
             }
         });
 

--- a/docs/file/src/viewer/scene/CameraControl/lib/handlers/MouseMiscHandler.js.html
+++ b/docs/file/src/viewer/scene/CameraControl/lib/handlers/MouseMiscHandler.js.html
@@ -157,7 +157,7 @@ class MouseMiscHandler {
 
         canvas.addEventListener(&quot;mouseleave&quot;, this._mouseLeaveHandler = () =&gt; {
             states.mouseover = false;
-            canvas.style.cursor = &quot;default&quot;;
+            canvas.style.cursor = null;
         });
 
         canvas.addEventListener(&quot;mousemove&quot;, this._mouseMoveHandler = (e) =&gt; {

--- a/src/viewer/scene/CameraControl/lib/handlers/KeyboardPanRotateDollyHandler.js
+++ b/src/viewer/scene/CameraControl/lib/handlers/KeyboardPanRotateDollyHandler.js
@@ -46,7 +46,7 @@ class KeyboardPanRotateDollyHandler {
             keyDownMap[keyCode] = false;
 
             if (keyCode === input.KEY_SHIFT) {
-                canvas.style.cursor = "default";
+                canvas.style.cursor = null;
             }
         });
 

--- a/src/viewer/scene/CameraControl/lib/handlers/MouseMiscHandler.js
+++ b/src/viewer/scene/CameraControl/lib/handlers/MouseMiscHandler.js
@@ -15,7 +15,7 @@ class MouseMiscHandler {
 
         canvas.addEventListener("mouseleave", this._mouseLeaveHandler = () => {
             states.mouseover = false;
-            canvas.style.cursor = "default";
+            canvas.style.cursor = null;
         });
 
         canvas.addEventListener("mousemove", this._mouseMoveHandler = (e) => {


### PR DESCRIPTION
If "default" is added to the cursor style, the cursor style from parent DOM Elements won't be able to change the canvas cursor style.

If null (or "") is added instead, it removes the cursor style entry from the style attribute of the canvas element, letting cursor style cascading from parent elements.