### PR TITLE
prevent console warnings on scroll.

### DIFF
--- a/src/viewer/scene/CameraControl/lib/handlers/MousePanRotateDollyHandler.js
+++ b/src/viewer/scene/CameraControl/lib/handlers/MousePanRotateDollyHandler.js
@@ -315,7 +315,6 @@ class MousePanRotateDollyHandler {
                 mouseMovedOnCanvasSinceLastWheel = false;
             }
 
-            e.preventDefault();
         }, {passive: true});
     }
 


### PR DESCRIPTION
If a passive listener does call preventDefault(),
the user agent will do nothing other than generate a console warning.

see:
https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener