### PR TITLE
Pan/Rotate: mousemove event listen on document instead of canvas

### DIFF
--- a/src/viewer/scene/CameraControl/lib/handlers/MouseMiscHandler.js
+++ b/src/viewer/scene/CameraControl/lib/handlers/MouseMiscHandler.js
@@ -18,7 +18,7 @@ class MouseMiscHandler {
             canvas.style.cursor = null;
         });
 
-        canvas.addEventListener("mousemove", this._mouseMoveHandler = (e) => {
+        document.addEventListener("mousemove", this._mouseMoveHandler = (e) => {
             getCanvasPosFromEvent(e, states.pointerCanvasPos);
         });
 
@@ -44,7 +44,7 @@ class MouseMiscHandler {
 
         const canvas = this._scene.canvas.canvas;
 
-        canvas.removeEventListener("mousemove", this._mouseMoveHandler);
+        document.removeEventListener("mousemove", this._mouseMoveHandler);
         canvas.removeEventListener("mouseenter", this._mouseEnterHandler);
         canvas.removeEventListener("mouseleave", this._mouseLeaveHandler);
         canvas.removeEventListener("mousedown", this._mouseDownHandler);
@@ -58,7 +58,7 @@ function getCanvasPosFromEvent(event, canvasPos) {
         canvasPos[0] = event.x;
         canvasPos[1] = event.y;
     } else {
-        let element = event.target;
+        let element = event.currentTarget;
         let totalOffsetLeft = 0;
         let totalOffsetTop = 0;
         while (element.offsetParent) {

--- a/src/viewer/scene/CameraControl/lib/handlers/MousePanRotateDollyHandler.js
+++ b/src/viewer/scene/CameraControl/lib/handlers/MousePanRotateDollyHandler.js
@@ -79,6 +79,37 @@ class MousePanRotateDollyHandler {
             keyDown[keyCode] = false;
         });
 
+        function setMousedownState(pick = true) {
+            canvas.style.cursor = "move";
+            setMousedownPositions();
+            if (pick) {
+                setMousedownPick();
+            }
+        }
+
+        function setMousedownPositions() {
+            xRotateDelta = 0;
+            yRotateDelta = 0;
+
+            lastX = states.pointerCanvasPos[0];
+            lastY = states.pointerCanvasPos[1];
+            lastXDown = states.pointerCanvasPos[0];
+            lastYDown = states.pointerCanvasPos[1];
+        }
+
+        function setMousedownPick() {
+            pickController.pickCursorPos = states.pointerCanvasPos;
+            pickController.schedulePickSurface = true;
+            pickController.update();
+
+            if (pickController.picked && pickController.pickedSurface && pickController.pickResult && pickController.pickResult.worldPos) {
+                mouseDownPicked = true;
+                pickedWorldPos.set(pickController.pickResult.worldPos);
+            } else {
+                mouseDownPicked = false;
+            }
+        }
+
         canvas.addEventListener("mousedown", this._mouseDownHandler = (e) => {
 
             if (!(configs.active && configs.pointerEnabled)) {
@@ -93,39 +124,14 @@ class MousePanRotateDollyHandler {
 
                     if (keyDown[scene.input.KEY_SHIFT] || configs.planView) {
 
-                        canvas.style.cursor = "move";
-
-                        xRotateDelta = 0;
-                        yRotateDelta = 0;
-
-                        lastX = states.pointerCanvasPos[0];
-                        lastY = states.pointerCanvasPos[1];
-                        lastXDown = states.pointerCanvasPos[0];
-                        lastYDown = states.pointerCanvasPos[1];
-
-                        pickController.pickCursorPos = states.pointerCanvasPos;
-                        pickController.schedulePickSurface = true;
-                        pickController.update();
-
-                        if (pickController.picked && pickController.pickedSurface && pickController.pickResult && pickController.pickResult.worldPos) {
-                            mouseDownPicked = true;
-                            pickedWorldPos.set(pickController.pickResult.worldPos);
-                        } else {
-                            mouseDownPicked = false;
-                        }
+                        setMousedownState();
 
                     } else {
 
                         mouseDownLeft = true;
-                        canvas.style.cursor = "move";
 
-                        xRotateDelta = 0;
-                        yRotateDelta = 0;
+                        setMousedownState(false);
 
-                        lastX = states.pointerCanvasPos[0];
-                        lastY = states.pointerCanvasPos[1];
-                        lastXDown = states.pointerCanvasPos[0];
-                        lastYDown = states.pointerCanvasPos[1];
                     }
 
                     break;
@@ -136,26 +142,8 @@ class MousePanRotateDollyHandler {
 
                    if (!configs.panRightClick) {
 
-                        canvas.style.cursor = "move";
+                        setMousedownState();
 
-                        xRotateDelta = 0;
-                        yRotateDelta = 0;
-
-                        lastX = states.pointerCanvasPos[0];
-                        lastY = states.pointerCanvasPos[1];
-                        lastXDown = states.pointerCanvasPos[0];
-                        lastYDown = states.pointerCanvasPos[1];
-
-                        pickController.pickCursorPos = states.pointerCanvasPos;
-                        pickController.schedulePickSurface = true;
-                        pickController.update();
-
-                        if (pickController.picked && pickController.pickedSurface && pickController.pickResult && pickController.pickResult.worldPos) {
-                            mouseDownPicked = true;
-                            pickedWorldPos.set(pickController.pickResult.worldPos);
-                        } else {
-                            mouseDownPicked = false;
-                        }
                     }
 
                     break;
@@ -166,26 +154,8 @@ class MousePanRotateDollyHandler {
 
                     if (configs.panRightClick) {
 
-                        canvas.style.cursor = "move";
+                        setMousedownState();
 
-                        xRotateDelta = 0;
-                        yRotateDelta = 0;
-
-                        lastX = states.pointerCanvasPos[0];
-                        lastY = states.pointerCanvasPos[1];
-                        lastXDown = states.pointerCanvasPos[0];
-                        lastYDown = states.pointerCanvasPos[1];
-
-                        pickController.pickCursorPos = states.pointerCanvasPos;
-                        pickController.schedulePickSurface = true;
-                        pickController.update();
-
-                        if (pickController.picked && pickController.pickedSurface && pickController.pickResult && pickController.pickResult.worldPos) {
-                            mouseDownPicked = true;
-                            pickedWorldPos.set(pickController.pickResult.worldPos);
-                        } else {
-                            mouseDownPicked = false;
-                        }
                     }
 
                     break;


### PR DESCRIPTION
The mousemove event is listened on the document after the mousedown event is triggered on the canvas. This allow to rotate/pan event if the mouse goes out from the canvas.

Before:
![before-mousemove-update](https://user-images.githubusercontent.com/22523482/104210209-e448b400-5432-11eb-94ab-350ee5fae71d.gif)

After:
![after-mousemove-update](https://user-images.githubusercontent.com/22523482/104210230-e9a5fe80-5432-11eb-9ef8-54aeb4a155f0.gif)
