### PR TITLE
Image Plane destroy #668

### DIFF
--- a/src/viewer/scene/ImagePlane/ImagePlane.js
+++ b/src/viewer/scene/ImagePlane/ImagePlane.js
@@ -550,7 +550,6 @@ class ImagePlane extends Component {
      * @destroy
      */
     destroy() {
-        this._state.destroy();
         super.destroy();
     }
 


### PR DESCRIPTION
Aims to fix issue #668.
An imagePlane doesn't have a renderState (I assume it was left out on purpose?), nonetheless in the destroy method `this_state.destroy()` was called, which lead to an error.

If the correct solution would be to add a renderState to the imagePlane, please disregard this PR. Unfortunately I'm not that familiar with the RenderState class/functionality.