### PR TITLE
Fix JS imports

### DIFF
--- a/src/viewer/scene/PerformanceModel/PerformanceModel.js
+++ b/src/viewer/scene/PerformanceModel/PerformanceModel.js
@@ -17,7 +17,7 @@ import {PointsInstancingLayer} from './lib/layers/pointsInstancing/PointsInstanc
 import {ENTITY_FLAGS} from './lib/ENTITY_FLAGS.js';
 import {utils} from "../utils.js";
 import {RenderFlags} from "../webgl/RenderFlags.js";
-import {worldToRTCPositions} from "../math/rtcCoords";
+import {worldToRTCPositions} from "../math/rtcCoords.js";
 
 const instancedArraysSupported = WEBGL_INFO.SUPPORTED_EXTENSIONS["ANGLE_instanced_arrays"];
 

--- a/src/viewer/scene/webgl/RenderBufferManager.js
+++ b/src/viewer/scene/webgl/RenderBufferManager.js
@@ -1,4 +1,4 @@
-import {RenderBuffer} from "./RenderBuffer";
+import {RenderBuffer} from "./RenderBuffer.js";
 
 /**
  * @private

--- a/src/viewer/scene/webgl/Renderer.js
+++ b/src/viewer/scene/webgl/Renderer.js
@@ -8,7 +8,7 @@ import {OcclusionTester} from "./occlusion/OcclusionTester.js";
 import {SAOOcclusionRenderer} from "./sao/SAOOcclusionRenderer.js";
 import {createRTCViewMat} from "../math/rtcCoords.js";
 import {SAODepthLimitedBlurRenderer} from "./sao/SAODepthLimitedBlurRenderer.js";
-import {RenderBufferManager} from "./RenderBufferManager";
+import {RenderBufferManager} from "./RenderBufferManager.js";
 
 /**
  * @private


### PR DESCRIPTION
This PR adds the proper `.js` extension to 3 `import` statements.

W/out this change, `xeokit-sdk` cannot be served during its development for example from a `nodejs-express` setup.