### PR TITLE
Clean spinner destroy

### DIFF
--- a/src/viewer/scene/canvas/Spinner.js
+++ b/src/viewer/scene/canvas/Spinner.js
@@ -313,6 +313,10 @@ class Spinner extends Component {
             this._element.parentNode.removeChild(this._element);
             this._element = null;
         }
+        const styleElement = document.getElementById("xeokit-spinner-css");
+        if (styleElement) {
+            styleElement.parentNode.removeChild(styleElement)
+        }
     }
 }
 


### PR DESCRIPTION
The style element was not removed from the body when xeokit is destroyed.