### PR TITLE
Fix safari user agent detector in SAO

### DIFF
--- a/src/viewer/scene/postfx/SAO.js
+++ b/src/viewer/scene/postfx/SAO.js
@@ -176,9 +176,8 @@ class SAO extends Component {
 
         super(owner, cfg);
 
-        const ua = navigator.userAgent.match(/(opera|chrome|safari|firefox|msie)\/?\s*(\.?\d+(\.\d+)*)/i);
-        const browser = (navigator.userAgent.match(/Edge/i) || navigator.userAgent.match(/Trident.*rv[ :]*11\./i)) ? "msie" : ua[1].toLowerCase();
-        const isSafari = (browser === "safari");
+        const ua = navigator.userAgent.match(/(opera|chrome|safari|firefox|msie|mobile)\/?\s*(\.?\d+(\.\d+)*)/i);
+        const isSafari = (ua && ua[1].toLowerCase() === "safari");
 
         this._supported = (!isSafari) &&
             WEBGL_INFO.SUPPORTED_EXTENSIONS["OES_standard_derivatives"]; // For computing normals in SAO fragment shader


### PR DESCRIPTION
If user agent did not match with the regex pattern, xeokit would crash.
The fix makes the check more lenient.