### PR TITLE
fix gltf primitives parser

### DIFF
--- a/src/plugins/GLTFLoaderPlugin/GLTFPerformanceModelLoader.js
+++ b/src/plugins/GLTFLoaderPlugin/GLTFPerformanceModelLoader.js
@@ -374,11 +374,14 @@ const parseGLTF = (function () {
                     const meshIds = [];
 
                     for (let i = 0; i < numPrimitives; i++) {
+                        const primitiveInfo = meshInfo.primitives[i];
+                        if (primitiveInfo.mode < 4 ) {
+                            continue;
+                        }
                         const meshCfg = {
                             id: performanceModel.id + "." + ctx.numObjects++,
                             matrix: worldMatrix
                         };
-                        const primitiveInfo = meshInfo.primitives[i];
 
                         const materialIndex = primitiveInfo.material;
                         let materialInfo;

--- a/src/plugins/GLTFLoaderPlugin/GLTFSceneGraphLoader.js
+++ b/src/plugins/GLTFLoaderPlugin/GLTFSceneGraphLoader.js
@@ -593,14 +593,16 @@ var parseGLTF = (function () {
             var geometry;
 
             for (var i = 0, len = primitivesInfo.length; i < len; i++) {
-
+                primitiveInfo = primitivesInfo[i];
+                if (primitiveInfo.mode < 4 ) {
+                    continue;
+                }
                 geometryCfg = {
                     primitive: "triangles",
                     compressGeometry: true,
                     edgeThreshold: ctx.edgeThreshold
                 };
 
-                primitiveInfo = primitivesInfo[i];
                 indicesIndex = primitiveInfo.indices;
 
                 if (indicesIndex !== null && indicesIndex !== undefined) {


### PR DESCRIPTION
The xkt v6 has the same problem, but I can't submit a PR as the code has been deleted.
We need to maintain backward-compatibility with xkt v6. Do you see a solution or do we must use a fork and don't share the fix with the xeokit community? 