### PR TITLE
Keyboard handlers should listen to scene inputs instead of document events

### DIFF
--- a/src/viewer/scene/CameraControl/lib/handlers/KeyboardAxisViewHandler.js
+++ b/src/viewer/scene/CameraControl/lib/handlers/KeyboardAxisViewHandler.js
@@ -17,13 +17,13 @@ const tempCameraTarget = {
  */
 class KeyboardAxisViewHandler {
 
-    constructor(scene, controllers, configs, states, updates) {
+    constructor(scene, controllers, configs, states) {
 
         this._scene = scene;
         const cameraControl = controllers.cameraControl;
         const camera = scene.camera;
 
-        scene.input.on("keydown", this._documentKeyDownHandler = (e) => {
+        this._onSceneKeyDown = scene.input.on("keydown", () => {
 
             if (!(configs.active && configs.pointerEnabled) || (!scene.input.keyboardEnabled)) {
                 return;
@@ -115,7 +115,7 @@ class KeyboardAxisViewHandler {
     }
 
     destroy() {
-        document.removeEventListener("keydown", this._documentKeyDownHandler);
+        this._scene.input.off(this._onSceneKeyDown);
     }
 }
 

--- a/src/viewer/scene/CameraControl/lib/handlers/KeyboardPanRotateDollyHandler.js
+++ b/src/viewer/scene/CameraControl/lib/handlers/KeyboardPanRotateDollyHandler.js
@@ -12,22 +12,19 @@ class KeyboardPanRotateDollyHandler {
 
         const canvas = scene.canvas.canvas;
 
-        const pickController = controllers.pickController;
-
         let mouseMovedSinceLastKeyboardDolly = true;
 
-        document.addEventListener("mousemove", this._documentMouseMoveHandler = () => {
+        this._onSceneMouseMove = input.on("mousemove", () => {
             mouseMovedSinceLastKeyboardDolly = true;
         });
 
-        document.addEventListener("keydown", this._documentKeyDownHandler = (e) => {
+        this._onSceneKeyDown = input.on("keydown", (keyCode) => {
             if (!(configs.active && configs.pointerEnabled) || (!scene.input.keyboardEnabled)) {
                 return;
             }
             if (!states.mouseover) {
                 return;
             }
-            const keyCode = e.keyCode;
             keyDownMap[keyCode] = true;
 
             if (keyCode === input.KEY_SHIFT) {
@@ -35,14 +32,13 @@ class KeyboardPanRotateDollyHandler {
             }
         });
 
-        document.addEventListener("keyup", this._documentKeyUpHandler = (e) => {
+        this._onSceneKeyUp = input.on("keyup", (keyCode) => {
             if (!(configs.active && configs.pointerEnabled) || (!scene.input.keyboardEnabled)) {
                 return;
             }
             if (!states.mouseover) {
                 return;
             }
-            const keyCode = e.keyCode;
             keyDownMap[keyCode] = false;
 
             if (keyCode === input.KEY_SHIFT) {
@@ -177,9 +173,9 @@ class KeyboardPanRotateDollyHandler {
 
         this._scene.off(this._onTick);
 
-        document.removeEventListener("mousemove", this._documentMouseMoveHandler);
-        document.removeEventListener("keydown", this._documentKeyDownHandler);
-        document.removeEventListener("keyup", this._documentKeyUpHandler);
+        this._scene.input.off(this._onSceneMouseMove);
+        this._scene.input.off(this._onSceneKeyDown);
+        this._scene.input.off(this._onSceneKeyUp);
     }
 }
 


### PR DESCRIPTION
Example of some issue fixed by this change:

if the user focus is on an INPUT or TEXTAREA element, it must be impossible to pan the model even if the mouse is hovering it. In input.js, this logic is correctly handled and the event is not fired. However, as this handler listens on the document events and not scene input, the model moves.