### PR TITLE
fix: set skybox unclippable.

### DIFF
--- a/src/viewer/scene/skybox/Skybox.js
+++ b/src/viewer/scene/skybox/Skybox.js
@@ -65,6 +65,7 @@ class Skybox extends Component {
             // stationary: true,
             visible: false,
             pickable: false,
+            clippable: false,
             collidable: false
         });
 


### PR DESCRIPTION
set skybox unclippable to prevent sectionbox from clipping skybox.