### PR TITLE
Take window scroll into account when placing follow pointer

### DIFF
--- a/src/viewer/scene/CameraControl/lib/controllers/PivotController.js
+++ b/src/viewer/scene/CameraControl/lib/controllers/PivotController.js
@@ -70,8 +70,8 @@ class PivotController {
             const canvasBoundingRect = canvasElem.getBoundingClientRect();
 
             if (this._pivotElement) {
-                this._pivotElement.style.left = (Math.floor(canvasBoundingRect.left + this._pivotCanvasPos[0]) - (this._pivotElement.clientWidth / 2)) + "px";
-                this._pivotElement.style.top = (Math.floor(canvasBoundingRect.top + this._pivotCanvasPos[1]) - (this._pivotElement.clientHeight / 2)) + "px";
+                this._pivotElement.style.left = (Math.floor(canvasBoundingRect.left + this._pivotCanvasPos[0]) - (this._pivotElement.clientWidth / 2) + window.scrollX) + "px";
+                this._pivotElement.style.top = (Math.floor(canvasBoundingRect.top + this._pivotCanvasPos[1]) - (this._pivotElement.clientHeight / 2) + window.scrollY) + "px";
             }
             this._cameraDirty = false;
         }


### PR DESCRIPTION
Use the window scrollX and scrollY positions to adjust the followPointer position to account for a canvas that is not displayed at the top of a page. This fixes #564 

Before:
https://user-images.githubusercontent.com/51397927/109496606-2be1d880-7a91-11eb-951b-991ca0905e97.mp4

After:
https://user-images.githubusercontent.com/51397927/109496623-32705000-7a91-11eb-8d0e-984188dd13d3.mp4

