### PR TITLE
Handle container offsets in distance & angle measurement

### DIFF
--- a/src/plugins/AngleMeasurementsPlugin/AngleMeasurement.js
+++ b/src/plugins/AngleMeasurementsPlugin/AngleMeasurement.js
@@ -197,8 +197,9 @@ class AngleMeasurement extends Component {
 
             var canvas = scene.canvas.canvas;
             var offsets = canvas.getBoundingClientRect();
-            var top = offsets.top;
-            var left = offsets.left;
+            const containerOffsets = this._container.getBoundingClientRect();
+            var top = offsets.top - containerOffsets.top;
+            var left = offsets.left - containerOffsets.left;
             var aabb = scene.canvas.boundary;
             var canvasWidth = aabb[2];
             var canvasHeight = aabb[3];

--- a/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
+++ b/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
@@ -260,8 +260,9 @@ class DistanceMeasurement extends Component {
 
             var canvas = scene.canvas.canvas;
             var offsets = canvas.getBoundingClientRect();
-            var top = offsets.top;
-            var left = offsets.left;
+            const containerOffsets = this._container.getBoundingClientRect();
+            var top = offsets.top - containerOffsets.top;
+            var left = offsets.left - containerOffsets.left;
             var aabb = scene.canvas.boundary;
             var canvasWidth = aabb[2];
             var canvasHeight = aabb[3];


### PR DESCRIPTION
If a container is given to the corresponding plugins, (other than document.body by default), and if the container is not at the top left of the body, the positions may be incorrect.

![46801046d276a44f56f547c4ed3b0257](https://user-images.githubusercontent.com/22523482/148207175-1c1680de-f56e-4267-bae2-18c393f36a85.gif)
