### PR TITLE
[DataTexturePerformanceModel]: 80% GPU RAM savings!

### DIFF
--- a/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
+++ b/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
@@ -742,6 +742,7 @@ class XKTLoaderPlugin extends Plugin {
                 isModel: true,
                 origin: params.origin,
                 targetLodFps: params.useDataTextures.targetLodFps || false,
+                enableViewFrustumCulling: params.useDataTextures.enableViewFrustumCulling || false,
             }));
         } else {
             sceneModel = new VBOSceneModel(this.viewer.scene, utils.apply(params, {

--- a/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
+++ b/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
@@ -1,6 +1,6 @@
 import {utils} from "../../viewer/scene/utils.js"
 import {VBOSceneModel} from "../../viewer/scene/models/VBOSceneModel/VBOSceneModel.js";
-import {DataTexturePeformanceModel} from "../../viewer/scene/PerformanceModel/DataTexturePeformanceModel.js";
+import {DataTexturePeformanceModel} from "../../viewer/scene/models/VBOSceneModel/DataTexturePeformanceModel.js";
 import {Plugin} from "../../viewer/Plugin.js";
 import {XKTDefaultDataSource} from "./XKTDefaultDataSource.js";
 import {IFCObjectDefaults} from "../../viewer/metadata/IFCObjectDefaults.js";

--- a/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
+++ b/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
@@ -1,5 +1,6 @@
 import {utils} from "../../viewer/scene/utils.js"
 import {VBOSceneModel} from "../../viewer/scene/models/VBOSceneModel/VBOSceneModel.js";
+import {DataTexturePeformanceModel} from "../../viewer/scene/PerformanceModel/DataTexturePeformanceModel.js";
 import {Plugin} from "../../viewer/Plugin.js";
 import {XKTDefaultDataSource} from "./XKTDefaultDataSource.js";
 import {IFCObjectDefaults} from "../../viewer/metadata/IFCObjectDefaults.js";
@@ -724,6 +725,7 @@ class XKTLoaderPlugin extends Plugin {
      * all geometry instances into batches (````false````), and not use instancing to render them. Setting this ````false```` can significantly
      * improve Viewer performance for models that have excessive geometry reuse, but may also increases the amount of
      * browser and GPU memory used by the model. See [#769](https://github.com/xeokit/xeokit-sdk/issues/769) for more info.
+     * @param {Boolean} [params.useDataTextures=false] When we set this ````true````, an alternative memory representation of object geometry will be used that relies on data textures. At the expense of some rendering performance overhead, this will reduce the used RAM to around 25% respect to setting the option to ````false````.
      * @returns {Entity} Entity representing the model, which will have {@link Entity#isModel} set ````true```` and will be registered by {@link Entity#id} in {@link Scene#models}.
      */
     load(params = {}) {
@@ -733,12 +735,21 @@ class XKTLoaderPlugin extends Plugin {
             delete params.id;
         }
 
-        const sceneModel = new VBOSceneModel(this.viewer.scene, utils.apply(params, {
-            isModel: true,
-            textureTranscoder: this._textureTranscoder,
-            maxGeometryBatchSize: this._maxGeometryBatchSize,
-            origin: params.origin
-        }));
+        let sceneModel;
+
+        if (!!params.useDataTextures) {
+            sceneModel = new DataTexturePeformanceModel(this.viewer.scene, utils.apply(params, {
+                isModel: true,
+                origin: params.origin
+            }));
+        } else {
+            sceneModel = new VBOSceneModel(this.viewer.scene, utils.apply(params, {
+                isModel: true,
+                textureTranscoder: this._textureTranscoder,
+                maxGeometryBatchSize: this._maxGeometryBatchSize,
+                origin: params.origin
+            }));
+        }
 
         const modelId = sceneModel.id;  // In case ID was auto-generated
 

--- a/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
+++ b/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
@@ -740,7 +740,8 @@ class XKTLoaderPlugin extends Plugin {
         if (!!params.useDataTextures) {
             sceneModel = new DataTexturePeformanceModel(this.viewer.scene, utils.apply(params, {
                 isModel: true,
-                origin: params.origin
+                origin: params.origin,
+                targetLodFps: params.useDataTextures.targetLodFps || false,
             }));
         } else {
             sceneModel = new VBOSceneModel(this.viewer.scene, utils.apply(params, {

--- a/src/viewer/scene/CameraControl/lib/controllers/PivotController.js
+++ b/src/viewer/scene/CameraControl/lib/controllers/PivotController.js
@@ -66,8 +66,15 @@ class PivotController {
             this._pivotCanvasPos[0] = Math.floor((1 + this._pivotProjPos[0] / this._pivotProjPos[3]) * canvasWidth / 2);
             this._pivotCanvasPos[1] = Math.floor((1 - this._pivotProjPos[1] / this._pivotProjPos[3]) * canvasHeight / 2);
 
-            const canvasElem = canvas.canvas;
-            const canvasBoundingRect = canvasElem.getBoundingClientRect();
+            // data-textures: avoid to do continuous DOM layout calculations            
+            let canvasBoundingRect = canvas._lastBoundingClientRect;
+
+            if (!canvasBoundingRect || canvas._canvasSizeChanged)
+            {
+                const canvasElem = canvas.canvas;
+
+                canvasBoundingRect = canvas._lastBoundingClientRect = canvasElem.getBoundingClientRect ();
+            }
 
             if (this._pivotElement) {
                 this._pivotElement.style.left = (Math.floor(canvasBoundingRect.left + this._pivotCanvasPos[0]) - (this._pivotElement.clientWidth / 2) + window.scrollX) + "px";

--- a/src/viewer/scene/canvas/Canvas.js
+++ b/src/viewer/scene/canvas/Canvas.js
@@ -72,7 +72,7 @@ class Canvas extends Component {
          */
         this.transparent = !!cfg.transparent;
 
-        // chipmunk
+        // data-textures: avoid to continuos DOM layout calculations
         this.optimizeResizeDetection = true;
 
         /**

--- a/src/viewer/scene/canvas/Canvas.js
+++ b/src/viewer/scene/canvas/Canvas.js
@@ -502,6 +502,10 @@ class Canvas extends Component {
             // Setup extension (if necessary) and hints for fragment shader derivative functions
             if (this.webgl2) {
                 this.gl.hint(this.gl.FRAGMENT_SHADER_DERIVATIVE_HINT, this.gl.FASTEST);
+
+                    // data-textures: not using standard-derivatives
+                    if (!(this.gl instanceof WebGL2RenderingContext)) {
+                    }
             }
         }
     }

--- a/src/viewer/scene/math/rtcCoords.js
+++ b/src/viewer/scene/math/rtcCoords.js
@@ -12,7 +12,7 @@ const tempVec3a = math.vec3();
  */
 const createRTCViewMat = (function () {
 
-    const tempMat = new Float32Array(16);
+    const tempMat = new Float64Array(16);
     const rtcCenterWorld = new Float64Array(4);
     const rtcCenterView = new Float64Array(4);
 
@@ -24,7 +24,7 @@ const createRTCViewMat = (function () {
         rtcCenterWorld[3] = 1;
         math.transformVec4(viewMat, rtcCenterWorld, rtcCenterView);
         math.setMat4Translation(viewMat, rtcCenterView, rtcViewMat);
-        return rtcViewMat;
+        return rtcViewMat.slice ();
     }
 }());
 

--- a/src/viewer/scene/models/VBOSceneModel/DataTexturePeformanceModel.js
+++ b/src/viewer/scene/models/VBOSceneModel/DataTexturePeformanceModel.js
@@ -2289,10 +2289,11 @@ class DataTexturePeformanceModel extends Component {
      * Once finalized, you can't add anything more to this DataTexturePeformanceModel.
      */
     finalize() {
-
         if (this.destroyed) {
             return;
         }
+
+        this.beginDeferredFlagsInAllLayers ();
 
         if (this._vfcManager) {
             this._vfcManager.finalize (
@@ -2339,6 +2340,8 @@ class DataTexturePeformanceModel extends Component {
             const layer = this._layerList[i];
             layer.layerIndex = i;
         }
+
+        this.commitDeferredFlagsInAllLayers ();
 
         this.glRedraw();
 

--- a/src/viewer/scene/models/VBOSceneModel/DataTexturePeformanceModel.js
+++ b/src/viewer/scene/models/VBOSceneModel/DataTexturePeformanceModel.js
@@ -13,6 +13,8 @@ import {utils} from "../utils.js";
 import {RenderFlags} from "../webgl/RenderFlags.js";
 import {worldToRTCPositions} from "../math/rtcCoords.js";
 
+import { LodCullingManager } from "./lib/layers/trianglesDataTexture/LodCullingManager.js"
+
 const instancedArraysSupported = WEBGL_INFO.SUPPORTED_EXTENSIONS["ANGLE_instanced_arrays"];
 
 const tempVec3a = math.vec3();
@@ -941,6 +943,7 @@ class DataTexturePeformanceModel extends Component {
             throw "Using a DataTexturePerformanceModel requires the usage of webgl2";
         }
 
+        this._targetLodFps = cfg.targetLodFps;
         this._aabb = math.collapseAABB3();
         this._aabbDirty = false;
 
@@ -2301,6 +2304,14 @@ class DataTexturePeformanceModel extends Component {
 
         this._instancingGeometries = {};
         this._preparedInstancingGeometries = {};
+
+        if (this._targetLodFps) {
+            this.lodCullingManager = new LodCullingManager (
+                this,
+                [ 2000, 600, 150, 80, 20 ],
+                this._targetLodFps
+            );
+        }
     }
 
     _rebuildAABB() {
@@ -2345,8 +2356,6 @@ class DataTexturePeformanceModel extends Component {
 
     /**
      * This will start a "set-flags transaction" in all Layers of this Model.
-     * 
-     * @private
      */
     beginDeferredFlagsInAllLayers ()
     {
@@ -2361,8 +2370,6 @@ class DataTexturePeformanceModel extends Component {
     /**
      * This will commit any previously started "set-flags transaction" in all
      * Layers of this Model.
-     * 
-     * @private
      */
     commitDeferredFlagsInAllLayers ()
     {

--- a/src/viewer/scene/models/VBOSceneModel/DataTexturePeformanceModel.js
+++ b/src/viewer/scene/models/VBOSceneModel/DataTexturePeformanceModel.js
@@ -1,0 +1,2697 @@
+import {Component} from "../Component.js";
+import {math} from "../math/math.js";
+import {buildEdgeIndices} from '../math/buildEdgeIndices.js';
+import {WEBGL_INFO} from '../webglInfo.js';
+import {PerformanceMesh} from './lib/PerformanceMesh.js';
+import {PerformanceNode} from './lib/PerformanceNode.js';
+import {getScratchMemory, putScratchMemory} from "./lib/ScratchMemory.js";
+import {prepareMeshGeometry, TrianglesDataTextureLayer} from './lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js';
+import {TrianglesInstancingLayer} from './lib/layers/trianglesInstancing/TrianglesInstancingLayer.js';
+
+import {ENTITY_FLAGS} from './lib/ENTITY_FLAGS.js';
+import {utils} from "../utils.js";
+import {RenderFlags} from "../webgl/RenderFlags.js";
+import {worldToRTCPositions} from "../math/rtcCoords.js";
+
+const instancedArraysSupported = WEBGL_INFO.SUPPORTED_EXTENSIONS["ANGLE_instanced_arrays"];
+
+const tempVec3a = math.vec3();
+const tempMat4 = math.mat4();
+
+const defaultScale = math.vec3([1, 1, 1]);
+const defaultPosition = math.vec3([0, 0, 0]);
+const defaultRotation = math.vec3([0, 0, 0]);
+const defaultQuaternion = math.identityQuaternion();
+
+/**
+ * @desc A high-performance model representation for efficient rendering and low memory usage.
+ *
+ * # Examples
+ *
+ * * [DataTexturePeformanceModel using geometry batching](http://xeokit.github.io/xeokit-sdk/examples/#sceneRepresentation_PerformanceModel_batching)
+ * * [DataTexturePeformanceModel using geometry batching and RTC coordinates](http://xeokit.github.io/xeokit-sdk/examples/#sceneRepresentation_PerformanceModel_batching_origin)
+ * * [DataTexturePeformanceModel using geometry instancing](http://xeokit.github.io/xeokit-sdk/examples/#sceneRepresentation_PerformanceModel_instancing)
+ * * [DataTexturePeformanceModel using geometry instancing and RTC coordinates](http://xeokit.github.io/xeokit-sdk/examples/#sceneRepresentation_PerformanceModel_instancing_origin)
+ *
+ * # Overview
+ *
+ * While xeokit's standard [scene graph](https://github.com/xeokit/xeokit-sdk/wiki/Scene-Graphs) is great for gizmos and medium-sized models, it doesn't scale up to millions of objects in terms of memory and rendering efficiency.
+ *
+ * For huge models, we have the ````DataTexturePeformanceModel```` representation, which is optimized to pack large amounts of geometry into memory and render it efficiently using WebGL.
+ *
+ * ````DataTexturePeformanceModel```` is the default model representation loaded by  (at least) {@link GLTFLoaderPlugin}, {@link XKTLoaderPlugin} and  {@link WebIFCLoaderPlugin}.
+ *
+ * In this tutorial you'll learn how to use ````DataTexturePeformanceModel```` to create high-detail content programmatically. Ordinarily you'd be learning about ````DataTexturePeformanceModel```` if you were writing your own model loader plugins.
+ *
+ * # Contents
+ *
+ * - [DataTexturePeformanceModel](#DataTexturePeformanceModel)
+ * - [GPU-Resident Geometry](#gpu-resident-geometry)
+ * - [Picking](#picking)
+ * - [Example 1: Geometry Instancing](#example-1--geometry-instancing)
+ * - [Finalizing a DataTexturePeformanceModel](#finalizing-a-DataTexturePeformanceModel)
+ * - [Finding Entities](#finding-entities)
+ * - [Example 2: Geometry Batching](#example-2--geometry-batching)
+ * - [Classifying with Metadata](#classifying-with-metadata)
+ * - [Querying Metadata](#querying-metadata)
+ * - [Metadata Structure](#metadata-structure)
+ * - [RTC Coordinates](#rtc-coordinates-for-double-precision)
+ *   - [Example 3: RTC Coordinates with Geometry Instancing](#example-2--rtc-coordinates-with-geometry-instancing)
+ *   - [Example 4: RTC Coordinates with Geometry Batching](#example-2--rtc-coordinates-with-geometry-batching)
+ *
+ * ## DataTexturePeformanceModel
+ *
+ * ````DataTexturePeformanceModel```` uses two rendering techniques internally:
+ *
+ * 1. ***Geometry batching*** for unique geometries, combining those into a single WebGL geometry buffer, to render in one draw call, and
+ * 2. ***geometry instancing*** for geometries that are shared by multiple meshes, rendering all instances of each shared geometry in one draw call.
+ *
+ * <br>
+ * These techniques come with certain limitations:
+ *
+ * * Non-realistic rendering - while scene graphs can use xeokit's full set of material workflows, ````DataTexturePeformanceModel```` uses simple Lambertian shading without textures.
+ * * Static transforms - transforms within a ````DataTexturePeformanceModel```` are static and cannot be dynamically translated, rotated and scaled the way {@link Node}s and {@link Mesh}es in scene graphs can.
+ * * Immutable model representation - while scene graph {@link Node}s and
+ * {@link Mesh}es can be dynamically plugged together, ````DataTexturePeformanceModel```` is immutable,
+ * since it packs its geometries into buffers and instanced arrays.
+ *
+ * ````DataTexturePeformanceModel````'s API allows us to exploit batching and instancing, while exposing its elements as
+ * abstract {@link Entity} types.
+ *
+ * {@link Entity} is the abstract base class for
+ * the various xeokit components that represent models, objects, or anonymous visible elements. An Entity has a unique ID and can be
+ * individually shown, hidden, selected, highlighted, ghosted, culled, picked and clipped, and has its own World-space boundary.
+ *
+ * * A ````DataTexturePeformanceModel```` is an {@link Entity} that represents a model.
+ * * A ````DataTexturePeformanceModel```` represents each of its objects with an {@link Entity}.
+ * * Each {@link Entity} has one or more meshes that define its shape.
+ * * Each mesh has either its own unique geometry, or shares a geometry with other meshes.
+ *
+ * ## GPU-Resident Geometry
+ *
+ * For a low memory footprint, ````DataTexturePeformanceModel```` stores its geometries in GPU memory only, compressed (quantized) as integers. Unfortunately, GPU-resident geometry is
+ * not readable by JavaScript.
+ *
+ *
+ * ## Example 1: Geometry Instancing
+ *
+ * In the example below, we'll use a ````DataTexturePeformanceModel````
+ * to build a simple table model using geometry instancing.
+ *
+ * We'll start by adding a reusable box-shaped geometry to our ````DataTexturePeformanceModel````.
+ *
+ * Then, for each object in our model we'll add an {@link Entity}
+ * that has a mesh that instances our box geometry, transforming and coloring the instance.
+ *
+ * [![](http://xeokit.io/img/docs/sceneGraph.png)](https://xeokit.github.io/xeokit-sdk/examples/#sceneRepresentation_PerformanceModel_instancing)
+ *
+ * [[Run this example](https://xeokit.github.io/xeokit-sdk/examples/#sceneRepresentation_PerformanceModel_instancing)]
+ *
+ * ````javascript
+ * import {Viewer, DataTexturePeformanceModel} from "xeokit-sdk.es.js";
+ *
+ * const viewer = new Viewer({
+ *     canvasId: "myCanvas",
+ *     transparent: true
+ * });
+ *
+ * viewer.scene.camera.eye = [-21.80, 4.01, 6.56];
+ * viewer.scene.camera.look = [0, -5.75, 0];
+ * viewer.scene.camera.up = [0.37, 0.91, -0.11];
+ *
+ * // Build a DataTexturePeformanceModel representing a table
+ * // with four legs, using geometry instancing
+ *
+ * const DataTexturePeformanceModel = new DataTexturePeformanceModel(viewer.scene, {
+ *     id: "table",
+ *     isModel: true, // <--- Registers DataTexturePeformanceModel in viewer.scene.models
+ *     position: [0, 0, 0],
+ *     scale: [1, 1, 1],
+ *     rotation: [0, 0, 0]
+ * });
+ *
+ * // Create a reusable geometry within the DataTexturePeformanceModel
+ * // We'll instance this geometry by five meshes
+ *
+ * DataTexturePeformanceModel.createGeometry({
+ *
+ *     id: "myBoxGeometry",
+ *
+ *     // The primitive type - allowed values are "points", "lines" and "triangles".
+ *     // See the OpenGL/WebGL specification docs
+ *     // for how the coordinate arrays are supposed to be laid out.
+ *     primitive: "triangles",
+ *
+ *     // The vertices - eight for our cube, each
+ *     // one spanning three array elements for X,Y and Z
+ *     positions: [
+ *          1, 1, 1, -1, 1, 1, -1, -1, 1, 1, -1, 1, // v0-v1-v2-v3 front
+ *          1, 1, 1, 1, -1, 1, 1, -1, -1, 1, 1, -1, // v0-v3-v4-v1 right
+ *          1, 1, 1, 1, 1, -1, -1, 1, -1, -1, 1, 1, // v0-v1-v6-v1 top
+ *          -1, 1, 1, -1, 1, -1, -1, -1, -1, -1, -1, 1, // v1-v6-v7-v2 left
+ *          -1, -1, -1, 1, -1, -1, 1, -1, 1, -1, -1, 1, // v7-v4-v3-v2 bottom
+ *          1, -1, -1, -1, -1, -1, -1, 1, -1, 1, 1, -1 // v4-v7-v6-v1 back
+ *     ],
+ *
+ *     // Normal vectors, one for each vertex
+ *     normals: [
+ *         0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, // v0-v1-v2-v3 front
+ *         1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, // v0-v3-v4-v5 right
+ *         0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, // v0-v5-v6-v1 top
+ *         -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, // v1-v6-v7-v2 left
+ *         0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, // v7-v4-v3-v2 bottom
+ *         0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1 // v4-v7-v6-v5 back
+ *     ],
+ *
+ *     // Indices - these organise the positions and and normals
+ *     // into geometric primitives in accordance with the "primitive" parameter,
+ *     // in this case a set of three indices for each triangle.
+ *     //
+ *     // Note that each triangle is specified in counter-clockwise winding order.
+ *     //
+ *     indices: [
+ *         0, 1, 2, 0, 2, 3, // front
+ *         4, 5, 6, 4, 6, 7, // right
+ *         8, 9, 10, 8, 10, 11, // top
+ *         12, 13, 14, 12, 14, 15, // left
+ *         16, 17, 18, 16, 18, 19, // bottom
+ *         20, 21, 22, 20, 22, 23
+ *     ]
+ * });
+ *
+ * // Red table leg
+ *
+ * DataTexturePeformanceModel.createMesh({
+ *     id: "redLegMesh",
+ *     geometryId: "myBoxGeometry",
+ *     position: [-4, -6, -4],
+ *     scale: [1, 3, 1],
+ *     rotation: [0, 0, 0],
+ *     color: [1, 0.3, 0.3]
+ * });
+ *
+ * DataTexturePeformanceModel.createEntity({
+ *     id: "redLeg",
+ *     meshIds: ["redLegMesh"],
+ *     isObject: true // <---- Registers Entity by ID on viewer.scene.objects
+ * });
+ *
+ * // Green table leg
+ *
+ * DataTexturePeformanceModel.createMesh({
+ *     id: "greenLegMesh",
+ *     geometryId: "myBoxGeometry",
+ *     position: [4, -6, -4],
+ *     scale: [1, 3, 1],
+ *     rotation: [0, 0, 0],
+ *     color: [0.3, 1.0, 0.3]
+ * });
+ *
+ * DataTexturePeformanceModel.createEntity({
+ *     id: "greenLeg",
+ *     meshIds: ["greenLegMesh"],
+ *     isObject: true // <---- Registers Entity by ID on viewer.scene.objects
+ * });
+ *
+ * // Blue table leg
+ *
+ * DataTexturePeformanceModel.createMesh({
+ *     id: "blueLegMesh",
+ *     geometryId: "myBoxGeometry",
+ *     position: [4, -6, 4],
+ *     scale: [1, 3, 1],
+ *     rotation: [0, 0, 0],
+ *     color: [0.3, 0.3, 1.0]
+ * });
+ *
+ * DataTexturePeformanceModel.createEntity({
+ *     id: "blueLeg",
+ *     meshIds: ["blueLegMesh"],
+ *     isObject: true // <---- Registers Entity by ID on viewer.scene.objects
+ * });
+ *
+ * // Yellow table leg
+ *
+ * DataTexturePeformanceModel.createMesh({
+ *      id: "yellowLegMesh",
+ *      geometryId: "myBoxGeometry",
+ *      position: [-4, -6, 4],
+ *      scale: [1, 3, 1],
+ *      rotation: [0, 0, 0],
+ *      color: [1.0, 1.0, 0.0]
+ * });
+ *
+ * DataTexturePeformanceModel.createEntity({
+ *     id: "yellowLeg",
+ *     meshIds: ["yellowLegMesh"],
+ *     isObject: true // <---- Registers Entity by ID on viewer.scene.objects
+ * });
+ *
+ * // Purple table top
+ *
+ * DataTexturePeformanceModel.createMesh({
+ *     id: "purpleTableTopMesh",
+ *     geometryId: "myBoxGeometry",
+ *     position: [0, -3, 0],
+ *     scale: [6, 0.5, 6],
+ *     rotation: [0, 0, 0],
+ *     color: [1.0, 0.3, 1.0]
+ * });
+ *
+ * DataTexturePeformanceModel.createEntity({
+ *     id: "purpleTableTop",
+ *     meshIds: ["purpleTableTopMesh"],
+ *     isObject: true // <---- Registers Entity by ID on viewer.scene.objects
+ * });
+ *  ````
+ *
+ * ## Finalizing a DataTexturePeformanceModel
+ *
+ * Before we can view and interact with our ````DataTexturePeformanceModel````, we need to **finalize** it. Internally, this causes the ````DataTexturePeformanceModel```` to build the
+ * vertex buffer objects (VBOs) that support our geometry instances. When using geometry batching (see next example),
+ * this causes ````DataTexturePeformanceModel```` to build the VBOs that combine the batched geometries. Note that you can do both instancing and
+ * batching within the same ````DataTexturePeformanceModel````.
+ *
+ * Once finalized, we can't add anything more to our ````DataTexturePeformanceModel````.
+ *
+ * ```` javascript
+ * DataTexturePeformanceModel.finalize();
+ * ````
+ *
+ * ## Finding Entities
+ *
+ * As mentioned earlier, {@link Entity} is
+ * the abstract base class for components that represent models, objects, or just
+ * anonymous visible elements.
+ *
+ * Since we created configured our ````DataTexturePeformanceModel```` with ````isModel: true````,
+ * we're able to find it as an Entity by ID in ````viewer.scene.models````. Likewise, since
+ * we configured each of its Entities with ````isObject: true````, we're able to
+ * find them in  ````viewer.scene.objects````.
+ *
+ *
+ * ````javascript
+ * // Get the whole table model Entity
+ * const table = viewer.scene.models["table"];
+ *
+ *  // Get some leg object Entities
+ * const redLeg = viewer.scene.objects["redLeg"];
+ * const greenLeg = viewer.scene.objects["greenLeg"];
+ * const blueLeg = viewer.scene.objects["blueLeg"];
+ * ````
+ *
+ * ## Example 2: Geometry Batching
+ *
+ * Let's once more use a ````DataTexturePeformanceModel````
+ * to build the simple table model, this time exploiting geometry batching.
+ *
+ *  [![](http://xeokit.io/img/docs/sceneGraph.png)](https://xeokit.github.io/xeokit-sdk/examples/#sceneRepresentation_PerformanceModel_batching)
+ *
+ * * [[Run this example](https://xeokit.github.io/xeokit-sdk/examples/#sceneRepresentation_PerformanceModel_batching)]
+ *
+ * ````javascript
+ * import {Viewer, DataTexturePeformanceModel} from "xeokit-sdk.es.js";
+ *
+ * const viewer = new Viewer({
+ *     canvasId: "myCanvas",
+ *     transparent: true
+ * });
+ *
+ * viewer.scene.camera.eye = [-21.80, 4.01, 6.56];
+ * viewer.scene.camera.look = [0, -5.75, 0];
+ * viewer.scene.camera.up = [0.37, 0.91, -0.11];
+ *
+ * // Create a DataTexturePeformanceModel representing a table with four legs, using geometry batching
+ * const DataTexturePeformanceModel = new DataTexturePeformanceModel(viewer.scene, {
+ *     id: "table",
+ *     isModel: true,  // <--- Registers DataTexturePeformanceModel in viewer.scene.models
+ *     position: [0, 0, 0],
+ *     scale: [1, 1, 1],
+ *     rotation: [0, 0, 0]
+ * });
+ *
+ * // Red table leg
+ *
+ * DataTexturePeformanceModel.createMesh({
+ *     id: "redLegMesh",
+ *
+ *     // Geometry arrays are same as for the earlier batching example
+ *     primitive: "triangles",
+ *     positions: [ 1, 1, 1, -1, 1, 1, -1, -1, 1, 1, -1, 1 ... ],
+ *     normals: [ 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, ... ],
+ *     indices: [ 0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7, ... ],
+ *     position: [-4, -6, -4],
+ *     scale: [1, 3, 1],
+ *     rotation: [0, 0, 0],
+ *     color: [1, 0.3, 0.3]
+ * });
+ *
+ * DataTexturePeformanceModel.createEntity({
+ *     id: "redLeg",
+ *     meshIds: ["redLegMesh"],
+ *     isObject: true // <---- Registers Entity by ID on viewer.scene.objects
+ * });
+ *
+ * // Green table leg
+ *
+ * DataTexturePeformanceModel.createMesh({
+ *     id: "greenLegMesh",
+ *     primitive: "triangles",
+ *     primitive: "triangles",
+ *     positions: [ 1, 1, 1, -1, 1, 1, -1, -1, 1, 1, -1, 1 ... ],
+ *     normals: [ 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, ... ],
+ *     indices: [ 0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7, ... ],
+ *     position: [4, -6, -4],
+ *     scale: [1, 3, 1],
+ *     rotation: [0, 0, 0],
+ *     color: [0.3, 1.0, 0.3]
+ * });
+ *
+ * DataTexturePeformanceModel.createEntity({
+ *     id: "greenLeg",
+ *     meshIds: ["greenLegMesh"],
+ *     isObject: true // <---- Registers Entity by ID on viewer.scene.objects
+ * });
+ *
+ * // Blue table leg
+ *
+ * DataTexturePeformanceModel.createMesh({
+ *     id: "blueLegMesh",
+ *     primitive: "triangles",
+ *     positions: [ 1, 1, 1, -1, 1, 1, -1, -1, 1, 1, -1, 1 ... ],
+ *     normals: [ 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, ... ],
+ *     indices: [ 0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7, ... ],
+ *     position: [4, -6, 4],
+ *     scale: [1, 3, 1],
+ *     rotation: [0, 0, 0],
+ *     color: [0.3, 0.3, 1.0]
+ * });
+ *
+ * DataTexturePeformanceModel.createEntity({
+ *     id: "blueLeg",
+ *     meshIds: ["blueLegMesh"],
+ *     isObject: true // <---- Registers Entity by ID on viewer.scene.objects
+ * });
+ *
+ * // Yellow table leg object
+ *
+ * DataTexturePeformanceModel.createMesh({
+ *     id: "yellowLegMesh",
+ *     positions: [ 1, 1, 1, -1, 1, 1, -1, -1, 1, 1, -1, 1 ... ],
+ *     normals: [ 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, ... ],
+ *     indices: [ 0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7, ... ],
+ *     position: [-4, -6, 4],
+ *     scale: [1, 3, 1],
+ *     rotation: [0, 0, 0],
+ *     color: [1.0, 1.0, 0.0]
+ * });
+ *
+ * DataTexturePeformanceModel.createEntity({
+ *     id: "yellowLeg",
+ *     meshIds: ["yellowLegMesh"],
+ *     isObject: true // <---- Registers Entity by ID on viewer.scene.objects
+ * });
+ *
+ * // Purple table top
+ *
+ * DataTexturePeformanceModel.createMesh({
+ *     id: "purpleTableTopMesh",
+ *     positions: [ 1, 1, 1, -1, 1, 1, -1, -1, 1, 1, -1, 1 ... ],
+ *     normals: [ 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, ... ],
+ *     indices: [ 0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7, ... ],
+ *     position: [0, -3, 0],
+ *     scale: [6, 0.5, 6],
+ *     rotation: [0, 0, 0],
+ *     color: [1.0, 0.3, 1.0]
+ * });
+ *
+ * DataTexturePeformanceModel.createEntity({
+ *     id: "purpleTableTop",
+ *     meshIds: ["purpleTableTopMesh"],
+ *     isObject: true // <---- Registers Entity by ID on viewer.scene.objects
+ * });
+ *
+ * // Finalize the DataTexturePeformanceModel.
+ *
+ * DataTexturePeformanceModel.finalize();
+ *
+ * // Find BigModelNodes by their model and object IDs
+ *
+ * // Get the whole table model
+ * const table = viewer.scene.models["table"];
+ *
+ * // Get some leg objects
+ * const redLeg = viewer.scene.objects["redLeg"];
+ * const greenLeg = viewer.scene.objects["greenLeg"];
+ * const blueLeg = viewer.scene.objects["blueLeg"];
+ * ````
+ *
+ * ## Classifying with Metadata
+ *
+ * In the previous examples, we used ````DataTexturePeformanceModel```` to build
+ * two versions of the same table model, to demonstrate geometry batching and geometry instancing.
+ *
+ * We'll now classify our {@link Entity}s with metadata. This metadata
+ * will work the same for both our examples, since they create the exact same structure of {@link Entity}s
+ * to represent their models and objects. The abstract Entity type is, after all, intended to provide an abstract interface through which differently-implemented scene content can be accessed uniformly.
+ *
+ * To create the metadata, we'll create a {@link MetaModel} for our model,
+ * with a {@link MetaObject} for each of it's objects. The MetaModel and MetaObjects
+ * get the same IDs as the {@link Entity}s that represent their model and objects within our scene.
+ *
+ * ```` javascript
+ * const furnitureMetaModel = viewer.metaScene.createMetaModel("furniture", {         // Creates a MetaModel in the MetaScene
+ *
+ *      "projectId": "myTableProject",
+ *      "revisionId": "V1.0",
+ *
+ *      "metaObjects": [
+ *          {                               // Creates a MetaObject in the MetaModel
+ *              "id": "table",
+ *              "name": "Table",            // Same ID as an object Entity
+ *              "type": "furniture",        // Arbitrary type, could be IFC type
+ *              "properties": {             // Arbitrary properties, could be IfcPropertySet
+ *                  "cost": "200"
+ *              }
+ *          },
+ *          {
+ *              "id": "redLeg",
+ *              "name": "Red table Leg",
+ *              "type": "leg",
+ *              "parent": "table",           // References first MetaObject as parent
+ *              "properties": {
+ *                  "material": "wood"
+ *              }
+ *          },
+ *          {
+ *              "id": "greenLeg",           // Node with corresponding id does not need to exist
+ *              "name": "Green table leg",  // and MetaObject does not need to exist for Node with an id
+ *              "type": "leg",
+ *              "parent": "table",
+ *              "properties": {
+ *                  "material": "wood"
+ *              }
+ *          },
+ *          {
+ *              "id": "blueLeg",
+ *              "name": "Blue table leg",
+ *              "type": "leg",
+ *              "parent": "table",
+ *              "properties": {
+ *                  "material": "wood"
+ *              }
+ *          },
+ *          {
+ *              "id": "yellowLeg",
+ *              "name": "Yellow table leg",
+ *              "type": "leg",
+ *              "parent": "table",
+ *              "properties": {
+ *                  "material": "wood"
+ *              }
+ *          },
+ *          {
+ *              "id": "tableTop",
+ *              "name": "Purple table top",
+ *              "type": "surface",
+ *              "parent": "table",
+ *              "properties": {
+ *                  "material": "formica",
+ *                  "width": "60",
+ *                  "depth": "60",
+ *                  "thickness": "5"
+ *              }
+ *          }
+ *      ]
+ *  });
+ * ````
+ *
+ * ## Querying Metadata
+ *
+ * Having created and classified our model (either the instancing or batching example), we can now find the {@link MetaModel}
+ * and {@link MetaObject}s using the IDs of their
+ * corresponding {@link Entity}s.
+ *
+ * ````JavaScript
+ * const furnitureMetaModel = scene.metaScene.metaModels["furniture"];
+ *
+ * const redLegMetaObject = scene.metaScene.metaObjects["redLeg"];
+ * ````
+ *
+ * In the snippet below, we'll log metadata on each {@link Entity} we click on:
+ *
+ * ````JavaScript
+ * viewer.scene.input.on("mouseclicked", function (coords) {
+ *
+ *      const hit = viewer.scene.pick({
+ *          canvasPos: coords
+ *      });
+ *
+ *      if (hit) {
+ *          const entity = hit.entity;
+ *          const metaObject = viewer.metaScene.metaObjects[entity.id];
+ *          if (metaObject) {
+ *              console.log(JSON.stringify(metaObject.getJSON(), null, "\t"));
+ *          }
+ *      }
+ *  });
+ * ````
+ *
+ * ## Metadata Structure
+ *
+ * The {@link MetaModel}
+ * organizes its {@link MetaObject}s in
+ * a tree that describes their structural composition:
+ *
+ * ````JavaScript
+ * // Get metadata on the root object
+ * const tableMetaObject = furnitureMetaModel.rootMetaObject;
+ *
+ * // Get metadata on the leg objects
+ * const redLegMetaObject = tableMetaObject.children[0];
+ * const greenLegMetaObject = tableMetaObject.children[1];
+ * const blueLegMetaObject = tableMetaObject.children[2];
+ * const yellowLegMetaObject = tableMetaObject.children[3];
+ * ````
+ *
+ * Given an {@link Entity}, we can find the object or model of which it is a part, or the objects that comprise it. We can also generate UI
+ * components from the metadata, such as the tree view demonstrated in [this demo](https://xeokit.github.io/xeokit-sdk/examples/#BIMOffline_glTF_OTCConferenceCenter).
+ *
+ * This hierarchy allows us to express the hierarchical structure of a model while representing it in
+ * various ways in the 3D scene (such as with ````DataTexturePeformanceModel````, which
+ * has a non-hierarchical scene representation).
+ *
+ * Note also that a {@link MetaObject} does not need to have a corresponding
+ * {@link Entity} and vice-versa.
+ *
+ * # RTC Coordinates for Double Precision
+ *
+ * ````DataTexturePeformanceModel```` can emulate 64-bit precision on GPUs using relative-to-center (RTC) coordinates.
+ *
+ * Consider a model that contains many small objects, but with such large spatial extents that 32 bits of GPU precision (accurate to ~7 digits) will not be sufficient to render all of the the objects without jittering.
+ *
+ * To prevent jittering, we could spatially subdivide the objects into "tiles". Each tile would have a center position, and the positions of the objects within the tile would be relative to that center ("RTC coordinates").
+ *
+ * While the center positions of the tiles would be 64-bit values, the object positions only need to be 32-bit.
+ *
+ * Internally, when rendering an object with RTC coordinates, xeokit first temporarily translates the camera viewing matrix by the object's tile's RTC center, on the CPU, using 64-bit math.
+ *
+ * Then xeokit loads the viewing matrix into its WebGL shaders, where math happens at 32-bit precision. Within the shaders, the matrix is effectively down-cast to 32-bit precision, and the object's 32-bit vertex positions are transformed by the matrix.
+ *
+ * We see no jittering, because with RTC a detectable loss of GPU accuracy only starts happening to objects as they become very distant from the camera viewpoint, at which point they are too small to be discernible anyway.
+ *
+ * ## RTC Coordinates with Geometry Instancing
+ *
+ * To use RTC with ````DataTexturePeformanceModel```` geometry instancing, we specify an RTC center for the geometry via its ````origin```` parameter. Then ````DataTexturePeformanceModel```` assumes that all meshes that instance that geometry are within the same RTC coordinate system, ie. the meshes ````position```` and ````rotation```` properties are assumed to be relative to the geometry's ````origin````.
+ *
+ * For simplicity, our example's meshes all instance the same geometry. Therefore, our example model has only one RTC center.
+ *
+ * Note that the axis-aligned World-space boundary (AABB) of our model is ````[ -6, -9, -6, 1000000006, -2.5, 1000000006]````.
+ *
+ * [![](http://xeokit.io/img/docs/sceneGraph.png)](https://xeokit.github.io/xeokit-sdk/examples/#sceneRepresentation_PerformanceModel_batching)
+ *
+ * * [[Run this example](https://xeokit.github.io/xeokit-sdk/examples/#sceneRepresentation_PerformanceModel_instancing_origin)]
+ *
+ * ````javascript
+ * const origin = [100000000, 0, 100000000];
+ *
+ * DataTexturePeformanceModel.createGeometry({
+ *     id: "box",
+ *     origin: origin, // This geometry's positions, and the transforms of all meshes that instance the geometry, are relative to the RTC center
+ *     primitive: "triangles",
+ *     positions: [ 1, 1, 1, -1, 1, 1, -1, -1, 1, 1, -1, 1 ... ],
+ *     normals: [ 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, ... ],
+ *     indices: [ 0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7, ... ],
+ * });
+ *
+ * DataTexturePeformanceModel.createMesh({
+ *     id: "leg1",
+ *     geometryId: "box",
+ *     position: [-4, -6, -4],
+ *     scale: [1, 3, 1],
+ *     rotation: [0, 0, 0],
+ *     color: [1, 0.3, 0.3]
+ * });
+ *
+ * DataTexturePeformanceModel.createEntity({
+ *     meshIds: ["leg1"],
+ *     isObject: true
+ * });
+ *
+ * DataTexturePeformanceModel.createMesh({
+ *     id: "leg2",
+ *     geometryId: "box",
+ *     position: [4, -6, -4],
+ *     scale: [1, 3, 1],
+ *     rotation: [0, 0, 0],
+ *     color: [0.3, 1.0, 0.3]
+ * });
+ *
+ * DataTexturePeformanceModel.createEntity({
+ *     meshIds: ["leg2"],
+ *     isObject: true
+ * });
+ *
+ * DataTexturePeformanceModel.createMesh({
+ *     id: "leg3",
+ *     geometryId: "box",
+ *     position: [4, -6, 4],
+ *     scale: [1, 3, 1],
+ *     rotation: [0, 0, 0],
+ *     color: [0.3, 0.3, 1.0]
+ * });
+ *
+ * DataTexturePeformanceModel.createEntity({
+ *     meshIds: ["leg3"],
+ *     isObject: true
+ * });
+ *
+ * DataTexturePeformanceModel.createMesh({
+ *     id: "leg4",
+ *     geometryId: "box",
+ *     position: [-4, -6, 4],
+ *     scale: [1, 3, 1],
+ *     rotation: [0, 0, 0],
+ *     color: [1.0, 1.0, 0.0]
+ * });
+ *
+ * DataTexturePeformanceModel.createEntity({
+ *     meshIds: ["leg4"],
+ *     isObject: true
+ * });
+ *
+ * DataTexturePeformanceModel.createMesh({
+ *     id: "top",
+ *     geometryId: "box",
+ *     position: [0, -3, 0],
+ *     scale: [6, 0.5, 6],
+ *     rotation: [0, 0, 0],
+ *     color: [1.0, 0.3, 1.0]
+ * });
+ *
+ * DataTexturePeformanceModel.createEntity({
+ *     meshIds: ["top"],
+ *     isObject: true
+ * });
+ * ````
+ *
+ * ## RTC Coordinates with Geometry Batching
+ *
+ * To use RTC with ````DataTexturePeformanceModel```` geometry batching, we specify an RTC center (````origin````) for each mesh. For performance, we try to have as many meshes share the same value for ````origin```` as possible. Each mesh's ````positions````, ````position```` and ````rotation```` properties are assumed to be relative to ````origin````.
+ *
+ * For simplicity, the meshes in our example all share the same RTC center.
+ *
+ * The axis-aligned World-space boundary (AABB) of our model is ````[ -6, -9, -6, 1000000006, -2.5, 1000000006]````.
+ *
+ * [![](http://xeokit.io/img/docs/sceneGraph.png)](https://xeokit.github.io/xeokit-sdk/examples/#sceneRepresentation_PerformanceModel_batching)
+ *
+ * * [[Run this example](https://xeokit.github.io/xeokit-sdk/examples/#sceneRepresentation_PerformanceModel_batching_origin)]
+ *
+ * ````javascript
+ * const origin = [100000000, 0, 100000000];
+ *
+ * DataTexturePeformanceModel.createMesh({
+ *     id: "leg1",
+ *     origin: origin, // This mesh's positions and transforms are relative to the RTC center
+ *     primitive: "triangles",
+ *     positions: [ 1, 1, 1, -1, 1, 1, -1, -1, 1, 1, -1, 1 ... ],
+ *     normals: [ 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, ... ],
+ *     indices: [ 0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7, ... ],
+ *     position: [-4, -6, -4],
+ *     scale: [1, 3, 1],
+ *     rotation: [0, 0, 0],
+ *     color: [1, 0.3, 0.3]
+ * });
+ *
+ * DataTexturePeformanceModel.createEntity({
+ *     meshIds: ["leg1"],
+ *     isObject: true
+ * });
+ *
+ * DataTexturePeformanceModel.createMesh({
+ *     id: "leg2",
+ *     origin: origin, // This mesh's positions and transforms are relative to the RTC center
+ *     primitive: "triangles",
+ *     positions: [ 1, 1, 1, -1, 1, 1, -1, -1, 1, 1, -1, 1 ... ],
+ *     normals: [ 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, ... ],
+ *     indices: [ 0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7, ... ],
+ *     position: [4, -6, -4],
+ *     scale: [1, 3, 1],
+ *     rotation: [0, 0, 0],
+ *     color: [0.3, 1.0, 0.3]
+ * });
+ *
+ * DataTexturePeformanceModel.createEntity({
+ *     meshIds: ["leg2"],
+ *     isObject: true
+ * });
+ *
+ * DataTexturePeformanceModel.createMesh({
+ *     id: "leg3",
+ *     origin: origin, // This mesh's positions and transforms are relative to the RTC center
+ *     primitive: "triangles",
+ *     positions: [ 1, 1, 1, -1, 1, 1, -1, -1, 1, 1, -1, 1 ... ],
+ *     normals: [ 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, ... ],
+ *     indices: [ 0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7, ... ],
+ *     position: [4, -6, 4],
+ *     scale: [1, 3, 1],
+ *     rotation: [0, 0, 0],
+ *     color: [0.3, 0.3, 1.0]
+ * });
+ *
+ * DataTexturePeformanceModel.createEntity({
+ *     meshIds: ["leg3"],
+ *     isObject: true
+ * });
+ *
+ * DataTexturePeformanceModel.createMesh({
+ *     id: "leg4",
+ *     origin: origin, // This mesh's positions and transforms are relative to the RTC center
+ *     primitive: "triangles",
+ *     positions: [ 1, 1, 1, -1, 1, 1, -1, -1, 1, 1, -1, 1 ... ],
+ *     normals: [ 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, ... ],
+ *     indices: [ 0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7, ... ],
+ *     position: [-4, -6, 4],
+ *     scale: [1, 3, 1],
+ *     rotation: [0, 0, 0],
+ *     color: [1.0, 1.0, 0.0]
+ * });
+ *
+ * DataTexturePeformanceModel.createEntity({
+ *     meshIds: ["leg4"],
+ *     isObject: true
+ * });
+ *
+ * DataTexturePeformanceModel.createMesh({
+ *     id: "top",
+ *     origin: origin, // This mesh's positions and transforms are relative to the RTC center
+ *     primitive: "triangles",
+ *     positions: [ 1, 1, 1, -1, 1, 1, -1, -1, 1, 1, -1, 1 ... ],
+ *     normals: [ 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, ... ],
+ *     indices: [ 0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7, ... ],
+ *     position: [0, -3, 0],
+ *     scale: [6, 0.5, 6],
+ *     rotation: [0, 0, 0],
+ *     color: [1.0, 0.3, 1.0]
+ * });
+ *
+ * DataTexturePeformanceModel.createEntity({
+ *     meshIds: ["top"],
+ *     isObject: true
+ * });
+ * ````
+ *
+ * ## Positioning at World-space coordinates
+ *
+ * To position a DataTexturePeformanceModel at given double-precision World coordinates, we can
+ * configure the ````origin```` of the DataTexturePeformanceModel itself. The ````origin```` is a double-precision
+ * 3D World-space position at which the DataTexturePeformanceModel will be located.
+ *
+ * Note that ````position```` is a single-precision offset relative to ````origin````.
+ *
+ * ````javascript
+ * const origin = [100000000, 0, 100000000];
+ *
+ * const DataTexturePeformanceModel = new DataTexturePeformanceModel(viewer.scene, {
+ *     id: "table",
+ *     isModel: true,
+ *     origin: origin, // Everything in this DataTexturePeformanceModel is relative to this RTC center
+ *     position: [0, 0, 0],
+ *     scale: [1, 1, 1],
+ *     rotation: [0, 0, 0]
+ * });
+ *
+ * DataTexturePeformanceModel.createGeometry({
+ *     id: "box",
+ *     primitive: "triangles",
+ *     positions: [ 1, 1, 1, -1, 1, 1, -1, -1, 1, 1, -1, 1 ... ],
+ *     normals: [ 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, ... ],
+ *     indices: [ 0, 1, 2, 0, 2, 3, 4, 5, 6, 4, 6, 7, ... ],
+ * });
+ *
+ * DataTexturePeformanceModel.createMesh({
+ *     id: "leg1",
+ *     geometryId: "box",
+ *     position: [-4, -6, -4],
+ *     scale: [1, 3, 1],
+ *     rotation: [0, 0, 0],
+ *     color: [1, 0.3, 0.3]
+ * });
+ *
+ * DataTexturePeformanceModel.createEntity({
+ *     meshIds: ["leg1"],
+ *     isObject: true
+ * });
+ *
+ * DataTexturePeformanceModel.createMesh({
+ *     id: "leg2",
+ *     geometryId: "box",
+ *     position: [4, -6, -4],
+ *     scale: [1, 3, 1],
+ *     rotation: [0, 0, 0],
+ *     color: [0.3, 1.0, 0.3]
+ * });
+ *
+ * DataTexturePeformanceModel.createEntity({
+ *     meshIds: ["leg2"],
+ *     isObject: true
+ * });
+ *
+ * DataTexturePeformanceModel.createMesh({
+ *     id: "leg3",
+ *     geometryId: "box",
+ *     position: [4, -6, 4],
+ *     scale: [1, 3, 1],
+ *     rotation: [0, 0, 0],
+ *     color: [0.3, 0.3, 1.0]
+ * });
+ *
+ * DataTexturePeformanceModel.createEntity({
+ *     meshIds: ["leg3"],
+ *     isObject: true
+ * });
+ *
+ * DataTexturePeformanceModel.createMesh({
+ *     id: "leg4",
+ *     geometryId: "box",
+ *     position: [-4, -6, 4],
+ *     scale: [1, 3, 1],
+ *     rotation: [0, 0, 0],
+ *     color: [1.0, 1.0, 0.0]
+ * });
+ *
+ * DataTexturePeformanceModel.createEntity({
+ *     meshIds: ["leg4"],
+ *     isObject: true
+ * });
+ *
+ * DataTexturePeformanceModel.createMesh({
+ *     id: "top",
+ *     geometryId: "box",
+ *     position: [0, -3, 0],
+ *     scale: [6, 0.5, 6],
+ *     rotation: [0, 0, 0],
+ *     color: [1.0, 0.3, 1.0]
+ * });
+ *
+ * DataTexturePeformanceModel.createEntity({
+ *     meshIds: ["top"],
+ *     isObject: true
+ * });
+ * ````
+ *
+ * @implements {Drawable}
+ * @implements {Entity}
+ */
+class DataTexturePeformanceModel extends Component {
+
+    /**
+     * @constructor
+     * @param {Component} owner Owner component. When destroyed, the owner will destroy this component as well.
+     * @param {*} [cfg] Configs
+     * @param {String} [cfg.id] Optional ID, unique among all components in the parent scene, generated automatically when omitted.
+     * @param {Boolean} [cfg.isModel] Specify ````true```` if this DataTexturePeformanceModel represents a model, in which case the DataTexturePeformanceModel will be registered by {@link DataTexturePeformanceModel#id} in {@link Scene#models} and may also have a corresponding {@link MetaModel} with matching {@link MetaModel#id}, registered by that ID in {@link MetaScene#metaModels}.
+     * @param {Number[]} [cfg.origin=[0,0,0]] World-space double-precision 3D origin.
+     * @param {Number[]} [cfg.position=[0,0,0]] Local, single-precision 3D position, relative to the origin parameter.
+     * @param {Number[]} [cfg.scale=[1,1,1]] Local scale.
+     * @param {Number[]} [cfg.rotation=[0,0,0]] Local rotation, as Euler angles given in degrees, for each of the X, Y and Z axis.
+     * @param {Number[]} [cfg.matrix=[1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1] Local modelling transform matrix. Overrides the position, scale and rotation parameters.
+     * @param {Boolean} [cfg.visible=true] Indicates if the DataTexturePeformanceModel is initially visible.
+     * @param {Boolean} [cfg.culled=false] Indicates if the DataTexturePeformanceModel is initially culled from view.
+     * @param {Boolean} [cfg.pickable=true] Indicates if the DataTexturePeformanceModel is initially pickable.
+     * @param {Boolean} [cfg.clippable=true] Indicates if the DataTexturePeformanceModel is initially clippable.
+     * @param {Boolean} [cfg.collidable=true] Indicates if the DataTexturePeformanceModel is initially included in boundary calculations.
+     * @param {Boolean} [cfg.xrayed=false] Indicates if the DataTexturePeformanceModel is initially xrayed.
+     * @param {Boolean} [cfg.highlighted=false] Indicates if the DataTexturePeformanceModel is initially highlighted.
+     * @param {Boolean} [cfg.selected=false] Indicates if the DataTexturePeformanceModel is initially selected.
+     * @param {Boolean} [cfg.edges=false] Indicates if the DataTexturePeformanceModel's edges are initially emphasized.
+     * @param {Number[]} [cfg.colorize=[1.0,1.0,1.0]] DataTexturePeformanceModel's initial RGB colorize color, multiplies by the rendered fragment colors.
+     * @param {Number} [cfg.opacity=1.0] DataTexturePeformanceModel's initial opacity factor, multiplies by the rendered fragment alpha.
+     * @param {Number} [cfg.backfaces=false] When we set this ````true````, then we force rendering of backfaces for this DataTexturePeformanceModel. When
+     * we leave this ````false````, then we allow the Viewer to decide when to render backfaces. In that case, the
+     * Viewer will hide backfaces on watertight meshes, show backfaces on open meshes, and always show backfaces on meshes when we slice them open with {@link SectionPlane}s.
+     * @param {Boolean} [cfg.saoEnabled=true] Indicates if Scalable Ambient Obscurance (SAO) will apply to this DataTexturePeformanceModel. SAO is configured by the Scene's {@link SAO} component.
+     * @param {Boolean} [cfg.pbrEnabled=false] Indicates if physically-based rendering (PBR) will apply to the DataTexturePeformanceModel. Only works when {@link Scene#pbrEnabled} is also ````true````.
+     * @param {Number} [cfg.edgeThreshold=10] When xraying, highlighting, selecting or edging, this is the threshold angle between normals of adjacent triangles, below which their shared wireframe edge is not drawn.
+     */
+    constructor(owner, cfg = {}) {
+        super(owner, cfg);
+
+        if (!(this.scene.canvas.gl instanceof WebGL2RenderingContext)) {
+            throw "Using a DataTexturePerformanceModel requires the usage of webgl2";
+        }
+
+        this._aabb = math.collapseAABB3();
+        this._aabbDirty = false;
+
+        /**
+         * @type {Array<TrianglesDataTextureLayer>}
+         */
+        this._layerList = [];
+
+        /**
+         * @type {Array<PerformanceNode>}
+         */
+        this._nodeList = [];
+
+        /**
+         * @type {TrianglesDataTextureLayer}
+         */
+        this._currentDataTextureLayer = null;
+
+        this._instancingGeometries = {};
+
+        this._preparedInstancingGeometries = {};
+
+        this._scratchMemory = getScratchMemory();
+
+        /**
+         * @type {Map<string, PerformanceMesh>}
+         */
+        this._meshes = {};
+        
+        /**
+         * @type {Map<string, PerformanceNode>}
+         */
+        this._nodes = {};
+
+        /**
+         * @type {RenderFlags}
+         * @private
+         */
+        this.renderFlags = new RenderFlags();
+
+        /**
+         * @private
+         */
+        this.numGeometries = 0; // Number of instance-able geometries created with createGeometry()
+
+        // These counts are used to avoid unnecessary render passes
+        // They are incremented or decremented exclusively by BatchingLayer and InstancingLayer
+        /**
+         * @private
+         */
+        this.numPortions = 0;
+
+        /**
+         * @private
+         */
+        this.numVisibleLayerPortions = 0;
+
+        /**
+         * @private
+         */
+        this.numTransparentLayerPortions = 0;
+
+        /**
+         * @private
+         */
+        this.numXRayedLayerPortions = 0;
+
+        /**
+         * @private
+         */
+        this.numHighlightedLayerPortions = 0;
+
+        /**
+         * @private
+         */
+        this.numSelectedLayerPortions = 0;
+
+        /**
+         * @private
+         */
+        this.numEdgesLayerPortions = 0;
+
+        /**
+         * @private
+         */
+        this.numPickableLayerPortions = 0;
+
+        /**
+         * @private
+         */
+        this.numClippableLayerPortions = 0;
+
+        /**
+         * @private
+         */
+        this.numCulledLayerPortions = 0;
+
+        /** @private */
+        this.numEntities = 0;
+
+        /** @private */
+        this._numTriangles = 0;
+
+        this._edgeThreshold = cfg.edgeThreshold || 10;
+
+        this.visible = cfg.visible;
+        this.culled = cfg.culled;
+        this.pickable = cfg.pickable;
+        this.clippable = cfg.clippable;
+        this.collidable = cfg.collidable;
+        this.castsShadow = cfg.castsShadow;
+        this.receivesShadow = cfg.receivesShadow;
+        this.xrayed = cfg.xrayed;
+        this.highlighted = cfg.highlighted;
+        this.selected = cfg.selected;
+        this.edges = cfg.edges;
+        this.colorize = cfg.colorize;
+        this.opacity = cfg.opacity;
+        this.backfaces = cfg.backfaces;
+
+        // Build static matrix
+
+        this._origin = math.vec3(cfg.origin || [0, 0, 0]);
+        this._position = math.vec3(cfg.position || [0, 0, 0]);
+        this._rotation = math.vec3(cfg.rotation || [0, 0, 0]);
+        this._quaternion = math.vec4(cfg.quaternion || [0, 0, 0, 1]);
+        if (cfg.rotation) {
+            math.eulerToQuaternion(this._rotation, "XYZ", this._quaternion);
+        }
+        this._scale = math.vec3(cfg.scale || [1, 1, 1]);
+        this._worldMatrix = math.mat4();
+        math.composeMat4(this._position, this._quaternion, this._scale, this._worldMatrix);
+        this._worldNormalMatrix = math.mat4();
+        math.inverseMat4(this._worldMatrix, this._worldNormalMatrix);
+        math.transposeMat4(this._worldNormalMatrix);
+
+        if (cfg.matrix || cfg.position || cfg.rotation || cfg.scale || cfg.quaternion) {
+            this._viewMatrix = math.mat4();
+            this._viewNormalMatrix = math.mat4();
+            this._viewMatrixDirty = true;
+            this._worldMatrixNonIdentity = true;
+        }
+
+        this._opacity = 1.0;
+        this._colorize = [1, 1, 1];
+
+        this._saoEnabled = (cfg.saoEnabled !== false);
+
+        this._pbrEnabled = (!!cfg.pbrEnabled);
+
+        this._isModel = cfg.isModel;
+        if (this._isModel) {
+            this.scene._registerModel(this);
+        }
+
+        this._onCameraViewMatrix = this.scene.camera.on("matrix", () => {
+            this._viewMatrixDirty = true;
+        });
+    }
+
+    //------------------------------------------------------------------------------------------------------------------
+    // DataTexturePeformanceModel members
+    //------------------------------------------------------------------------------------------------------------------
+
+    /**
+     * Returns true to indicate that this Component is a DataTexturePeformanceModel.
+     * @type {Boolean}
+     */
+    get isPerformanceModel() {
+        return true;
+    }
+
+    /**
+     * Returns the {@link Entity}s in this DataTexturePeformanceModel.
+     * @returns {*|{}}
+     */
+    get objects() {
+        return this._nodes;
+    }
+
+    /**
+     * Gets the 3D World-space origin for this DataTexturePeformanceModel.
+     *
+     * Each geometry or mesh origin, if supplied, is relative to this origin.
+     *
+     * Default value is ````[0,0,0]````.
+     *
+     * @type {Float64Array}
+     * @abstract
+     */
+    get origin() {
+        return this._origin;
+    }
+
+    /**
+     * Gets the DataTexturePeformanceModel's local translation.
+     *
+     * Default value is ````[0,0,0]````.
+     *
+     * @type {Number[]}
+     */
+    get position() {
+        return this._position;
+    }
+
+    /**
+     * Gets the DataTexturePeformanceModel's local rotation, as Euler angles given in degrees, for each of the X, Y and Z axis.
+     *
+     * Default value is ````[0,0,0]````.
+     *
+     * @type {Number[]}
+     */
+    get rotation() {
+        return this._rotation;
+    }
+
+    /**
+     * Gets the PerformanceModels's local rotation quaternion.
+     *
+     * Default value is ````[0,0,0,1]````.
+     *
+     * @type {Number[]}
+     */
+    get quaternion() {
+        return this._quaternion;
+    }
+
+    /**
+     * Gets the DataTexturePeformanceModel's local scale.
+     *
+     * Default value is ````[1,1,1]````.
+     *
+     * @type {Number[]}
+     */
+    get scale() {
+        return this._scale;
+    }
+
+    /**
+     * Gets the DataTexturePeformanceModel's local modeling transform matrix.
+     *
+     * Default value is ````[1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]````.
+     *
+     * @type {Number[]}
+     */
+    get matrix() {
+        return this._worldMatrix;
+    }
+
+    /**
+     * Gets the DataTexturePeformanceModel's World matrix.
+     *
+     * @property worldMatrix
+     * @type {Number[]}
+     */
+    get worldMatrix() {
+        return this._worldMatrix;
+    }
+
+    /**
+     * Gets the DataTexturePeformanceModel's World normal matrix.
+     *
+     * @type {Number[]}
+     */
+    get worldNormalMatrix() {
+        return this._worldNormalMatrix;
+    }
+
+    /**
+     * Called by private renderers in ./lib, returns the view matrix with which to
+     * render this DataTexturePeformanceModel. The view matrix is the concatenation of the
+     * Camera view matrix with the Performance model's world (modeling) matrix.
+     *
+     * @private
+     */
+    get viewMatrix() {
+        if (!this._viewMatrix) {
+            return this.scene.camera.viewMatrix;
+        }
+        if (this._viewMatrixDirty) {
+            math.mulMat4(this.scene.camera.viewMatrix, this._worldMatrix, this._viewMatrix);
+            math.inverseMat4(this._viewMatrix, this._viewNormalMatrix);
+            math.transposeMat4(this._viewNormalMatrix);
+            this._viewMatrixDirty = false;
+        }
+        return this._viewMatrix;
+    }
+
+    /**
+     * Called by private renderers in ./lib, returns the view normal matrix with which to render this DataTexturePeformanceModel.
+     *
+     * @private
+     */
+    get viewNormalMatrix() {
+        if (!this._viewNormalMatrix) {
+            return this.scene.camera.viewNormalMatrix;
+        }
+        if (this._viewMatrixDirty) {
+            math.mulMat4(this.scene.camera.viewMatrix, this._worldMatrix, this._viewMatrix);
+            math.inverseMat4(this._viewMatrix, this._viewNormalMatrix);
+            math.transposeMat4(this._viewNormalMatrix);
+            this._viewMatrixDirty = false;
+        }
+        return this._viewNormalMatrix;
+    }
+
+    /**
+     * Sets if backfaces are rendered for this DataTexturePeformanceModel.
+     *
+     * Default is ````false````.
+     *
+     * @type {Boolean}
+     */
+    get backfaces() {
+        return this._backfaces;
+    }
+
+    /**
+     * Sets if backfaces are rendered for this DataTexturePeformanceModel.
+     *
+     * Default is ````false````.
+     *
+     * When we set this ````true````, then backfaces are always rendered for this DataTexturePeformanceModel.
+     *
+     * When we set this ````false````, then we allow the Viewer to decide whether to render backfaces. In this case,
+     * the Viewer will:
+     *
+     *  * hide backfaces on watertight meshes,
+     *  * show backfaces on open meshes, and
+     *  * always show backfaces on meshes when we slice them open with {@link SectionPlane}s.
+     *
+     * @type {Boolean}
+     */
+    set backfaces(backfaces) {
+        backfaces = !!backfaces;
+        this._backfaces = backfaces;
+        this.glRedraw();
+    }
+
+    /**
+     * Gets the list of {@link Entity}s within this DataTexturePeformanceModel.
+     *
+     * @returns {Entity[]}
+     */
+    get entityList() {
+        return this._nodeList;
+    }
+
+    /**
+     * Returns true to indicate that DataTexturePeformanceModel is an {@link Entity}.
+     * @type {Boolean}
+     */
+    get isEntity() {
+        return true;
+    }
+
+    /**
+     * Returns ````true```` if this DataTexturePeformanceModel represents a model.
+     *
+     * When ````true```` the DataTexturePeformanceModel will be registered by {@link DataTexturePeformanceModel#id} in
+     * {@link Scene#models} and may also have a {@link MetaObject} with matching {@link MetaObject#id}.
+     *
+     * @type {Boolean}
+     */
+    get isModel() {
+        return this._isModel;
+    }
+
+    //------------------------------------------------------------------------------------------------------------------
+    // DataTexturePeformanceModel members
+    //------------------------------------------------------------------------------------------------------------------
+
+    /**
+     * Returns ````false```` to indicate that DataTexturePeformanceModel never represents an object.
+     *
+     * @type {Boolean}
+     */
+    get isObject() {
+        return false;
+    }
+
+    /**
+     * Gets the DataTexturePeformanceModel's World-space 3D axis-aligned bounding box.
+     *
+     * Represented by a six-element Float64Array containing the min/max extents of the
+     * axis-aligned volume, ie. ````[xmin, ymin,zmin,xmax,ymax, zmax]````.
+     *
+     * @type {Number[]}
+     */
+    get aabb() {
+        if (this._aabbDirty) {
+            this._rebuildAABB();
+        }
+        return this._aabb;
+    }
+
+    /**
+     * The approximate number of triangle primitives in this DataTexturePeformanceModel.
+     *
+     * @type {Number}
+     */
+    get numTriangles() {
+        return this._numTriangles;
+    }
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Entity members
+    //------------------------------------------------------------------------------------------------------------------
+
+    /**
+     * The approximate number of line primitives in this DataTexturePeformanceModel.
+     *
+     * @type {Number}
+     */
+    get numLines() {
+        return 0;
+    }
+
+    /**
+     * The approximate number of point primitives in this DataTexturePeformanceModel.
+     *
+     * @type {Number}
+     */
+    get numPoints() {
+        return 0;
+    }
+
+    /**
+     * Gets if any {@link Entity}s in this DataTexturePeformanceModel are visible.
+     *
+     * The DataTexturePeformanceModel is only rendered when {@link DataTexturePeformanceModel#visible} is ````true```` and {@link DataTexturePeformanceModel#culled} is ````false````.
+     *
+     * @type {Boolean}
+     */
+    get visible() {
+        return (this.numVisibleLayerPortions > 0);
+    }
+
+    /**
+     * Sets if this DataTexturePeformanceModel is visible.
+     *
+     * The DataTexturePeformanceModel is only rendered when {@link DataTexturePeformanceModel#visible} is ````true```` and {@link DataTexturePeformanceModel#culled} is ````false````.
+     **
+     * @type {Boolean}
+     */
+    set visible(visible) {
+        visible = visible !== false;
+        this._visible = visible;
+        for (let i = 0, len = this._nodeList.length; i < len; i++) {
+            this._nodeList[i].visible = visible;
+        }
+        this.glRedraw();
+    }
+
+    /**
+     * Gets if any {@link Entity}s in this DataTexturePeformanceModel are xrayed.
+     *
+     * @type {Boolean}
+     */
+    get xrayed() {
+        return (this.numXRayedLayerPortions > 0);
+    }
+
+    /**
+     * Sets if all {@link Entity}s in this DataTexturePeformanceModel are xrayed.
+     *
+     * @type {Boolean}
+     */
+    set xrayed(xrayed) {
+        xrayed = !!xrayed;
+        this._xrayed = xrayed;
+        for (let i = 0, len = this._nodeList.length; i < len; i++) {
+            this._nodeList[i].xrayed = xrayed;
+        }
+        this.glRedraw();
+    }
+
+    /**
+     * Gets if any {@link Entity}s in this DataTexturePeformanceModel are highlighted.
+     *
+     * @type {Boolean}
+     */
+    get highlighted() {
+        return (this.numHighlightedLayerPortions > 0);
+    }
+
+    /**
+     * Sets if all {@link Entity}s in this DataTexturePeformanceModel are highlighted.
+     *
+     * @type {Boolean}
+     */
+    set highlighted(highlighted) {
+        highlighted = !!highlighted;
+        this._highlighted = highlighted;
+        for (let i = 0, len = this._nodeList.length; i < len; i++) {
+            this._nodeList[i].highlighted = highlighted;
+        }
+        this.glRedraw();
+    }
+
+    /**
+     * Gets if any {@link Entity}s in this DataTexturePeformanceModel are selected.
+     *
+     * @type {Boolean}
+     */
+    get selected() {
+        return (this.numSelectedLayerPortions > 0);
+    }
+
+    /**
+     * Sets if all {@link Entity}s in this DataTexturePeformanceModel are selected.
+     *
+     * @type {Boolean}
+     */
+    set selected(selected) {
+        selected = !!selected;
+        this._selected = selected;
+        for (let i = 0, len = this._nodeList.length; i < len; i++) {
+            this._nodeList[i].selected = selected;
+        }
+        this.glRedraw();
+    }
+
+    /**
+     * Gets if any {@link Entity}s in this DataTexturePeformanceModel have edges emphasised.
+     *
+     * @type {Boolean}
+     */
+    get edges() {
+        return (this.numEdgesLayerPortions > 0);
+    }
+
+    /**
+     * Sets if all {@link Entity}s in this DataTexturePeformanceModel have edges emphasised.
+     *
+     * @type {Boolean}
+     */
+    set edges(edges) {
+        edges = !!edges;
+        this._edges = edges;
+        for (let i = 0, len = this._nodeList.length; i < len; i++) {
+            this._nodeList[i].edges = edges;
+        }
+        this.glRedraw();
+    }
+
+    /**
+     * Gets if this DataTexturePeformanceModel is culled from view.
+     *
+     * The DataTexturePeformanceModel is only rendered when {@link DataTexturePeformanceModel#visible} is true and {@link DataTexturePeformanceModel#culled} is false.
+     *
+     * @type {Boolean}
+     */
+    get culled() {
+        return this._culled;
+    }
+
+    /**
+     * Sets if this DataTexturePeformanceModel is culled from view.
+     *
+     * The DataTexturePeformanceModel is only rendered when {@link DataTexturePeformanceModel#visible} is true and {@link DataTexturePeformanceModel#culled} is false.
+     *
+     * @type {Boolean}
+     */
+    set culled(culled) {
+        culled = !!culled;
+        this._culled = culled;
+        for (let i = 0, len = this._nodeList.length; i < len; i++) {
+            this._nodeList[i].culled = culled;
+        }
+        this.glRedraw();
+    }
+
+    /**
+     * Gets if {@link Entity}s in this DataTexturePeformanceModel are clippable.
+     *
+     * Clipping is done by the {@link SectionPlane}s in {@link Scene#sectionPlanes}.
+     *
+     * @type {Boolean}
+     */
+    get clippable() {
+        return this._clippable;
+    }
+
+    /**
+     * Sets if {@link Entity}s in this DataTexturePeformanceModel are clippable.
+     *
+     * Clipping is done by the {@link SectionPlane}s in {@link Scene#sectionPlanes}.
+     *
+     * @type {Boolean}
+     */
+    set clippable(clippable) {
+        clippable = clippable !== false;
+        this._clippable = clippable;
+        for (let i = 0, len = this._nodeList.length; i < len; i++) {
+            this._nodeList[i].clippable = clippable;
+        }
+        this.glRedraw();
+    }
+
+    /**
+     * Gets if this DataTexturePeformanceModel is collidable.
+     *
+     * @type {Boolean}
+     */
+    get collidable() {
+        return this._collidable;
+    }
+
+    /**
+     * Sets if {@link Entity}s in this DataTexturePeformanceModel are collidable.
+     *
+     * @type {Boolean}
+     */
+    set collidable(collidable) {
+        collidable = collidable !== false;
+        this._collidable = collidable;
+        for (let i = 0, len = this._nodeList.length; i < len; i++) {
+            this._nodeList[i].collidable = collidable;
+        }
+    }
+
+    /**
+     * Gets if this DataTexturePeformanceModel is pickable.
+     *
+     * Picking is done via calls to {@link Scene#pick}.
+     *
+     * @type {Boolean}
+     */
+    get pickable() {
+        return (this.numPickableLayerPortions > 0);
+    }
+
+    /**
+     * Sets if {@link Entity}s in this DataTexturePeformanceModel are pickable.
+     *
+     * Picking is done via calls to {@link Scene#pick}.
+     *
+     * @type {Boolean}
+     */
+    set pickable(pickable) {
+        pickable = pickable !== false;
+        this._pickable = pickable;
+        for (let i = 0, len = this._nodeList.length; i < len; i++) {
+            this._nodeList[i].pickable = pickable;
+        }
+    }
+
+    /**
+     * Gets the RGB colorize color for this DataTexturePeformanceModel.
+     *
+     * Each element of the color is in range ````[0..1]````.
+     *
+     * @type {Number[]}
+     */
+    get colorize() {
+        return this._colorize;
+    }
+
+    /**
+     * Sets the RGB colorize color for this DataTexturePeformanceModel.
+     *
+     * Multiplies by rendered fragment colors.
+     *
+     * Each element of the color is in range ````[0..1]````.
+     *
+     * @type {Number[]}
+     */
+    set colorize(colorize) {
+        this._colorize = colorize;
+        for (let i = 0, len = this._nodeList.length; i < len; i++) {
+            this._nodeList[i].colorize = colorize;
+        }
+    }
+
+    /**
+     * Gets this DataTexturePeformanceModel's opacity factor.
+     *
+     * This is a factor in range ````[0..1]```` which multiplies by the rendered fragment alphas.
+     *
+     * @type {Number}
+     */
+    get opacity() {
+        return this._opacity;
+    }
+
+    /**
+     * Sets the opacity factor for this DataTexturePeformanceModel.
+     *
+     * This is a factor in range ````[0..1]```` which multiplies by the rendered fragment alphas.
+     *
+     * @type {Number}
+     */
+    set opacity(opacity) {
+        this._opacity = opacity;
+        for (let i = 0, len = this._nodeList.length; i < len; i++) {
+            this._nodeList[i].opacity = opacity;
+        }
+    }
+
+    /**
+     * Gets if this DataTexturePeformanceModel casts a shadow.
+     *
+     * @type {Boolean}
+     */
+    get castsShadow() {
+        return this._castsShadow;
+    }
+
+    /**
+     * Sets if this DataTexturePeformanceModel casts a shadow.
+     *
+     * @type {Boolean}
+     */
+    set castsShadow(castsShadow) {
+        castsShadow = (castsShadow !== false);
+        if (castsShadow !== this._castsShadow) {
+            this._castsShadow = castsShadow;
+            this.glRedraw();
+        }
+    }
+
+    /**
+     * Sets if this DataTexturePeformanceModel can have shadow cast upon it.
+     *
+     * @type {Boolean}
+     */
+    get receivesShadow() {
+        return this._receivesShadow;
+    }
+
+    /**
+     * Sets if this DataTexturePeformanceModel can have shadow cast upon it.
+     *
+     * @type {Boolean}
+     */
+    set receivesShadow(receivesShadow) {
+        receivesShadow = (receivesShadow !== false);
+        if (receivesShadow !== this._receivesShadow) {
+            this._receivesShadow = receivesShadow;
+            this.glRedraw();
+        }
+    }
+
+    /**
+     * Gets if Scalable Ambient Obscurance (SAO) will apply to this DataTexturePeformanceModel.
+     *
+     * SAO is configured by the Scene's {@link SAO} component.
+     *
+     *  Only works when {@link SAO#enabled} is also true.
+     *
+     * @type {Boolean}
+     */
+    get saoEnabled() {
+        return this._saoEnabled;
+    }
+
+    /**
+     * Gets if physically-based rendering (PBR) is enabled for this DataTexturePeformanceModel.
+     *
+     * Only works when {@link Scene#pbrEnabled} is also true.
+     *
+     * @type {Boolean}
+     */
+    get pbrEnabled() {
+        return this._pbrEnabled;
+    }
+
+    /**
+     * Returns true to indicate that DataTexturePeformanceModel is implements {@link Drawable}.
+     *
+     * @type {Boolean}
+     */
+    get isDrawable() {
+        return true;
+    }
+
+    /** @private */
+    get isStateSortable() {
+        return false
+    }
+
+    /**
+     * Configures the appearance of xrayed {@link Entity}s within this DataTexturePeformanceModel.
+     *
+     * This is the {@link Scene#xrayMaterial}.
+     *
+     * @type {EmphasisMaterial}
+     */
+    get xrayMaterial() {
+        return this.scene.xrayMaterial;
+    }
+
+    /**
+     * Configures the appearance of highlighted {@link Entity}s within this DataTexturePeformanceModel.
+     *
+     * This is the {@link Scene#highlightMaterial}.
+     *
+     * @type {EmphasisMaterial}
+     */
+    get highlightMaterial() {
+        return this.scene.highlightMaterial;
+    }
+
+    /**
+     * Configures the appearance of selected {@link Entity}s within this DataTexturePeformanceModel.
+     *
+     * This is the {@link Scene#selectedMaterial}.
+     *
+     * @type {EmphasisMaterial}
+     */
+    get selectedMaterial() {
+        return this.scene.selectedMaterial;
+    }
+
+    /**
+     * Configures the appearance of edges of {@link Entity}s within this DataTexturePeformanceModel.
+     *
+     * This is the {@link Scene#edgeMaterial}.
+     *
+     * @type {EdgeMaterial}
+     */
+    get edgeMaterial() {
+        return this.scene.edgeMaterial;
+    }
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Drawable members
+    //------------------------------------------------------------------------------------------------------------------
+
+    /**
+     * Called by private renderers in ./lib, returns the picking view matrix with which to
+     * ray-pick on this DataTexturePeformanceModel.
+     *
+     * @private
+     */
+    getPickViewMatrix(pickViewMatrix) {
+        if (!this._viewMatrix) {
+            return pickViewMatrix;
+        }
+        return this._viewMatrix;
+    }
+
+    /**
+     * Creates a reusable geometry within this DataTexturePeformanceModel.
+     *
+     * We can then supply the geometry ID to {@link DataTexturePeformanceModel#createMesh} when we want to create meshes that instance the geometry.
+     *
+     * If provide a  ````positionsDecodeMatrix```` , then ````createGeometry()```` will assume
+     * that the ````positions```` and ````normals```` arrays are compressed. When compressed, ````positions```` will be
+     * quantized and in World-space, and ````normals```` will be oct-encoded and in World-space.
+     *
+     * Note that ````positions````, ````normals```` and ````indices```` are all required together.
+     *
+     * @param {*} cfg Geometry properties.
+     * @param {String|Number} cfg.id Mandatory ID for the geometry, to refer to with {@link DataTexturePeformanceModel#createMesh}.
+     * @param {String} cfg.primitive The primitive type. Accepted values are 'points', 'lines', 'triangles', 'solid' and 'surface'.
+     * @param {Number[]} cfg.positions Flat array of positions.
+     * @param {Number[]} [cfg.normals] Flat array of normal vectors. Only used with 'triangles' primitives. When no normals are given, the geometry will be flat shaded using auto-generated face-aligned normals.
+     * @param {Number[]} [cfg.colors] Flat array of RGBA vertex colors as float values in range ````[0..1]````. Ignored when ````geometryId```` is given, overidden by ````color```` and ````colorsCompressed````.
+     * @param {Number[]} [cfg.colorsCompressed] Flat array of RGBA vertex colors as unsigned short integers in range ````[0..255]````. Ignored when ````geometryId```` is given, overrides ````colors```` and is overriden by ````color````.
+     * @param {Number[]} [cfg.indices] Array of indices. Not required for `points` primitives.
+     * @param {Number[]} [cfg.edgeIndices] Array of edge line indices. Used only for Required for 'triangles' primitives. These are automatically generated internally if not supplied, using the ````edgeThreshold```` given to the ````DataTexturePeformanceModel```` constructor.
+     * @param {Number[]} [cfg.positionsDecodeMatrix] A 4x4 matrix for decompressing ````positions````.
+     * @param {Number[]} [cfg.origin] Optional geometry origin, relative to {@link DataTexturePeformanceModel#origin}. When this is given, then every mesh created with {@link DataTexturePeformanceModel#createMesh} that uses this geometry will
+     * be transformed relative to this origin.
+     */
+    createGeometry(cfg) {
+        const geometryId = cfg.id;
+
+        if (geometryId === undefined || geometryId === null) {
+            this.error("Config missing: id");
+            return;
+        }
+        if (geometryId in this._instancingGeometries) {
+            this.error("Geometry already created: " + geometryId);
+            return;
+        }
+
+        const primitive = cfg.primitive;
+
+        if (primitive === undefined || primitive === null) {
+            this.error("Config missing: primitive");
+            return;
+        }
+
+        const cfgOrigin = cfg.origin || cfg.rtcCenter;
+        const origin = (cfgOrigin) ? math.addVec3(this._origin, cfgOrigin, tempVec3a) : this._origin;
+
+        switch (primitive) {
+            case "triangles":
+            case "solid":
+            case "surface":
+
+                this._instancingGeometries [cfg.id] = utils.apply(
+                    {
+                        origin,
+                        layerIndex: 0,
+                        solid: primitive !== "surface"
+                    },
+                    cfg
+                );
+                this._numTriangles += (cfg.indices ? Math.round(cfg.indices.length / 3) : 0);
+                break;
+            case "lines":
+                throw "Not supported at the moment";
+                break;
+            case "points":
+                throw "Not supported at the moment";
+                break;
+        }
+
+        this.numGeometries++;
+    }
+
+    /**
+     * Creates a mesh within this DataTexturePeformanceModel.
+     *
+     * A mesh can either share geometry with other meshes, or have its own unique geometry.
+     *
+     * To share a geometry with other meshes, provide the ID of a geometry created earlier
+     * with {@link DataTexturePeformanceModel#createGeometry}.
+     *
+     * To create unique geometry for the mesh, provide geometry data arrays.
+     *
+     * Internally, DataTexturePeformanceModel will batch all unique mesh geometries into the same arrays, which improves
+     * rendering performance.
+     *
+     * If you accompany the arrays with a  ````positionsDecodeMatrix```` , then ````createMesh()```` will assume
+     * that the ````positions```` and ````normals```` arrays are compressed. When compressed, ````positions```` will be
+     * quantized and in World-space, and ````normals```` will be oct-encoded and in World-space.
+     *
+     * If you accompany the arrays with an  ````origin````, then ````createMesh()```` will assume
+     * that the ````positions```` are in relative-to-center (RTC) coordinates, with ````origin```` being the origin of their
+     * RTC coordinate system.
+     *
+     * When providing either ````positionsDecodeMatrix```` or ````origin````, ````createMesh()```` will start a new
+     * batch each time either of those two parameters change since the last call. Therefore, to combine arrays into the
+     * minimum number of batches, it's best for performance to create your shared meshes in runs that have the same value
+     * for ````positionsDecodeMatrix```` and ````origin````.
+     *
+     * Note that ````positions````, ````normals```` and ````indices```` are all required together.
+     *
+     * @param {object} cfg Object properties.
+     * @param {String} cfg.id Mandatory ID for the new mesh. Must not clash with any existing components within the {@link Scene}.
+     * @param {String|Number} [cfg.geometryId] ID of a geometry to instance, previously created with {@link DataTexturePeformanceModel#createGeometry:method"}}createMesh(){{/crossLink}}. Overrides all other geometry parameters given to this method.
+     * @param {String} [cfg.primitive="triangles"]  Geometry primitive type. Ignored when ````geometryId```` is given. Accepted values are 'points', 'lines' and 'triangles'.
+     * @param {Number[]} [cfg.positions] Flat array of vertex positions. Ignored when ````geometryId```` is given.
+     * @param {Number[]} [cfg.colors] Flat array of RGB vertex colors as float values in range ````[0..1]````. Ignored when ````geometryId```` is given, overriden by ````color```` and ````colorsCompressed````.
+     * @param {Number[]} [cfg.colorsCompressed] Flat array of RGB vertex colors as unsigned short integers in range ````[0..255]````. Ignored when ````geometryId```` is given, overrides ````colors```` and is overriden by ````color````.
+     * @param {Number[]} [cfg.normals] Flat array of normal vectors. Only used with 'triangles' primitives. When no normals are given, the mesh will be flat shaded using auto-generated face-aligned normals.
+     * @param {Number[]} [cfg.positionsDecodeMatrix] A 4x4 matrix for decompressing ````positions````.
+     * @param {Number[]} [cfg.origin] Optional geometry origin, relative to {@link DataTexturePeformanceModel#origin}. When this is given, then ````positions```` are assumed to be relative to this.
+     * @param {Number[]} [cfg.indices] Array of triangle indices. Ignored when ````geometryId```` is given.
+     * @param {Number[]} [cfg.edgeIndices] Array of edge line indices. If ````geometryId```` is not given, edge line indices are
+     * automatically generated internally if not given, using the ````edgeThreshold```` given to the ````DataTexturePeformanceModel````
+     * constructor. This parameter is ignored when ````geometryId```` is given.
+     * @param {Number[]} [cfg.position=[0,0,0]] Local 3D position. of the mesh
+     * @param {Number[]} [cfg.scale=[1,1,1]] Scale of the mesh.
+     * @param {Number[]} [cfg.rotation=[0,0,0]] Rotation of the mesh as Euler angles given in degrees, for each of the X, Y and Z axis.
+     * @param {Number[]} [cfg.matrix=[1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1]] Mesh modelling transform matrix. Overrides the ````position````, ````scale```` and ````rotation```` parameters.
+     * @param {Number[]} [cfg.color=[1,1,1]] RGB color in range ````[0..1, 0..`, 0..1]````. Overrides ````colors```` and ````colorsCompressed````.
+     * @param {Number} [cfg.opacity=1] Opacity in range ````[0..1]````.
+     */
+    createMesh(cfg) {
+
+        let id = cfg.id;
+        if (id === undefined || id === null) {
+            this.error("Config missing: id");
+            return;
+        }
+        if (this._meshes[id]) {
+            this.error("DataTexturePeformanceModel already has a Mesh with this ID: " + id + "");
+            return;
+        }
+
+        const geometryId = cfg.geometryId;
+        const instancing = (geometryId !== undefined);
+
+        let geometryCfg = null;
+
+        if (instancing) {
+            geometryCfg = this._instancingGeometries[geometryId];
+        } else {
+            geometryCfg = cfg;
+        }
+
+        /**
+         * This will be the prepared mesh geometry, with index rebucketting applied.
+         */
+        let preparedGeometryCfg = null;
+
+        if (!instancing || !(geometryId in this._preparedInstancingGeometries))
+        {
+            let primitive = geometryCfg.primitive || "triangles";
+
+            if (primitive !== "triangles" && primitive !== "solid" && primitive !== "surface") {
+                this.error(`Unsupported value for 'primitive': '${primitive}' - supported values are 'triangles', 'solid' and 'surface'. Defaulting to 'triangles'.`);
+                primitive = "triangles";
+            }
+
+            let positions = geometryCfg.positions;
+
+            if (!positions) {
+                this.error("Config missing: positions (no meshIds provided, so expecting geometry arrays instead)");
+                return null;
+            }
+
+            let indices = geometryCfg.indices;
+            let edgeIndices = geometryCfg.edgeIndices;
+
+            if (!geometryCfg.indices && primitive === "triangles") {
+                this.error("Config missing for triangles primitive: indices (no meshIds provided, so expecting geometry arrays instead)");
+                return null;
+            }
+
+            if (!edgeIndices) {
+                edgeIndices = buildEdgeIndices(positions, indices, null, this._edgeThreshold);
+            }
+
+            geometryCfg.edgeIndices = edgeIndices;
+
+            preparedGeometryCfg = prepareMeshGeometry (geometryCfg);
+
+            if (instancing) {
+                this._preparedInstancingGeometries[geometryId] = preparedGeometryCfg;
+            }
+        } else {
+            preparedGeometryCfg = this._preparedInstancingGeometries[geometryId];
+        }
+        
+        let layer = this._currentDataTextureLayer;
+
+        if (null !== layer && !layer.canCreatePortion(preparedGeometryCfg, instancing ? geometryId : null))
+        {
+            layer.finalize();
+            delete this._currentDataTextureLayer;;
+            layer = null;
+        }
+
+        if (!layer)
+        {
+            layer = new TrianglesDataTextureLayer(this, {
+                layerIndex: 0, // This is set in #finalize()
+                scratchMemory: this._scratchMemory,
+
+                // chipmunk
+                // positionsDecodeMatrix: cfg.positionsDecodeMatrix,  // Can be undefined
+
+                // chipmunk: allow to have different origins per-mesh
+                origin: cfg.origin,
+
+                // chipmunk: TODO, encode as a property for each object in the per-object texture, and if needed adjust the vertices clockwise sense in the shader
+                solid: true,
+            });
+            this._layerList.push(layer);
+            this._currentDataTextureLayer = layer;
+        }
+
+        let portionId;
+
+        const color = (cfg.color) ? new Uint8Array([Math.floor(cfg.color[0] * 255), Math.floor(cfg.color[1] * 255), Math.floor(cfg.color[2] * 255)]) : [255, 255, 255];
+        const opacity = (cfg.opacity !== undefined && cfg.opacity !== null) ? Math.floor(cfg.opacity * 255) : 255;
+        const metallic = (cfg.metallic !== undefined && cfg.metallic !== null) ? Math.floor(cfg.metallic * 255) : 0;
+        const roughness = (cfg.roughness !== undefined && cfg.roughness !== null) ? Math.floor(cfg.roughness * 255) : 255;
+
+        const mesh = new PerformanceMesh(this, id, color, opacity);
+
+        const pickId = mesh.pickId;
+
+        const a = pickId >> 24 & 0xFF;
+        const b = pickId >> 16 & 0xFF;
+        const g = pickId >> 8 & 0xFF;
+        const r = pickId & 0xFF;
+
+        const pickColor = new Uint8Array([r, g, b, a]); // Quantized pick color
+
+        const aabb = math.collapseAABB3();
+
+        if (instancing) {
+
+            let meshMatrix;
+            let worldMatrix = this._worldMatrixNonIdentity ? this._worldMatrix : null;
+
+            if (cfg.matrix) {
+                meshMatrix = cfg.matrix;
+            } else {
+                const scale = cfg.scale || defaultScale;
+                const position = cfg.position || defaultPosition;
+                const rotation = cfg.rotation || defaultRotation;
+                math.eulerToQuaternion(rotation, "XYZ", defaultQuaternion);
+                meshMatrix = math.composeMat4(position, defaultQuaternion, scale, tempMat4);
+            }
+
+            portionId = layer.createPortion(
+                preparedGeometryCfg,
+                {
+                    geometryId: geometryId,
+                    color: color,
+                    metallic: metallic,
+                    roughness: roughness,
+                    opacity: opacity,
+                    meshMatrix: meshMatrix,
+                    worldMatrix: worldMatrix,
+                    aabb: aabb,
+                    pickColor: pickColor
+                }
+            );
+
+            math.expandAABB3(this._aabb, aabb);
+
+            this._numTriangles += preparedGeometryCfg.indices.length / 3;
+            mesh.numTriangles = preparedGeometryCfg.indices.length / 3;
+
+            mesh.origin = preparedGeometryCfg.origin;
+        } else { // Batching
+            let origin = null;
+
+            if (!cfg.positionsDecodeMatrix) { // TODO: Assumes we never quantize double-precision coordinates
+                const rtcCenter = math.vec3();
+                const rtcPositions = [];
+                const rtcNeeded = worldToRTCPositions(positions, rtcPositions, rtcCenter);
+                if (rtcNeeded) {
+                    positions = rtcPositions;
+                    origin = math.addVec3(this._origin, rtcCenter, rtcCenter);
+                }
+            }
+
+            const cfgOrigin = cfg.origin || cfg.rtcCenter;
+            if (cfgOrigin) {
+                if (!origin) {
+                    origin = cfgOrigin;
+                } else {
+                    origin = math.addVec3(this._origin, cfgOrigin, tempVec3a);
+                }
+            } else {
+                origin = this._origin;
+            }
+
+            // TODO: treat the possibility of different origins
+
+            const worldMatrix = this._worldMatrixNonIdentity ? this._worldMatrix : null;
+            let meshMatrix;
+
+            if (!cfg.positionsDecodeMatrix) {
+                if (cfg.matrix) {
+                    meshMatrix = cfg.matrix;
+                } else {
+                    const scale = cfg.scale || defaultScale;
+                    const position = cfg.position || defaultPosition;
+                    const rotation = cfg.rotation || defaultRotation;
+                    math.eulerToQuaternion(rotation, "XYZ", defaultQuaternion);
+                    meshMatrix = math.composeMat4(position, defaultQuaternion, scale, tempMat4);
+                }
+            }
+
+            let primitive = cfg.primitive || "triangles";
+
+            switch (primitive) {
+
+                case "triangles":
+                case "solid":
+                case "surface":                    
+                    portionId = layer.createPortion(utils.apply (
+                        {
+                            origin: origin,
+                            color: color,
+                            metallic: metallic,
+                            roughness: roughness,
+                            colors: cfg.colors,
+                            colorsCompressed: cfg.colorsCompressed,
+                            opacity: opacity,
+                            meshMatrix: meshMatrix,
+                            worldMatrix: worldMatrix,
+                            aabb: aabb,
+                            pickColor: pickColor
+                        },
+                        preparedGeometryCfg
+                    ));
+
+                    const numTriangles = Math.round(preparedGeometryCfg.indices.length / 3);
+
+                    this._numTriangles += numTriangles;
+
+                    mesh.numTriangles = numTriangles;
+                    break;
+                case "lines":
+                    throw "Not supported at the moment";
+                    break;
+                case "points":
+                    throw "Not supported at the moment";
+                    break;
+            }
+
+            math.expandAABB3(this._aabb, aabb);
+
+            this.numGeometries++;
+
+            mesh.origin = origin;
+        }
+        
+        mesh.parent = null; // Will be set within PerformanceModelNode constructor
+        mesh._layer = layer;
+        mesh._portionId = portionId;
+        mesh.aabb = aabb;
+
+        this._meshes[id] = mesh;
+    }
+
+    /**
+     * Creates an {@link Entity} within this DataTexturePeformanceModel, giving it one or more meshes previously created with {@link DataTexturePeformanceModel#createMesh}.
+     *
+     * A mesh can only belong to one {@link Entity}, so you'll get an error if you try to reuse a mesh among multiple {@link Entity}s.
+     *
+     * @param {Object} cfg Entity configuration.
+     * @param {String} cfg.id Optional ID for the new Entity. Must not clash with any existing components within the {@link Scene}.
+     * @param {String[]} cfg.meshIds IDs of one or more meshes created previously with {@link DataTexturePeformanceModel@createMesh}.
+
+     * @param {Boolean} [cfg.isObject] Set ````true```` if the {@link Entity} represents an object, in which case it will be registered by {@link Entity#id} in {@link Scene#objects} and can also have a corresponding {@link MetaObject} with matching {@link MetaObject#id}, registered by that ID in {@link MetaScene#metaObjects}.
+     * @param {Boolean} [cfg.visible=true] Indicates if the Entity is initially visible.
+     * @param {Boolean} [cfg.culled=false] Indicates if the Entity is initially culled from view.
+     * @param {Boolean} [cfg.pickable=true] Indicates if the Entity is initially pickable.
+     * @param {Boolean} [cfg.clippable=true] Indicates if the Entity is initially clippable.
+     * @param {Boolean} [cfg.collidable=true] Indicates if the Entity is initially included in boundary calculations.
+     * @param {Boolean} [cfg.castsShadow=true] Indicates if the Entity initially casts shadows.
+     * @param {Boolean} [cfg.receivesShadow=true]  Indicates if the Entity initially receives shadows.
+     * @param {Boolean} [cfg.xrayed=false] Indicates if the Entity is initially xrayed. XRayed appearance is configured by {@link DataTexturePeformanceModel#xrayMaterial}.
+     * @param {Boolean} [cfg.highlighted=false] Indicates if the Entity is initially highlighted. Highlighted appearance is configured by {@link DataTexturePeformanceModel#highlightMaterial}.
+     * @param {Boolean} [cfg.selected=false] Indicates if the Entity is initially selected. Selected appearance is configured by {@link DataTexturePeformanceModel#selectedMaterial}.
+     * @param {Boolean} [cfg.edges=false] Indicates if the Entity's edges are initially emphasized. Edges appearance is configured by {@link DataTexturePeformanceModel#edgeMaterial}.
+     * @returns {Entity}
+     */
+    createEntity(cfg) {
+        // Validate or generate Entity ID
+        let id = cfg.id;
+        if (id === undefined) {
+            id = math.createUUID();
+        } else if (this.scene.components[id]) {
+            this.error("Scene already has a Component with this ID: " + id + " - will assign random ID");
+            id = math.createUUID();
+        }
+        // Collect PerformanceModelNode's PerformanceModelMeshes
+        const meshIds = cfg.meshIds;
+        if (meshIds === undefined) {
+            this.error("Config missing: meshIds");
+            return;
+        }
+        let meshes = [];
+        for (let i = 0, len = meshIds.length; i < len; i++) {
+            const meshId = meshIds[i];
+            const mesh = this._meshes[meshId];
+            if (!mesh) {
+                this.error("Mesh with this ID not found: " + meshId + " - ignoring this mesh");
+                continue;
+            }
+            if (mesh.parent) {
+                this.error("Mesh with ID " + meshId + " already belongs to object with ID " + mesh.parent.id + " - ignoring this mesh");
+                continue;
+            }
+            meshes.push(mesh);
+        }
+        // Create PerformanceModelNode flags
+        let flags = 0;
+        if (this._visible && cfg.visible !== false) {
+            flags = flags | ENTITY_FLAGS.VISIBLE;
+        }
+        if (this._pickable && cfg.pickable !== false) {
+            flags = flags | ENTITY_FLAGS.PICKABLE;
+        }
+        if (this._culled && cfg.culled !== false) {
+            flags = flags | ENTITY_FLAGS.CULLED;
+        }
+        if (this._clippable && cfg.clippable !== false) {
+            flags = flags | ENTITY_FLAGS.CLIPPABLE;
+        }
+        if (this._collidable && cfg.collidable !== false) {
+            flags = flags | ENTITY_FLAGS.COLLIDABLE;
+        }
+        if (this._edges && cfg.edges !== false) {
+            flags = flags | ENTITY_FLAGS.EDGES;
+        }
+        if (this._xrayed && cfg.xrayed !== false) {
+            flags = flags | ENTITY_FLAGS.XRAYED;
+        }
+        if (this._highlighted && cfg.highlighted !== false) {
+            flags = flags | ENTITY_FLAGS.HIGHLIGHTED;
+        }
+        if (this._selected && cfg.selected !== false) {
+            flags = flags | ENTITY_FLAGS.SELECTED;
+        }
+
+        // Create PerformanceModelNode AABB
+        let aabb;
+        if (meshes.length === 1) {
+            aabb = meshes[0].aabb;
+        } else {
+            aabb = math.collapseAABB3();
+            for (let i = 0, len = meshes.length; i < len; i++) {
+                math.expandAABB3(aabb, meshes[i].aabb);
+            }
+        }
+
+        const node = new PerformanceNode(this, cfg.isObject, id, meshes, flags, aabb); // Internally sets PerformanceModelMesh#parent to this PerformanceModelNode
+        this._nodeList.push(node);
+        this._nodes[id] = node;
+        this.numEntities++;
+        return node;
+    }
+
+    /**
+     * Finalizes this DataTexturePeformanceModel.
+     *
+     * Immediately creates the DataTexturePeformanceModel's {@link Entity}s within the {@link Scene}.
+     *
+     * Once finalized, you can't add anything more to this DataTexturePeformanceModel.
+     */
+    finalize() {
+
+        if (this.destroyed) {
+            return;
+        }
+
+        if (this._currentDataTextureLayer) {
+            this._currentDataTextureLayer.finalize ();
+        }
+
+        for (let i = 0, len = this._nodeList.length; i < len; i++) {
+            const node = this._nodeList[i];
+            node._finalize();
+        }
+
+        for (let i = 0, len = this._nodeList.length; i < len; i++) {
+            const node = this._nodeList[i];
+            node._finalize2();
+        }
+
+
+        // Sort layers to reduce WebGL shader switching when rendering them
+
+        this._layerList.sort((a, b) => {
+            if (a.sortId < b.sortId) {
+                return -1;
+            }
+            if (a.sortId > b.sortId) {
+                return 1;
+            }
+            return 0;
+        });
+
+        for (let i = 0, len = this._layerList.length; i < len; i++) {
+            const layer = this._layerList[i];
+            layer.layerIndex = i;
+        }
+
+        this.glRedraw();
+
+        this.scene._aabbDirty = true;
+
+        this._instancingGeometries = {};
+        this._preparedInstancingGeometries = {};
+    }
+
+    _rebuildAABB() {
+        math.collapseAABB3(this._aabb);
+        for (let i = 0, len = this._nodeList.length; i < len; i++) {
+            const node = this._nodeList[i];
+            math.expandAABB3(this._aabb, node.aabb);
+        }
+        this._aabbDirty = false;
+    }
+
+    /** @private */
+    stateSortCompare(drawable1, drawable2) {
+    }
+
+    /** @private */
+    rebuildRenderFlags() {
+        this.renderFlags.reset();
+        this._updateRenderFlagsVisibleLayers();
+        if (this.renderFlags.numLayers > 0 && this.renderFlags.numVisibleLayers === 0) {
+            this.renderFlags.culled = true;
+            return;
+        }
+        this._updateRenderFlags();
+    }
+
+    /**
+     * @private
+     */
+    _updateRenderFlagsVisibleLayers() {
+        const renderFlags = this.renderFlags;
+        renderFlags.numLayers = this._layerList.length;
+        renderFlags.numVisibleLayers = 0;
+        for (let layerIndex = 0, len = this._layerList.length; layerIndex < len; layerIndex++) {
+            const layer = this._layerList[layerIndex];
+            const layerVisible = this._getActiveSectionPlanesForLayer(layer);
+            if (layerVisible) {
+                renderFlags.visibleLayers[renderFlags.numVisibleLayers++] = layerIndex;
+            }
+        }
+    }
+
+    /**
+     * This will start a "set-flags transaction" in all Layers of this Model.
+     * 
+     * @private
+     */
+    beginDeferredFlagsInAllLayers ()
+    {
+        for (let i = 0, len = this._layerList.length; i < len; i++)
+        {
+            const layer = this._layerList[i];
+
+            if (layer.beginDeferredFlags)
+            {
+                layer.beginDeferredFlags ();
+            }
+        }
+    }
+    
+    /**
+     * This will commit any previously started "set-flags transaction" in all
+     * Layers of this Model.
+     * 
+     * @private
+     */
+    commitDeferredFlagsInAllLayers ()
+    {
+        for (let i = 0, len = this._layerList.length; i < len; i++)
+        {
+            const layer = this._layerList[i];
+
+            if (layer.flushDeferredFlags)
+            {
+                layer.flushDeferredFlags ();
+            }
+        }
+    }
+
+    /** @private */
+    _getActiveSectionPlanesForLayer(layer) {
+
+        const renderFlags = this.renderFlags;
+        const sectionPlanes = this.scene._sectionPlanesState.sectionPlanes;
+        const numSectionPlanes = sectionPlanes.length;
+        const baseIndex = layer.layerIndex * numSectionPlanes;
+
+        if (numSectionPlanes > 0) {
+            for (let i = 0; i < numSectionPlanes; i++) {
+
+                const sectionPlane = sectionPlanes[i];
+
+                if (!sectionPlane.active) {
+                    renderFlags.sectionPlanesActivePerLayer[baseIndex + i] = false;
+
+                } else {
+                    renderFlags.sectionPlanesActivePerLayer[baseIndex + i] = true;
+                    renderFlags.sectioned = true;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /** @private */
+    _updateRenderFlags() {
+
+        if (this.numVisibleLayerPortions === 0) {
+            return;
+        }
+
+        if (this.numCulledLayerPortions === this.numPortions) {
+            return;
+        }
+
+        const renderFlags = this.renderFlags;
+
+        renderFlags.colorOpaque = (this.numTransparentLayerPortions < this.numPortions);
+
+        if (this.numTransparentLayerPortions > 0) {
+            renderFlags.colorTransparent = true;
+        }
+
+        if (this.numXRayedLayerPortions > 0) {
+            const xrayMaterial = this.scene.xrayMaterial._state;
+            if (xrayMaterial.fill) {
+                if (xrayMaterial.fillAlpha < 1.0) {
+                    renderFlags.xrayedSilhouetteTransparent = true;
+                } else {
+                    renderFlags.xrayedSilhouetteOpaque = true;
+                }
+            }
+            if (xrayMaterial.edges) {
+                if (xrayMaterial.edgeAlpha < 1.0) {
+                    renderFlags.xrayedEdgesTransparent = true;
+                } else {
+                    renderFlags.xrayedEdgesOpaque = true;
+                }
+            }
+        }
+
+        if (this.numEdgesLayerPortions > 0) {
+            const edgeMaterial = this.scene.edgeMaterial._state;
+            if (edgeMaterial.edges) {
+                renderFlags.edgesOpaque = (this.numTransparentLayerPortions < this.numPortions);
+                if (this.numTransparentLayerPortions > 0) {
+                    renderFlags.edgesTransparent = true;
+                }
+            }
+        }
+
+        if (this.numSelectedLayerPortions > 0) {
+            const selectedMaterial = this.scene.selectedMaterial._state;
+            if (selectedMaterial.fill) {
+                if (selectedMaterial.fillAlpha < 1.0) {
+                    renderFlags.selectedSilhouetteTransparent = true;
+                } else {
+                    renderFlags.selectedSilhouetteOpaque = true;
+                }
+            }
+            if (selectedMaterial.edges) {
+                if (selectedMaterial.edgeAlpha < 1.0) {
+                    renderFlags.selectedEdgesTransparent = true;
+                } else {
+                    renderFlags.selectedEdgesOpaque = true;
+                }
+            }
+        }
+
+        if (this.numHighlightedLayerPortions > 0) {
+            const highlightMaterial = this.scene.highlightMaterial._state;
+            if (highlightMaterial.fill) {
+                if (highlightMaterial.fillAlpha < 1.0) {
+                    renderFlags.highlightedSilhouetteTransparent = true;
+                } else {
+                    renderFlags.highlightedSilhouetteOpaque = true;
+                }
+            }
+            if (highlightMaterial.edges) {
+                if (highlightMaterial.edgeAlpha < 1.0) {
+                    renderFlags.highlightedEdgesTransparent = true;
+                } else {
+                    renderFlags.highlightedEdgesOpaque = true;
+                }
+            }
+        }
+    }
+
+    // -------------- RENDERING ---------------------------------------------------------------------------------------
+
+    /** @private */
+    drawColorOpaque(frameCtx) {
+        const renderFlags = this.renderFlags;
+        for (let i = 0, len = renderFlags.visibleLayers.length; i < len; i++) {
+            const layerIndex = renderFlags.visibleLayers[i];
+            this._layerList[layerIndex].drawColorOpaque(renderFlags, frameCtx);
+        }
+    }
+
+    /** @private */
+    drawColorTransparent(frameCtx) {
+        const renderFlags = this.renderFlags;
+        for (let i = 0, len = renderFlags.visibleLayers.length; i < len; i++) {
+            const layerIndex = renderFlags.visibleLayers[i];
+            this._layerList[layerIndex].drawColorTransparent(renderFlags, frameCtx);
+        }
+    }
+
+    /** @private */
+    drawDepth(frameCtx) { // Dedicated to SAO because it skips transparent objects
+        const renderFlags = this.renderFlags;
+        for (let i = 0, len = renderFlags.visibleLayers.length; i < len; i++) {
+            const layerIndex = renderFlags.visibleLayers[i];
+            this._layerList[layerIndex].drawDepth(renderFlags, frameCtx);
+        }
+    }
+
+    /** @private */
+    drawNormals(frameCtx) { // Dedicated to SAO because it skips transparent objects
+        const renderFlags = this.renderFlags;
+        for (let i = 0, len = renderFlags.visibleLayers.length; i < len; i++) {
+            const layerIndex = renderFlags.visibleLayers[i];
+            this._layerList[layerIndex].drawNormals(renderFlags, frameCtx);
+        }
+    }
+
+    /** @private */
+    drawSilhouetteXRayed(frameCtx) {
+        const renderFlags = this.renderFlags;
+        for (let i = 0, len = renderFlags.visibleLayers.length; i < len; i++) {
+            const layerIndex = renderFlags.visibleLayers[i];
+            this._layerList[layerIndex].drawSilhouetteXRayed(renderFlags, frameCtx);
+        }
+    }
+
+    /** @private */
+    drawSilhouetteHighlighted(frameCtx) {
+        const renderFlags = this.renderFlags;
+        for (let i = 0, len = renderFlags.visibleLayers.length; i < len; i++) {
+            const layerIndex = renderFlags.visibleLayers[i];
+            this._layerList[layerIndex].drawSilhouetteHighlighted(renderFlags, frameCtx);
+        }
+    }
+
+    /** @private */
+    drawSilhouetteSelected(frameCtx) {
+        const renderFlags = this.renderFlags;
+        for (let i = 0, len = renderFlags.visibleLayers.length; i < len; i++) {
+            const layerIndex = renderFlags.visibleLayers[i];
+            this._layerList[layerIndex].drawSilhouetteSelected(renderFlags, frameCtx);
+        }
+    }
+
+    /** @private */
+    drawEdgesColorOpaque(frameCtx) {
+        const renderFlags = this.renderFlags;
+        for (let i = 0, len = renderFlags.visibleLayers.length; i < len; i++) {
+            const layerIndex = renderFlags.visibleLayers[i];
+            this._layerList[layerIndex].drawEdgesColorOpaque(renderFlags, frameCtx);
+        }
+    }
+
+    /** @private */
+    drawEdgesColorTransparent(frameCtx) {
+        const renderFlags = this.renderFlags;
+        for (let i = 0, len = renderFlags.visibleLayers.length; i < len; i++) {
+            const layerIndex = renderFlags.visibleLayers[i];
+            this._layerList[layerIndex].drawEdgesColorTransparent(renderFlags, frameCtx);
+        }
+    }
+
+    /** @private */
+    drawEdgesXRayed(frameCtx) {
+        const renderFlags = this.renderFlags;
+        for (let i = 0, len = renderFlags.visibleLayers.length; i < len; i++) {
+            const layerIndex = renderFlags.visibleLayers[i];
+            this._layerList[layerIndex].drawEdgesXRayed(renderFlags, frameCtx);
+        }
+    }
+
+    /** @private */
+    drawEdgesHighlighted(frameCtx) {
+        const renderFlags = this.renderFlags;
+        for (let i = 0, len = renderFlags.visibleLayers.length; i < len; i++) {
+            const layerIndex = renderFlags.visibleLayers[i];
+            this._layerList[layerIndex].drawEdgesHighlighted(renderFlags, frameCtx);
+        }
+    }
+
+    /** @private */
+    drawEdgesSelected(frameCtx) {
+        const renderFlags = this.renderFlags;
+        for (let i = 0, len = renderFlags.visibleLayers.length; i < len; i++) {
+            const layerIndex = renderFlags.visibleLayers[i];
+            this._layerList[layerIndex].drawEdgesSelected(renderFlags, frameCtx);
+        }
+    }
+
+    /**
+     * @private
+     */
+    drawOcclusion(frameCtx) {
+        if (this.numVisibleLayerPortions === 0) {
+            return;
+        }
+        const renderFlags = this.renderFlags;
+        for (let i = 0, len = renderFlags.visibleLayers.length; i < len; i++) {
+            const layerIndex = renderFlags.visibleLayers[i];
+            this._layerList[layerIndex].drawOcclusion(renderFlags, frameCtx);
+        }
+    }
+
+    /**
+     * @private
+     */
+    drawShadow(frameCtx) {
+        if (this.numVisibleLayerPortions === 0) {
+            return;
+        }
+        const renderFlags = this.renderFlags;
+        for (let i = 0, len = renderFlags.visibleLayers.length; i < len; i++) {
+            const layerIndex = renderFlags.visibleLayers[i];
+            this._layerList[layerIndex].drawShadow(renderFlags, frameCtx);
+        }
+    }
+
+    /** @private */
+    drawPickMesh(frameCtx) {
+        if (this.numVisibleLayerPortions === 0) {
+            return;
+        }
+        const renderFlags = this.renderFlags;
+        for (let i = 0, len = renderFlags.visibleLayers.length; i < len; i++) {
+            const layerIndex = renderFlags.visibleLayers[i];
+            this._layerList[layerIndex].drawPickMesh(renderFlags, frameCtx);
+        }
+    }
+
+    /**
+     * Called by PerformanceMesh.drawPickDepths()
+     * @private
+     */
+    drawPickDepths(frameCtx) {
+        if (this.numVisibleLayerPortions === 0) {
+            return;
+        }
+        const renderFlags = this.renderFlags;
+        for (let i = 0, len = renderFlags.visibleLayers.length; i < len; i++) {
+            const layerIndex = renderFlags.visibleLayers[i];
+            this._layerList[layerIndex].drawPickDepths(renderFlags, frameCtx);
+        }
+    }
+
+    /**
+     * Called by PerformanceMesh.drawPickNormals()
+     * @private
+     */
+    drawPickNormals(frameCtx) {
+        if (this.numVisibleLayerPortions === 0) {
+            return;
+        }
+        const renderFlags = this.renderFlags;
+        for (let i = 0, len = renderFlags.visibleLayers.length; i < len; i++) {
+            const layerIndex = renderFlags.visibleLayers[i];
+            this._layerList[layerIndex].drawPickNormals(renderFlags, frameCtx);
+        }
+    }
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Component members
+    //------------------------------------------------------------------------------------------------------------------
+
+    /**
+     * Destroys this DataTexturePeformanceModel.
+     */
+    destroy() {
+        this.scene.camera.off(this._onCameraViewMatrix);
+        for (let i = 0, len = this._layerList.length; i < len; i++) {
+            this._layerList[i].destroy();
+        }
+        for (let i = 0, len = this._nodeList.length; i < len; i++) {
+            this._nodeList[i]._destroy();
+        }
+        this.scene._aabbDirty = true;
+        if (this._isModel) {
+            this.scene._deregisterModel(this);
+        }
+        putScratchMemory();
+        super.destroy();
+    }
+}
+
+export {DataTexturePeformanceModel};

--- a/src/viewer/scene/models/VBOSceneModel/DataTexturePeformanceModel.js
+++ b/src/viewer/scene/models/VBOSceneModel/DataTexturePeformanceModel.js
@@ -2354,10 +2354,7 @@ class DataTexturePeformanceModel extends Component {
         {
             const layer = this._layerList[i];
 
-            if (layer.beginDeferredFlags)
-            {
-                layer.beginDeferredFlags ();
-            }
+            layer.beginDeferredFlags ();
         }
     }
     
@@ -2373,10 +2370,7 @@ class DataTexturePeformanceModel extends Component {
         {
             const layer = this._layerList[i];
 
-            if (layer.flushDeferredFlags)
-            {
-                layer.flushDeferredFlags ();
-            }
+            layer.commitDeferredFlags ();
         }
     }
 

--- a/src/viewer/scene/models/VBOSceneModel/DataTexturePeformanceModel.js
+++ b/src/viewer/scene/models/VBOSceneModel/DataTexturePeformanceModel.js
@@ -1856,7 +1856,6 @@ class DataTexturePeformanceModel extends Component {
                     {
                         origin,
                         layerIndex: 0,
-                        solid: primitive !== "surface"
                     },
                     cfg
                 );
@@ -2027,9 +2026,6 @@ class DataTexturePeformanceModel extends Component {
 
                 // chipmunk: allow to have different origins per-mesh
                 origin: cfg.origin,
-
-                // chipmunk: TODO, encode as a property for each object in the per-object texture, and if needed adjust the vertices clockwise sense in the shader
-                solid: true,
             });
             this._layerList.push(layer);
             this._currentDataTextureLayer = layer;
@@ -2054,6 +2050,8 @@ class DataTexturePeformanceModel extends Component {
         const pickColor = new Uint8Array([r, g, b, a]); // Quantized pick color
 
         const aabb = math.collapseAABB3();
+
+        preparedGeometryCfg.solid = preparedGeometryCfg.primitive == "solid";
 
         if (instancing) {
 

--- a/src/viewer/scene/models/VBOSceneModel/DataTexturePeformanceModel.js
+++ b/src/viewer/scene/models/VBOSceneModel/DataTexturePeformanceModel.js
@@ -1,17 +1,17 @@
-import {Component} from "../Component.js";
-import {math} from "../math/math.js";
-import {buildEdgeIndices} from '../math/buildEdgeIndices.js';
-import {WEBGL_INFO} from '../webglInfo.js';
-import {PerformanceMesh} from './lib/PerformanceMesh.js';
-import {PerformanceNode} from './lib/PerformanceNode.js';
+import {Component} from "../../Component.js";
+import {math} from "../../math/math.js";
+import {buildEdgeIndices} from '../../math/buildEdgeIndices.js';
+import {WEBGL_INFO} from '../../webglInfo.js';
+import {VBOSceneModelMesh} from './lib/VBOSceneModelMesh.js';
+import {VBOSceneModelNode} from './lib/VBOSceneModelNode.js';
 import {getScratchMemory, putScratchMemory} from "./lib/ScratchMemory.js";
 import {prepareMeshGeometry, TrianglesDataTextureLayer} from './lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js';
 import {TrianglesInstancingLayer} from './lib/layers/trianglesInstancing/TrianglesInstancingLayer.js';
 
 import {ENTITY_FLAGS} from './lib/ENTITY_FLAGS.js';
-import {utils} from "../utils.js";
-import {RenderFlags} from "../webgl/RenderFlags.js";
-import {worldToRTCPositions} from "../math/rtcCoords.js";
+import {utils} from "../../utils.js";
+import {RenderFlags} from "../../webgl/RenderFlags.js";
+import {worldToRTCPositions} from "../../math/rtcCoords.js";
 
 import { LodCullingManager } from "./lib/layers/trianglesDataTexture/LodCullingManager.js";
 import { ViewFrustumCullingManager } from "./lib/layers/trianglesDataTexture/ViewFrustumCullingManager.js";
@@ -962,7 +962,7 @@ class DataTexturePeformanceModel extends Component {
         this._layerList = [];
 
         /**
-         * @type {Array<PerformanceNode>}
+         * @type {Array<VBOSceneModelNode>}
          */
         this._nodeList = [];
 
@@ -978,12 +978,12 @@ class DataTexturePeformanceModel extends Component {
         this._scratchMemory = getScratchMemory();
 
         /**
-         * @type {Map<string, PerformanceMesh>}
+         * @type {Map<string, VBOSceneModelMesh>}
          */
         this._meshes = {};
         
         /**
-         * @type {Map<string, PerformanceNode>}
+         * @type {Map<string, VBOSceneModelNode>}
          */
         this._nodes = {};
 
@@ -1821,6 +1821,11 @@ class DataTexturePeformanceModel extends Component {
      * be transformed relative to this origin.
      */
     createGeometry(cfg) {
+        if (cfg.positionsCompressed && !cfg.positions)
+        {
+            cfg.positions = cfg.positionsCompressed;
+        }
+
         const geometryId = cfg.id;
 
         if (geometryId === undefined || geometryId === null) {
@@ -1918,6 +1923,11 @@ class DataTexturePeformanceModel extends Component {
      * @param {Number} [cfg.opacity=1] Opacity in range ````[0..1]````.
      */
     createMesh(cfg) {
+        if (cfg.positionsCompressed && !cfg.positions)
+        {
+            cfg.positions = cfg.positionsCompressed;
+        }
+
         if (this._vfcManager && !this._vfcManager.finalized) {
             if (cfg.color) {
                 cfg.color = cfg.color.slice ();
@@ -2032,7 +2042,7 @@ class DataTexturePeformanceModel extends Component {
         const metallic = (cfg.metallic !== undefined && cfg.metallic !== null) ? Math.floor(cfg.metallic * 255) : 0;
         const roughness = (cfg.roughness !== undefined && cfg.roughness !== null) ? Math.floor(cfg.roughness * 255) : 255;
 
-        const mesh = new PerformanceMesh(this, id, color, opacity);
+        const mesh = new VBOSceneModelMesh(this, id, color, opacity);
 
         const pickId = mesh.pickId;
 
@@ -2063,6 +2073,7 @@ class DataTexturePeformanceModel extends Component {
             portionId = layer.createPortion(
                 preparedGeometryCfg,
                 {
+                    origin: cfg.origin,
                     geometryId: geometryId,
                     color: color,
                     metallic: metallic,
@@ -2274,7 +2285,7 @@ class DataTexturePeformanceModel extends Component {
             }
         }
 
-        const node = new PerformanceNode(this, cfg.isObject, id, meshes, flags, aabb); // Internally sets PerformanceModelMesh#parent to this PerformanceModelNode
+        const node = new VBOSceneModelNode(this, cfg.isObject, id, meshes, flags, aabb); // Internally sets PerformanceModelMesh#parent to this PerformanceModelNode
         this._nodeList.push(node);
         this._nodes[id] = node;
         this.numEntities++;
@@ -2687,7 +2698,7 @@ class DataTexturePeformanceModel extends Component {
     }
 
     /**
-     * Called by PerformanceMesh.drawPickDepths()
+     * Called by VBOSceneModelMesh.drawPickDepths()
      * @private
      */
     drawPickDepths(frameCtx) {
@@ -2702,7 +2713,7 @@ class DataTexturePeformanceModel extends Component {
     }
 
     /**
-     * Called by PerformanceMesh.drawPickNormals()
+     * Called by VBOSceneModelMesh.drawPickNormals()
      * @private
      */
     drawPickNormals(frameCtx) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/VBOSceneModelNode.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/VBOSceneModelNode.js
@@ -317,6 +317,14 @@ class VBOSceneModelNode {
         this.model.glRedraw();
     }
 
+    get culledLOD() {
+        return !!(this._culledLOD);
+    }
+    set culledLOD(culled) {
+        this._culledLOD = culled;
+        this.internalSetCulled ();
+    }
+
     /**
      * Gets if this VBOSceneModelNode is culled.
      *
@@ -325,7 +333,8 @@ class VBOSceneModelNode {
      * @type {Boolean}
      */
     get culled() {
-        return this._getFlag(ENTITY_FLAGS.CULLED);
+        return !!(this._culled);
+        // return this._getFlag(ENTITY_FLAGS.CULLED);
     }
 
     /**
@@ -336,6 +345,13 @@ class VBOSceneModelNode {
      * @type {Boolean}
      */
     set culled(culled) {
+        this._culled = culled;
+        this.internalSetCulled ();
+    }
+
+    internalSetCulled()
+    {
+        let culled = !!(this._culled) || !!(this._culledLOD);
         if (!!(this._flags & ENTITY_FLAGS.CULLED) === culled) {
             return; // Redundant update
         }

--- a/src/viewer/scene/models/VBOSceneModel/lib/VBOSceneModelNode.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/VBOSceneModelNode.js
@@ -73,6 +73,11 @@ class VBOSceneModelNode {
         this._colorizeUpdated = false;
         this._opacityUpdated = false;
 
+        this._culled = false;
+        this._culledVFC = false;
+        this._culledLOD = false;
+
+
         if (this._isObject) {
             model.scene._registerObject(this);
         }
@@ -317,9 +322,19 @@ class VBOSceneModelNode {
         this.model.glRedraw();
     }
 
+    get culledVFC() {
+        return !!(this._culledVFC);
+    }
+
+    set culledVFC(culled) {
+        this._culledVFC = culled;
+        this.internalSetCulled ();
+    }
+
     get culledLOD() {
         return !!(this._culledLOD);
     }
+
     set culledLOD(culled) {
         this._culledLOD = culled;
         this.internalSetCulled ();
@@ -351,7 +366,8 @@ class VBOSceneModelNode {
 
     internalSetCulled()
     {
-        let culled = !!(this._culled) || !!(this._culledLOD);
+        let culled = !!(this._culled) || !!(this._culledLOD) || !!(this._culledVFC);
+
         if (!!(this._flags & ENTITY_FLAGS.CULLED) === culled) {
             return; // Redundant update
         }

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/DataTextureState.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/DataTextureState.js
@@ -1,10 +1,9 @@
-import { createRTCViewMat } from "../../../math/rtcCoords.js";
-import { Float16Array, isFloat16Array, getFloat16, setFloat16, hfround, } from "./float16.js";
+import { createRTCViewMat } from "../../../../math/rtcCoords.js";
 
 // Imports used to complete the JSDocs arguments to methods
-import { Program } from "../../../webgl/Program.js"
-import { Camera } from "../../../camera/Camera.js"
-import { Scene } from "../../../scene/Scene.js"
+import { Program } from "../../../../webgl/Program.js"
+import { Camera } from "../../../../camera/Camera.js"
+import { Scene } from "../../../../scene/Scene.js"
 
 const identityMatrix = [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 ];
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/DataTextureState.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/DataTextureState.js
@@ -910,7 +910,7 @@ class DataTextureGenerator
 
         gl.bindTexture (gl.TEXTURE_2D, texture);
         
-        gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RGBA16F, textureWidth, textureHeight);
+        gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RGBA32F, textureWidth, textureHeight);
 
         gl.texSubImage2D(
             gl.TEXTURE_2D,

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/DataTextureState.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/DataTextureState.js
@@ -881,7 +881,7 @@ class DataTextureGenerator
         // 3 matrices per row
         const textureWidth = 4 * 3;
 
-        var texArray = new Float16Array(4 * textureWidth * textureHeight);
+        var texArray = new Float32Array(4 * textureWidth * textureHeight);
 
         dataTextureRamStats.sizeDataPositionDecodeMatrices +=texArray.byteLength;
 
@@ -920,8 +920,8 @@ class DataTextureGenerator
             textureWidth,
             textureHeight,
             gl.RGBA,
-            gl.HALF_FLOAT,
-            new Uint16Array (texArray.buffer),
+            gl.FLOAT,
+            texArray,
             0
         );
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/DataTextureState.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/DataTextureState.js
@@ -1,0 +1,1362 @@
+import { createRTCViewMat } from "../../../math/rtcCoords.js";
+import { Float16Array, isFloat16Array, getFloat16, setFloat16, hfround, } from "./float16.js";
+
+// Imports used to complete the JSDocs arguments to methods
+import { Program } from "../../../webgl/Program.js"
+import { Camera } from "../../../camera/Camera.js"
+import { Scene } from "../../../scene/Scene.js"
+
+const identityMatrix = [ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1 ];
+
+const dataTextureRamStats = {
+    sizeDataColorsAndFlags: 0,
+    sizeDataPositionDecodeMatrices: 0,
+    sizeDataTexturePositions: 0,
+    sizeDataTextureIndices: 0,
+    sizeDataTextureEdgeIndices: 0,
+    sizeDataTexturePortionIds: 0,
+    numberOfGeometries: 0,
+    numberOfPortions: 0,
+    numberOfLayers: 0,
+    totalPolygons: 0,
+    totalPolygons8Bits: 0,
+    totalPolygons16Bits: 0,
+    totalPolygons32Bits: 0,
+    totalEdges: 0,
+    totalEdges8Bits: 0,
+    totalEdges16Bits: 0,
+    totalEdges32Bits: 0,
+    cannotCreatePortion: {
+        because10BitsObjectId: 0,
+        becauseTextureSize: 0,
+    },
+    overheadSizeAlignementIndices: 0, 
+    overheadSizeAlignementEdgeIndices: 0, 
+};
+
+window.printDataTextureRamStats = function () {
+    console.log (JSON.stringify(dataTextureRamStats, null, 4));
+
+    let totalRamSize = 0;
+
+    Object.keys(dataTextureRamStats).forEach (key => {
+        if (key.startsWith ("size")) {
+            totalRamSize+=dataTextureRamStats[key];
+        }
+    });
+
+    console.log (`Total size ${totalRamSize} bytes (${(totalRamSize/1000/1000).toFixed(2)} MB)`);
+    console.log (`Avg bytes / triangle: ${(totalRamSize / dataTextureRamStats.totalPolygons).toFixed(2)}`);
+
+    let percentualRamStats = {};
+
+    Object.keys(dataTextureRamStats).forEach (key => {
+        if (key.startsWith ("size")) {
+            percentualRamStats[key] = 
+                `${(dataTextureRamStats[key] / totalRamSize * 100).toFixed(2)} % of total`;
+        }
+    });
+
+    console.log (JSON.stringify({percentualRamUsage: percentualRamStats}, null, 4));
+};
+
+class BindableDataTexture
+{
+    /**
+     * 
+     * @param {WebGL2RenderingContext} gl 
+     * @param {WebGLTexture} texture 
+     * @param {int} textureWidth 
+     * @param {int} textureHeight 
+     * @param {TypedArray} textureData 
+     */
+    constructor(gl, texture, textureWidth, textureHeight, textureData = null)
+    {
+        /**
+         * The WebGL context.
+         * 
+         * @type WebGL2RenderingContext
+         * @private
+         */
+        this._gl = gl;
+
+        /**
+         * The WebGLTexture handle.
+         * 
+         * @type {WebGLTexture}
+         * @private
+         */
+        this._texture = texture;
+
+        /**
+         * The texture width.
+         * 
+         * @type {number}
+         * @private
+         */
+        this._textureWidth = textureWidth;
+
+        /**
+         * The texture height.
+         * 
+         * @type {number}
+         * @private
+         */
+        this._textureHeight = textureHeight;
+
+         /**
+          * (nullable) When the texture data array is kept in the JS side, it will be stored here.
+          * 
+          * @type {TypedArray}
+          * @private
+          */
+        this._textureData = textureData;
+    }
+
+    /**
+     * Convenience method to be used by the renderers to bind the texture before draw calls.
+     * 
+     * @param {Program} glProgram 
+     * @param {string} shaderName The name of the shader attribute
+     * @param {number} glTextureUnit The WebGL texture unit
+     * 
+     * @returns {bool}
+     */
+    bindTexture (glProgram, shaderName, glTextureUnit) {
+        return glProgram.bindTexture (shaderName, this, glTextureUnit);
+    }
+
+    /**
+     * 
+     * Used internally by the `program` passed to `bindTexture` in order to bind the texture to an active `texture-unit`.
+     * 
+     * @param {number} unit The WebGL texture unit
+     * 
+     * @returns {bool}
+     * @private
+     */
+    bind (unit) {
+        this._gl.activeTexture(this._gl["TEXTURE" + unit]);
+        this._gl.bindTexture(this._gl.TEXTURE_2D, this._texture);
+        return true;
+    }
+
+    /**
+     * Used internally by the `program` passed to `bindTexture` in order to bind the texture to an active `texture-unit`.
+     * 
+     * @param {number} unit The WebGL texture unit
+     * @private
+     */
+    unbind (unit) {
+        // This `unbind` method is ignored at the moment to allow avoiding to rebind same texture already bound to a texture unit.
+
+        // this._gl.activeTexture(this.state.gl["TEXTURE" + unit]);
+        // this._gl.bindTexture(this.state.gl.TEXTURE_2D, null);
+    }
+}
+
+class DataTextureBuffer
+{
+    constructor ()
+    {
+        this.positions = [];
+        this.indices8Bits = [];
+        this.indices16Bits = [];
+        this.indices32Bits = [];
+        this.edgeIndices8Bits = [];
+        this.edgeIndices16Bits = [];
+        this.edgeIndices32Bits = [];
+        this.edgeIndices = [];
+        this._objectDataColors = [];
+        this._objectDataPickColors = [];
+        this._vertexBasesForObject = [];
+        this._indexBaseOffsetsForObject = [];
+        this._edgeIndexBaseOffsetsForObject = [];
+        this._objectDataPositionsMatrices = [];
+        this._objectDataInstanceGeometryMatrices = [];
+        this._objectDataInstanceNormalsMatrices = [];
+        this._portionIdForIndices8Bits = [];
+        this._portionIdForIndices16Bits = [];
+        this._portionIdForIndices32Bits = [];
+        this._portionIdForEdges8Bits = [];
+        this._portionIdForEdges16Bits = [];
+        this._portionIdForEdges32Bits = [];
+        this._portionIdFanOut = [];
+    }
+}
+
+class DataTextureState
+{
+    constructor ()
+    {
+        /**
+         * Texture that holds colors/pickColors/flags/flags2 per-object:
+         * - columns: one concept per column => color / pick-color / ...
+         * - row: the object Id
+         * 
+         * @type BindableDataTexture
+         */
+        this.texturePerObjectIdColorsAndFlags = null;
+
+        /**
+         * Texture that holds the positionsDecodeMatrix per-object:
+         * - columns: each column is one column of the matrix
+         * - row: the object Id
+         * 
+         * @type BindableDataTexture
+         */
+        this.texturePerObjectIdPositionsDecodeMatrix = null;
+
+        /**
+         * Texture that holds all the `different-vertices` used by the layer.
+         * 
+         * @type BindableDataTexture
+         */            
+        this.texturePerVertexIdCoordinates = null;
+
+        /**
+         * Texture that holds the PortionId that corresponds to a given polygon-id.
+         * 
+         * Variant of the texture for 8-bit based polygon-ids.
+         * 
+         * @type BindableDataTexture
+         */
+        this.texturePerPolygonIdPortionIds8Bits = null;
+
+        /**
+         * Texture that holds the PortionId that corresponds to a given polygon-id.
+         * 
+         * Variant of the texture for 16-bit based polygon-ids.
+         * 
+         * @type BindableDataTexture
+         */
+        this.texturePerPolygonIdPortionIds16Bits = null;
+
+        /**
+         * Texture that holds the PortionId that corresponds to a given polygon-id.
+         * 
+         * Variant of the texture for 32-bit based polygon-ids.
+         * 
+         * @type BindableDataTexture
+         */
+        this.texturePerPolygonIdPortionIds32Bits = null;
+
+        /**
+         * Texture that holds the PortionId that corresponds to a given edge-id.
+         * 
+         * Variant of the texture for 8-bit based polygon-ids.
+         * 
+         * @type BindableDataTexture
+         */
+        this.texturePerEdgeIdPortionIds8Bits = null;
+
+        /**
+         * Texture that holds the PortionId that corresponds to a given edge-id.
+         * 
+         * Variant of the texture for 16-bit based polygon-ids.
+         * 
+         * @type BindableDataTexture
+         */
+        this.texturePerEdgeIdPortionIds16Bits = null;
+
+        /**
+         * Texture that holds the PortionId that corresponds to a given edge-id.
+         * 
+         * Variant of the texture for 32-bit based polygon-ids.
+         * 
+         * @type BindableDataTexture
+         */
+        this.texturePerEdgeIdPortionIds32Bits = null;
+
+        /**
+         * Texture that holds the unique-vertex-indices for 8-bit based indices.
+         * 
+         * @type BindableDataTexture
+         */            
+        this.texturePerPolygonIdIndices8Bits = null;
+
+        /**
+         * Texture that holds the unique-vertex-indices for 16-bit based indices.
+         * 
+         * @type BindableDataTexture
+         */            
+        this.texturePerPolygonIdIndices16Bits = null;
+
+        /**
+         * Texture that holds the unique-vertex-indices for 32-bit based indices.
+         * 
+         * @type BindableDataTexture
+         */            
+        this.texturePerPolygonIdIndices32Bits = null;
+
+        /**
+         * Texture that holds the unique-vertex-indices for 8-bit based edge indices.
+         * 
+         * @type BindableDataTexture
+         */            
+        this.texturePerPolygonIdEdgeIndices8Bits = null;
+
+        /**
+         * Texture that holds the unique-vertex-indices for 16-bit based edge indices.
+         * 
+         * @type BindableDataTexture
+         */            
+        this.texturePerPolygonIdEdgeIndices16Bits = null;
+
+        /**
+         * Texture that holds the unique-vertex-indices for 32-bit based edge indices.
+         * 
+         * @type BindableDataTexture
+         */            
+        this.texturePerPolygonIdEdgeIndices32Bits = null;
+
+        /**
+         * Texture that holds the camera matrices
+         * - columns: each column in the texture is a camera matrix column.
+         * - row: each row is a different camera matrix.
+         * 
+         * @type BindableDataTexture
+         */
+        this.textureCameraMatrices = null;
+
+        /**
+         * Texture that holds the model matrices
+         * - columns: each column in the texture is a model matrix column.
+         * - row: each row is a different model matrix.
+         * 
+         * @type BindableDataTexture
+         */
+        this.textureModelMatrices = null;
+    }
+
+    finalize()
+    {
+        this.indicesPerBitnessTextures = {
+            8: this.texturePerPolygonIdIndices8Bits,
+            16: this.texturePerPolygonIdIndices16Bits,
+            32: this.texturePerPolygonIdIndices32Bits,
+        };
+
+        this.indicesPortionIdsPerBitnessTextures = {
+            8: this.texturePerPolygonIdPortionIds8Bits,
+            16: this.texturePerPolygonIdPortionIds16Bits,
+            32: this.texturePerPolygonIdPortionIds32Bits,
+        };
+
+        this.edgeIndicesPerBitnessTextures = {
+            8: this.texturePerPolygonIdEdgeIndices8Bits,
+            16: this.texturePerPolygonIdEdgeIndices16Bits,
+            32: this.texturePerPolygonIdEdgeIndices32Bits,
+        };
+
+        this.edgeIndicesPortionIdsPerBitnessTextures = {
+            8: this.texturePerEdgeIdPortionIds8Bits,
+            16: this.texturePerEdgeIdPortionIds16Bits,
+            32: this.texturePerEdgeIdPortionIds32Bits,
+        };
+    }
+
+    /**
+     * 
+     * @param {Program} glProgram 
+     * @param {string} objectMatricesTextureShaderName 
+     * @param {string} vertexTextureShaderName 
+     * @param {string} objectAttributesTextureShaderName 
+     * @param {string} cameraMatricesShaderName 
+     * @param {string} modelMatricesShaderName 
+     */
+    bindCommonTextures (
+        glProgram,
+        objectMatricesTextureShaderName,
+        vertexTextureShaderName,
+        objectAttributesTextureShaderName,
+        cameraMatricesShaderName,
+        modelMatricesShaderName
+    ) {
+        this.texturePerObjectIdPositionsDecodeMatrix.bindTexture (
+            glProgram,
+            objectMatricesTextureShaderName,
+            1 // webgl texture unit
+        );
+
+        this.texturePerVertexIdCoordinates.bindTexture (
+            glProgram,
+            vertexTextureShaderName, 
+            2 // webgl texture unit
+        );
+                
+        this.texturePerObjectIdColorsAndFlags.bindTexture (
+            glProgram,
+            objectAttributesTextureShaderName, 
+            3 // webgl texture unit
+        );
+
+        this.textureCameraMatrices.bindTexture (
+            glProgram,
+            cameraMatricesShaderName, 
+            4 // webgl texture unit
+        );
+
+        this.textureModelMatrices.bindTexture (
+            glProgram,
+            modelMatricesShaderName, 
+            5 // webgl texture unit
+        );
+    }
+
+    /**
+     * 
+     * @param {Program} glProgram 
+     * @param {string} portionIdsShaderName 
+     * @param {string} polygonIndicesShaderName 
+     * @param {8|16|32} textureBitness 
+     */
+    bindTriangleIndicesTextures (
+        glProgram,
+        portionIdsShaderName,
+        polygonIndicesShaderName,
+        textureBitness,
+    ) {
+        this.indicesPortionIdsPerBitnessTextures[textureBitness].bindTexture (
+            glProgram,
+            portionIdsShaderName, 
+            6 // webgl texture unit
+        );    
+
+        this.indicesPerBitnessTextures[textureBitness].bindTexture (
+            glProgram,
+            polygonIndicesShaderName, 
+            7 // webgl texture unit
+        );
+    }
+
+    /**
+     * 
+     * @param {Program} glProgram 
+     * @param {string} edgePortionIdsShaderName 
+     * @param {string} edgeIndicesShaderName 
+     * @param {8|16|32} textureBitness 
+     */
+    bindEdgeIndicesTextures (
+        glProgram,
+        edgePortionIdsShaderName,
+        edgeIndicesShaderName,
+        textureBitness,
+    ) {
+        this.edgeIndicesPortionIdsPerBitnessTextures[textureBitness].bindTexture (
+            glProgram,
+            edgePortionIdsShaderName, 
+            6 // webgl texture unit
+        );    
+
+        this.edgeIndicesPerBitnessTextures[textureBitness].bindTexture (
+            glProgram,
+            edgeIndicesShaderName, 
+            7 // webgl texture unit
+        );
+    }
+}
+
+class DataTextureGenerator
+{
+    /**
+     * Enables the currently binded ````WebGLTexture```` to be used as a data texture.
+     * 
+     * @param {WebGL2RenderingContext} gl
+     * 
+     * @private
+     */
+    disableBindedTextureFiltering (gl)
+    {
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    }
+
+    /**
+     * Generate and return a `camera data texture`.
+     * 
+     * The texture will automatically update its contents before each render when the camera matrix is dirty,
+     * and to do so will use the following events:
+     * 
+     * - `scene.rendering` event will be used to know that the camera texture should be updated
+     * - `camera.matrix` event will be used to know that the camera matices changed
+     * 
+     * @param {WebGL2RenderingContext} gl 
+     * @param {Camera} camera 
+     * @param {Scene} scene 
+     * @param {null|number[3]} origin 
+     * 
+     * @returns {BindableDataTexture}
+     */
+    generateCameraDataTexture (gl, camera, scene, origin)
+    {
+        const textureWidth = 4;
+        const textureHeight = 3; // space for 3 matrices
+
+        const texture = gl.createTexture();
+
+        gl.bindTexture (gl.TEXTURE_2D, texture);
+        
+        gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RGBA32F, textureWidth, textureHeight);
+
+        this.disableBindedTextureFiltering (gl);
+
+        gl.bindTexture (gl.TEXTURE_2D, null);
+
+        const cameraTexture = new BindableDataTexture(
+            gl,
+            texture,
+            textureWidth,
+            textureHeight
+        );
+
+        let cameraDirty = true;
+
+        const onCameraMatrix = () => {
+            if (!cameraDirty) {
+                return;
+            }
+
+            cameraDirty = false;
+            
+            gl.bindTexture (gl.TEXTURE_2D, cameraTexture._texture);
+
+            // Camera's "view matrix"
+            gl.texSubImage2D(
+                gl.TEXTURE_2D,
+                0,
+                0,
+                0, // 1st matrix: camera view matrix
+                4,
+                1,
+                gl.RGBA,
+                gl.FLOAT,
+                new Float32Array ((origin) ? createRTCViewMat(camera.viewMatrix, origin) : camera.viewMatrix)
+            );
+
+            // Camera's "view normal matrix"
+            gl.texSubImage2D(
+                gl.TEXTURE_2D,
+                0,
+                0,
+                1, // 2nd matrix: camera view normal matrix
+                4,
+                1,
+                gl.RGBA,
+                gl.FLOAT,
+                new Float32Array (camera.viewNormalMatrix)
+            );
+
+            // Camera's "project matrix"
+            gl.texSubImage2D(
+                gl.TEXTURE_2D,
+                0,
+                0,
+                2, // 3rd matrix: camera project matrix
+                4,
+                1,
+                gl.RGBA,
+                gl.FLOAT,
+                new Float32Array (camera.project.matrix)
+            );
+        };
+
+        camera.on ("matrix", () => cameraDirty = true);
+
+        scene.on ("rendering", onCameraMatrix);
+
+        onCameraMatrix ();
+
+        return cameraTexture;
+    }
+
+    /**
+     * Generate and return a `model data texture`.
+     *
+     * @param {WebGL2RenderingContext} gl 
+     * @param {PerformanceModel} model 
+     * 
+     * @returns {BindableDataTexture}
+    */
+    generatePeformanceModelDataTexture (gl, model)
+    {
+        const textureWidth = 4;
+        const textureHeight = 2; // space for 2 matrices
+
+        const texture = gl.createTexture();
+
+        gl.bindTexture (gl.TEXTURE_2D, texture);
+        
+        gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RGBA32F, textureWidth, textureHeight);
+
+        gl.texSubImage2D(
+            gl.TEXTURE_2D,
+            0,
+            0, // x-offset
+            0, // y-offset (model world matrix)
+            4, // data width (4x4 values)
+            1, // data height (1 matrix)
+            gl.RGBA,
+            gl.FLOAT,
+            new Float32Array (model.worldMatrix)
+        );
+        
+        gl.texSubImage2D(
+            gl.TEXTURE_2D,
+            0,
+            0, // x-offset
+            1, // y-offset (model normal matrix)
+            4, // data width (4x4 values)
+            1, // data height (1 matrix)
+            gl.RGBA,
+            gl.FLOAT,
+            new Float32Array (model.worldNormalMatrix)
+        );
+
+        this.disableBindedTextureFiltering (gl);
+
+        gl.bindTexture (gl.TEXTURE_2D, null);
+
+        return new BindableDataTexture(
+            gl,
+            texture,
+            textureWidth,
+            textureHeight
+        );
+    }
+
+    /**
+     * This will generate an RGBA texture for:
+     * - colors
+     * - pickColors
+     * - flags
+     * - flags2
+     * - vertex bases
+     * - vertex base offsets
+     * 
+     * The texture will have:
+     * - 4 RGBA columns per row: for each object (pick) color and flags(2)
+     * - N rows where N is the number of objects
+     * 
+     * @param {WebGL2RenderingContext} gl
+     * @param {ArrayLike<ArrayLike<int>>} colors Array of colors for all objects in the layer
+     * @param {ArrayLike<ArrayLike<int>>} pickColors Array of pickColors for all objects in the layer
+     * @param {ArrayLike<int>} vertexBases Array of position-index-bases foteh all objects in the layer
+     * @param {ArrayLike<int>} indexBaseOffsets For triangles: array of offests between the (gl_VertexID / 3) and the position where the indices start in the texture layer
+     * @param {ArrayLike<int>} edgeIndexBaseOffsets For edges: Array of offests between the (gl_VertexID / 2) and the position where the edge indices start in the texture layer
+     * 
+     * @returns {BindableDataTexture}
+     */
+    generateTextureForColorsAndFlags (gl, colors, pickColors, vertexBases, indexBaseOffsets, edgeIndexBaseOffsets) {
+        // The number of rows in the texture is the number of
+        // objects in the layer.
+
+        const textureHeight = colors.length;
+
+        if (textureHeight == 0)
+        {
+            throw "texture height == 0";
+        }
+
+        // 4 columns per texture row:
+        // - col0: (RGBA) object color RGBA
+        // - col1: (packed Uint32 as RGBA) object pick color
+        // - col2: (packed 4 bytes as RGBA) object flags
+        // - col3: (packed 4 bytes as RGBA) object flags2
+        // - col4: (packed Uint32 bytes as RGBA) vertex base
+        // - col5: (packed Uint32 bytes as RGBA) index base offset
+        // - col6: (packed Uint32 bytes as RGBA) edge index base offset
+        const textureWidth = 7;
+
+        const texArray = new Uint8Array (4 * textureWidth * textureHeight);
+
+        dataTextureRamStats.sizeDataColorsAndFlags +=texArray.byteLength;
+
+        for (var i = 0; i < textureHeight; i++)
+        {
+            // object color
+            texArray.set (
+                colors [i],
+                i * 28 + 0
+            );
+
+            // object pick color
+            texArray.set (
+                pickColors [i],
+                i * 28 + 4
+            );
+
+            // object flags
+            texArray.set (
+                [
+                    0, 0, 0, 0
+                ],
+                i * 28 + 8
+            );
+
+            // object flags2
+            texArray.set (
+                [
+                    0, 0, 0, 0
+                ],
+                i * 28 + 12
+            );
+
+            // vertex base
+            texArray.set (
+                [
+                    (vertexBases[i] >> 24) & 255,
+                    (vertexBases[i] >> 16) & 255,
+                    (vertexBases[i] >> 8) & 255,
+                    (vertexBases[i]) & 255,
+                ],
+                i * 28 + 16
+            );
+
+            // triangles index base offset
+            texArray.set (
+                [
+                    (indexBaseOffsets[i] >> 24) & 255,
+                    (indexBaseOffsets[i] >> 16) & 255,
+                    (indexBaseOffsets[i] >> 8) & 255,
+                    (indexBaseOffsets[i]) & 255,
+                ],
+                i * 28 + 20
+            );
+
+            // edge index base offset
+            texArray.set (
+                [
+                    (edgeIndexBaseOffsets[i] >> 24) & 255,
+                    (edgeIndexBaseOffsets[i] >> 16) & 255,
+                    (edgeIndexBaseOffsets[i] >> 8) & 255,
+                    (edgeIndexBaseOffsets[i]) & 255,
+                ],
+                i * 28 + 24
+            );
+        }
+
+        const texture = gl.createTexture();
+
+        gl.bindTexture (gl.TEXTURE_2D, texture);
+
+        gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RGBA8UI, textureWidth, textureHeight);
+
+        gl.texSubImage2D(
+            gl.TEXTURE_2D,
+            0,
+            0,
+            0,
+            textureWidth,
+            textureHeight,
+            gl.RGBA_INTEGER,
+            gl.UNSIGNED_BYTE,
+            texArray,
+            0
+        );
+
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D,gl.TEXTURE_WRAP_S,gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D,gl.TEXTURE_WRAP_T,gl.CLAMP_TO_EDGE);
+
+        gl.bindTexture(gl.TEXTURE_2D, null);
+
+        return new BindableDataTexture(
+            gl,
+            texture,
+            textureWidth,
+            textureHeight,
+            texArray
+        );
+    }
+    /**
+     * This will generate a texture for all positions decode matrices in the layer.
+     * 
+     * The texture will have:
+     * - 4 RGBA columns per row (each column will contain 4 packed half-float (16 bits) components).
+     *   Thus, each row will contain 16 packed half-floats corresponding to a complete positions decode matrix)
+     * - N rows where N is the number of objects
+     * 
+     * @param {WebGL2RenderingContext} gl
+     * @param {ArrayLike<Matrix4x4>} positionDecodeMatrices Array of positions decode matrices for all objects in the layer
+     * @param {ArrayLike<Matrix4x4>} instanceMatrices Array of geometry instancing matrices for all objects in the layer. Null if the objects are not instanced.
+     * @param {ArrayLike<Matrix4x4>} instancesNormalMatrices Array of normals instancing matrices for all objects in the layer. Null if the objects are not instanced.
+     * 
+     * @returns {BindableDataTexture}
+     */
+    generateTextureForPositionsDecodeMatrices (gl, positionDecodeMatrices, instanceMatrices, instancesNormalMatrices) {
+        const textureHeight =  positionDecodeMatrices.length;
+
+        if (textureHeight == 0)
+        {
+            throw "texture height == 0";
+        }
+
+        // 3 matrices per row
+        const textureWidth = 4 * 3;
+
+        var texArray = new Float16Array(4 * textureWidth * textureHeight);
+
+        dataTextureRamStats.sizeDataPositionDecodeMatrices +=texArray.byteLength;
+
+        for (var i = 0; i < positionDecodeMatrices.length; i++)
+        {
+            // 4x4 values
+            texArray.set (
+                positionDecodeMatrices [i],
+                i * 48
+            );
+
+            // 4x4 values
+            texArray.set (
+                instanceMatrices [i],
+                i * 48 + 16
+            );
+            
+            // 4x4 values
+            texArray.set (
+                instancesNormalMatrices [i],
+                i * 48 + 32
+            );
+        }
+
+        const texture = gl.createTexture();
+
+        gl.bindTexture (gl.TEXTURE_2D, texture);
+        
+        gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RGBA16F, textureWidth, textureHeight);
+
+        gl.texSubImage2D(
+            gl.TEXTURE_2D,
+            0,
+            0,
+            0,
+            textureWidth,
+            textureHeight,
+            gl.RGBA,
+            gl.HALF_FLOAT,
+            new Uint16Array (texArray.buffer),
+            0
+        );
+
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D,gl.TEXTURE_WRAP_S,gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D,gl.TEXTURE_WRAP_T,gl.CLAMP_TO_EDGE);
+
+        gl.bindTexture(gl.TEXTURE_2D, null);
+
+        return new BindableDataTexture(
+            gl,
+            texture,
+            textureWidth,
+            textureHeight
+        );
+    }
+
+    /**
+     * @param {WebGL2RenderingContext} gl
+     * @param {ArrayLike<int>} indices
+     * 
+     * @returns {BindableDataTexture}
+     */
+    generateTextureFor8BitIndices (gl, indices) {
+        if (indices.length == 0) {
+            return {
+                texture: null,
+                textureHeight: 0,
+            };
+        }
+
+        const textureWidth = 1024;
+        const textureHeight = Math.ceil (indices.length / 3 / textureWidth);
+
+        if (textureHeight == 0)
+        {
+            throw "texture height == 0";
+        }
+
+        const texArraySize = textureWidth * textureHeight * 3;
+        const texArray = new Uint8Array (texArraySize);
+
+        dataTextureRamStats.sizeDataTextureIndices +=texArray.byteLength;
+
+        texArray.fill(0);
+        texArray.set(indices, 0)
+
+        const texture = gl.createTexture();
+
+        gl.bindTexture (gl.TEXTURE_2D, texture);
+
+        gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RGB8UI, textureWidth, textureHeight);
+
+        gl.texSubImage2D(
+            gl.TEXTURE_2D,
+            0,
+            0,
+            0,
+            textureWidth,
+            textureHeight,
+            gl.RGB_INTEGER,
+            gl.UNSIGNED_BYTE,
+            texArray,
+            0
+        );
+
+        this.disableBindedTextureFiltering (gl);
+
+        gl.bindTexture(gl.TEXTURE_2D, null);
+
+        return new BindableDataTexture(
+            gl,
+            texture,
+            textureWidth,
+            textureHeight
+        );
+    }
+
+    /**
+     * @param {WebGL2RenderingContext} gl
+     * @param {ArrayLike<int>} indices
+     * 
+     * @returns {BindableDataTexture}
+     */
+    generateTextureFor16BitIndices (gl, indices) {
+        if (indices.length == 0) {
+            return {
+                texture: null,
+                textureHeight: 0,
+            };
+        }
+        const textureWidth = 1024;
+        const textureHeight = Math.ceil (indices.length / 3 / textureWidth);
+
+        if (textureHeight == 0)
+        {
+            throw "texture height == 0";
+        }
+
+        const texArraySize = textureWidth * textureHeight * 3;
+        const texArray = new Uint16Array (texArraySize);
+
+        dataTextureRamStats.sizeDataTextureIndices +=texArray.byteLength;
+
+        texArray.fill(0);
+        texArray.set(indices, 0)
+
+        const texture = gl.createTexture();
+
+        gl.bindTexture (gl.TEXTURE_2D, texture);
+
+        gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RGB16UI, textureWidth, textureHeight);
+
+        gl.texSubImage2D(
+            gl.TEXTURE_2D,
+            0,
+            0,
+            0,
+            textureWidth,
+            textureHeight,
+            gl.RGB_INTEGER,
+            gl.UNSIGNED_SHORT,
+            texArray,
+            0
+        );
+
+        this.disableBindedTextureFiltering (gl);
+
+        gl.bindTexture(gl.TEXTURE_2D, null);
+
+        return new BindableDataTexture(
+            gl,
+            texture,
+            textureWidth,
+            textureHeight
+        );
+    }
+
+    /**
+     * @param {WebGL2RenderingContext} gl
+     * @param {ArrayLike<int>} indices
+     * 
+     * @returns {BindableDataTexture}
+     */
+    generateTextureFor32BitIndices (gl, indices) {
+        if (indices.length == 0) {
+            return {
+                texture: null,
+                textureHeight: 0,
+            };
+        }
+
+        const textureWidth = 1024;
+        const textureHeight = Math.ceil (indices.length / 3 / textureWidth);
+
+        if (textureHeight == 0)
+        {
+            throw "texture height == 0";
+        }
+
+        const texArraySize = textureWidth * textureHeight * 3;
+        const texArray = new Uint32Array (texArraySize);
+
+        dataTextureRamStats.sizeDataTextureIndices +=texArray.byteLength;
+
+        texArray.fill(0);
+        texArray.set(indices, 0)
+
+        const texture = gl.createTexture();
+
+        gl.bindTexture (gl.TEXTURE_2D, texture);
+
+        gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RGB32UI, textureWidth, textureHeight);
+
+        gl.texSubImage2D(
+            gl.TEXTURE_2D,
+            0,
+            0,
+            0,
+            textureWidth,
+            textureHeight,
+            gl.RGB_INTEGER,
+            gl.UNSIGNED_INT,
+            texArray,
+            0
+        );
+
+        this.disableBindedTextureFiltering (gl);
+
+        gl.bindTexture(gl.TEXTURE_2D, null);
+
+        return new BindableDataTexture(
+            gl,
+            texture,
+            textureWidth,
+            textureHeight
+        );
+    }
+
+    /**
+     * @param {WebGL2RenderingContext} gl
+     * @param {ArrayLike<int>} edgeIndices
+     * 
+     * @returns {BindableDataTexture}
+     */
+    generateTextureFor8BitsEdgeIndices (gl, edgeIndices) {
+        if (edgeIndices.length == 0) {
+            return {
+                texture: null,
+                textureHeight: 0,
+            };
+        }
+
+        const textureWidth = 1024;
+        const textureHeight = Math.ceil (edgeIndices.length / 2 / textureWidth);
+
+        if (textureHeight == 0)
+        {
+            throw "texture height == 0";
+        }
+
+        const texArraySize = textureWidth * textureHeight * 2;
+        const texArray = new Uint8Array (texArraySize);
+
+        dataTextureRamStats.sizeDataTextureEdgeIndices +=texArray.byteLength;
+
+        texArray.fill(0);
+        texArray.set(edgeIndices, 0)
+
+        const texture = gl.createTexture();
+
+        gl.bindTexture (gl.TEXTURE_2D, texture);
+
+        gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RG8UI, textureWidth, textureHeight);
+
+        gl.texSubImage2D(
+            gl.TEXTURE_2D,
+            0,
+            0,
+            0,
+            textureWidth,
+            textureHeight,
+            gl.RG_INTEGER,
+            gl.UNSIGNED_BYTE,
+            texArray,
+            0
+        );
+
+        this.disableBindedTextureFiltering (gl);
+
+        gl.bindTexture(gl.TEXTURE_2D, null);
+
+        return new BindableDataTexture(
+            gl,
+            texture,
+            textureWidth,
+            textureHeight
+        );
+    }
+
+    /**
+     * @param {WebGL2RenderingContext} gl
+     * @param {ArrayLike<int>} edgeIndices
+     * 
+     * @returns {BindableDataTexture}
+     */
+    generateTextureFor16BitsEdgeIndices (gl, edgeIndices) {
+        if (edgeIndices.length == 0) {
+            return {
+                texture: null,
+                textureHeight: 0,
+            };
+        }
+
+        const textureWidth = 1024;
+        const textureHeight = Math.ceil (edgeIndices.length / 2 / textureWidth);
+
+        if (textureHeight == 0)
+        {
+            throw "texture height == 0";
+        }
+
+        const texArraySize = textureWidth * textureHeight * 2;
+        const texArray = new Uint16Array (texArraySize);
+
+        dataTextureRamStats.sizeDataTextureEdgeIndices +=texArray.byteLength;
+
+        texArray.fill(0);
+        texArray.set(edgeIndices, 0)
+
+        const texture = gl.createTexture();
+
+        gl.bindTexture (gl.TEXTURE_2D, texture);
+
+        gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RG16UI, textureWidth, textureHeight);
+
+        gl.texSubImage2D(
+            gl.TEXTURE_2D,
+            0,
+            0,
+            0,
+            textureWidth,
+            textureHeight,
+            gl.RG_INTEGER,
+            gl.UNSIGNED_SHORT,
+            texArray,
+            0
+        );
+
+        this.disableBindedTextureFiltering (gl);
+
+        gl.bindTexture(gl.TEXTURE_2D, null);
+
+        return new BindableDataTexture(
+            gl,
+            texture,
+            textureWidth,
+            textureHeight
+        );
+    }
+
+    /**
+     * @param {WebGL2RenderingContext} gl
+     * @param {ArrayLike<int>} edgeIndices
+     * 
+     * @returns {BindableDataTexture}
+     */
+    generateTextureFor32BitsEdgeIndices (gl, edgeIndices) {
+        if (edgeIndices.length == 0) {
+            return {
+                texture: null,
+                textureHeight: 0,
+            };
+        }
+
+        const textureWidth = 1024;
+        const textureHeight = Math.ceil (edgeIndices.length / 2 / textureWidth);
+
+        if (textureHeight == 0)
+        {
+            throw "texture height == 0";
+        }
+
+        const texArraySize = textureWidth * textureHeight * 2;
+        const texArray = new Uint32Array (texArraySize);
+
+        dataTextureRamStats.sizeDataTextureEdgeIndices +=texArray.byteLength;
+
+        texArray.fill(0);
+        texArray.set(edgeIndices, 0)
+
+        const texture = gl.createTexture();
+
+        gl.bindTexture (gl.TEXTURE_2D, texture);
+
+        gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RG32UI, textureWidth, textureHeight);
+
+        gl.texSubImage2D(
+            gl.TEXTURE_2D,
+            0,
+            0,
+            0,
+            textureWidth,
+            textureHeight,
+            gl.RG_INTEGER,
+            gl.UNSIGNED_INT,
+            texArray,
+            0
+        );
+
+        this.disableBindedTextureFiltering (gl);
+
+        gl.bindTexture(gl.TEXTURE_2D, null);
+
+        return new BindableDataTexture(
+            gl,
+            texture,
+            textureWidth,
+            textureHeight
+        );
+    }
+
+    /**
+     * @param {WebGL2RenderingContext} gl
+     * @param {ArrayLike<int>} positions Array of (uniquified) quantized positions in the layer
+     * 
+     * This will generate a texture for positions in the layer.
+     * 
+     * The texture will have:
+     * - 1024 columns, where each pixel will be a 16-bit-per-component RGB texture, corresponding to the XYZ of the position 
+     * - a number of rows R where R*1024 is just >= than the number of vertices (positions / 3)
+     * 
+     * @returns {BindableDataTexture}
+     */
+    generateTextureForPositions (gl, positions) {
+        const numVertices = positions.length / 3;
+        const textureWidth = 1024;
+        const textureHeight =  Math.ceil (numVertices / textureWidth);
+
+        if (textureHeight == 0)
+        {
+            throw "texture height == 0";
+        }
+
+        const texArraySize = textureWidth * textureHeight * 3;
+        const texArray = new Uint16Array (texArraySize);
+
+        dataTextureRamStats.sizeDataTexturePositions +=texArray.byteLength;
+
+        texArray.fill(0);
+
+        texArray.set (positions, 0);
+
+        const texture = gl.createTexture();
+
+        gl.bindTexture (gl.TEXTURE_2D, texture);
+
+        gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RGB16UI, textureWidth, textureHeight);
+
+        gl.texSubImage2D(
+            gl.TEXTURE_2D,
+            0,
+            0,
+            0,
+            textureWidth,
+            textureHeight,
+            gl.RGB_INTEGER,
+            gl.UNSIGNED_SHORT,
+            texArray,
+            0
+        );
+
+        gl.texParameteri(gl.TEXTURE_2D,gl.TEXTURE_MAG_FILTER,gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D,gl.TEXTURE_MIN_FILTER,gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D,gl.TEXTURE_WRAP_S,gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D,gl.TEXTURE_WRAP_T,gl.CLAMP_TO_EDGE);
+
+        gl.bindTexture(gl.TEXTURE_2D, null);
+
+        return new BindableDataTexture(
+            gl,
+            texture,
+            textureWidth,
+            textureHeight
+        );
+    }
+
+    /**
+     * @param {WebGL2RenderingContext} gl
+     * @param {ArrayLike<int>} portionIdsArray
+     * 
+     * @returns {BindableDataTexture}
+    */
+    generateTextureForPackedPortionIds (gl, portionIdsArray) {
+        if (portionIdsArray.length == 0) {
+            return {
+                texture: null,
+                textureHeight: 0,
+            };
+        }
+        const lenArray = portionIdsArray.length;
+        const textureWidth = 1024;
+        const textureHeight = Math.ceil (lenArray / textureWidth);
+
+        if (textureHeight == 0)
+        {
+            throw "texture height == 0";
+        }
+
+        const texArraySize = textureWidth * textureHeight;
+        const texArray = new Uint16Array (texArraySize);
+
+        texArray.set (
+            portionIdsArray,
+            0
+        );
+
+        dataTextureRamStats.sizeDataTexturePortionIds += texArray.byteLength;
+
+        const texture = gl.createTexture();
+
+        gl.bindTexture (gl.TEXTURE_2D, texture);
+
+        gl.texStorage2D(gl.TEXTURE_2D, 1, gl.R16UI, textureWidth, textureHeight);
+
+        gl.texSubImage2D(
+            gl.TEXTURE_2D,
+            0,
+            0,
+            0,
+            textureWidth,
+            textureHeight,
+            gl.RED_INTEGER,
+            gl.UNSIGNED_SHORT,
+            texArray,
+            0
+        );
+
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+        gl.texParameteri(gl.TEXTURE_2D,gl.TEXTURE_WRAP_S,gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D,gl.TEXTURE_WRAP_T,gl.CLAMP_TO_EDGE);
+
+        gl.bindTexture(gl.TEXTURE_2D, null);
+
+        return new BindableDataTexture(
+            gl,
+            texture,
+            textureWidth,
+            textureHeight
+        );
+    }
+}
+
+export {
+    dataTextureRamStats,
+    DataTextureState,
+    DataTextureBuffer,
+    DataTextureGenerator,
+}

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/DataTextureState.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/DataTextureState.js
@@ -865,11 +865,10 @@ class DataTextureGenerator
      * @param {WebGL2RenderingContext} gl
      * @param {ArrayLike<Matrix4x4>} positionDecodeMatrices Array of positions decode matrices for all objects in the layer
      * @param {ArrayLike<Matrix4x4>} instanceMatrices Array of geometry instancing matrices for all objects in the layer. Null if the objects are not instanced.
-     * @param {ArrayLike<Matrix4x4>} instancesNormalMatrices Array of normals instancing matrices for all objects in the layer. Null if the objects are not instanced.
      * 
      * @returns {BindableDataTexture}
      */
-    generateTextureForPositionsDecodeMatrices (gl, positionDecodeMatrices, instanceMatrices, instancesNormalMatrices) {
+    generateTextureForPositionsDecodeMatrices (gl, positionDecodeMatrices, instanceMatrices) {
         const textureHeight =  positionDecodeMatrices.length;
 
         if (textureHeight == 0)
@@ -877,8 +876,8 @@ class DataTextureGenerator
             throw "texture height == 0";
         }
 
-        // 3 matrices per row
-        const textureWidth = 4 * 3;
+        // 2 matrices per row
+        const textureWidth = 4 * 2;
 
         var texArray = new Float32Array(4 * textureWidth * textureHeight);
 
@@ -889,19 +888,13 @@ class DataTextureGenerator
             // 4x4 values
             texArray.set (
                 positionDecodeMatrices [i],
-                i * 48
+                i * 32
             );
 
             // 4x4 values
             texArray.set (
                 instanceMatrices [i],
-                i * 48 + 16
-            );
-            
-            // 4x4 values
-            texArray.set (
-                instancesNormalMatrices [i],
-                i * 48 + 32
+                i * 32 + 16
             );
         }
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/DataTextureState.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/DataTextureState.js
@@ -18,6 +18,7 @@ const dataTextureRamStats = {
     numberOfGeometries: 0,
     numberOfPortions: 0,
     numberOfLayers: 0,
+    numberOfTextures: 0, 
     totalPolygons: 0,
     totalPolygons8Bits: 0,
     totalPolygons16Bits: 0,
@@ -688,7 +689,8 @@ class DataTextureGenerator
 
         const texArray = new Uint8Array (4 * textureWidth * textureHeight);
 
-        dataTextureRamStats.sizeDataColorsAndFlags +=texArray.byteLength;
+        dataTextureRamStats.sizeDataColorsAndFlags += texArray.byteLength;
+        dataTextureRamStats.numberOfTextures++;
 
         for (var i = 0; i < textureHeight; i++)
         {
@@ -810,6 +812,7 @@ class DataTextureGenerator
         var texArray = new Float32Array(3 * textureWidth * textureHeight);
 
         dataTextureRamStats.sizeDataTextureOffsets += texArray.byteLength;
+        dataTextureRamStats.numberOfTextures++;
 
         for (var i = 0; i < offsets.length; i++)
         {
@@ -881,7 +884,8 @@ class DataTextureGenerator
 
         var texArray = new Float32Array(4 * textureWidth * textureHeight);
 
-        dataTextureRamStats.sizeDataPositionDecodeMatrices +=texArray.byteLength;
+        dataTextureRamStats.sizeDataPositionDecodeMatrices += texArray.byteLength;
+        dataTextureRamStats.numberOfTextures++;
 
         for (var i = 0; i < positionDecodeMatrices.length; i++)
         {
@@ -957,7 +961,8 @@ class DataTextureGenerator
         const texArraySize = textureWidth * textureHeight * 3;
         const texArray = new Uint8Array (texArraySize);
 
-        dataTextureRamStats.sizeDataTextureIndices +=texArray.byteLength;
+        dataTextureRamStats.sizeDataTextureIndices += texArray.byteLength;
+        dataTextureRamStats.numberOfTextures++;
 
         texArray.fill(0);
         texArray.set(indices, 0)
@@ -1017,7 +1022,8 @@ class DataTextureGenerator
         const texArraySize = textureWidth * textureHeight * 3;
         const texArray = new Uint16Array (texArraySize);
 
-        dataTextureRamStats.sizeDataTextureIndices +=texArray.byteLength;
+        dataTextureRamStats.sizeDataTextureIndices += texArray.byteLength;
+        dataTextureRamStats.numberOfTextures++;
 
         texArray.fill(0);
         texArray.set(indices, 0)
@@ -1078,7 +1084,8 @@ class DataTextureGenerator
         const texArraySize = textureWidth * textureHeight * 3;
         const texArray = new Uint32Array (texArraySize);
 
-        dataTextureRamStats.sizeDataTextureIndices +=texArray.byteLength;
+        dataTextureRamStats.sizeDataTextureIndices += texArray.byteLength;
+        dataTextureRamStats.numberOfTextures++;
 
         texArray.fill(0);
         texArray.set(indices, 0)
@@ -1139,7 +1146,8 @@ class DataTextureGenerator
         const texArraySize = textureWidth * textureHeight * 2;
         const texArray = new Uint8Array (texArraySize);
 
-        dataTextureRamStats.sizeDataTextureEdgeIndices +=texArray.byteLength;
+        dataTextureRamStats.sizeDataTextureEdgeIndices += texArray.byteLength;
+        dataTextureRamStats.numberOfTextures++;
 
         texArray.fill(0);
         texArray.set(edgeIndices, 0)
@@ -1200,7 +1208,8 @@ class DataTextureGenerator
         const texArraySize = textureWidth * textureHeight * 2;
         const texArray = new Uint16Array (texArraySize);
 
-        dataTextureRamStats.sizeDataTextureEdgeIndices +=texArray.byteLength;
+        dataTextureRamStats.sizeDataTextureEdgeIndices += texArray.byteLength;
+        dataTextureRamStats.numberOfTextures++;
 
         texArray.fill(0);
         texArray.set(edgeIndices, 0)
@@ -1261,7 +1270,8 @@ class DataTextureGenerator
         const texArraySize = textureWidth * textureHeight * 2;
         const texArray = new Uint32Array (texArraySize);
 
-        dataTextureRamStats.sizeDataTextureEdgeIndices +=texArray.byteLength;
+        dataTextureRamStats.sizeDataTextureEdgeIndices += texArray.byteLength;
+        dataTextureRamStats.numberOfTextures++;
 
         texArray.fill(0);
         texArray.set(edgeIndices, 0)
@@ -1322,7 +1332,8 @@ class DataTextureGenerator
         const texArraySize = textureWidth * textureHeight * 3;
         const texArray = new Uint16Array (texArraySize);
 
-        dataTextureRamStats.sizeDataTexturePositions +=texArray.byteLength;
+        dataTextureRamStats.sizeDataTexturePositions += texArray.byteLength;
+        dataTextureRamStats.numberOfTextures++;
 
         texArray.fill(0);
 
@@ -1393,6 +1404,7 @@ class DataTextureGenerator
         );
 
         dataTextureRamStats.sizeDataTexturePortionIds += texArray.byteLength;
+        dataTextureRamStats.numberOfTextures++;
 
         const texture = gl.createTexture();
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/DataTextureState.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/DataTextureState.js
@@ -677,8 +677,6 @@ class DataTextureGenerator
         const textureWidth = 512 * 7;
         const textureHeight =  Math.ceil (numPortions / (textureWidth / 7));
 
-        console.log ({textureWidth, textureHeight, numPortions});
-
         if (textureHeight == 0)
         {
             throw "texture height == 0";

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/DataTextureState.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/DataTextureState.js
@@ -667,17 +667,24 @@ class DataTextureGenerator
      * @returns {BindableDataTexture}
      */
     generateTextureForColorsAndFlags (gl, colors, pickColors, vertexBases, indexBaseOffsets, edgeIndexBaseOffsets) {
+        const numPortions = colors.length;
+
         // The number of rows in the texture is the number of
         // objects in the layer.
 
-        const textureHeight = colors.length;
+        this.numPortions = numPortions;
+
+        const textureWidth = 512 * 7;
+        const textureHeight =  Math.ceil (numPortions / (textureWidth / 7));
+
+        console.log ({textureWidth, textureHeight, numPortions});
 
         if (textureHeight == 0)
         {
             throw "texture height == 0";
         }
 
-        // 4 columns per texture row:
+        // 7 columns per texture row:
         // - col0: (RGBA) object color RGBA
         // - col1: (packed Uint32 as RGBA) object pick color
         // - col2: (packed 4 bytes as RGBA) object flags
@@ -685,14 +692,13 @@ class DataTextureGenerator
         // - col4: (packed Uint32 bytes as RGBA) vertex base
         // - col5: (packed Uint32 bytes as RGBA) index base offset
         // - col6: (packed Uint32 bytes as RGBA) edge index base offset
-        const textureWidth = 7;
 
         const texArray = new Uint8Array (4 * textureWidth * textureHeight);
 
         dataTextureRamStats.sizeDataColorsAndFlags += texArray.byteLength;
         dataTextureRamStats.numberOfTextures++;
 
-        for (var i = 0; i < textureHeight; i++)
+        for (let i = 0; i < numPortions; i++)
         {
             // object color
             texArray.set (

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/DataTextureState.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/DataTextureState.js
@@ -803,29 +803,20 @@ class DataTextureGenerator
      * 
      * @returns {BindableDataTexture}
      */
-    generateTextureForObjectOffsets (gl, offsets) {
-        const textureHeight =  offsets.length;
+    generateTextureForObjectOffsets (gl, numOffsets) {
+        const textureWidth = 512;
+        const textureHeight = Math.ceil (numOffsets / textureWidth);
 
         if (textureHeight == 0)
         {
             throw "texture height == 0";
         }
 
-        const textureWidth = 1;
-
-        var texArray = new Float32Array(3 * textureWidth * textureHeight);
+        var texArray = new Float32Array(3 * textureWidth * textureHeight).fill(0);
 
         dataTextureRamStats.sizeDataTextureOffsets += texArray.byteLength;
         dataTextureRamStats.numberOfTextures++;
 
-        for (var i = 0; i < offsets.length; i++)
-        {
-            // object offset
-            texArray.set (
-                offsets [i],
-                i * 3
-            );
-        }
 
         const texture = gl.createTexture();
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/DataTextureState.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/DataTextureState.js
@@ -876,15 +876,16 @@ class DataTextureGenerator
      * @returns {BindableDataTexture}
      */
     generateTextureForPositionsDecodeMatrices (gl, positionDecodeMatrices, instanceMatrices) {
-        const textureHeight =  positionDecodeMatrices.length;
+        const numMatrices = positionDecodeMatrices.length;
 
-        if (textureHeight == 0)
+        if (numMatrices == 0)
         {
-            throw "texture height == 0";
+            throw "num decode+entity matrices == 0";
         }
 
-        // 2 matrices per row
-        const textureWidth = 4 * 2;
+        // in one row we can fit 512 matrices        
+        const textureWidth = 512 * 8;
+        const textureHeight =  Math.ceil (numMatrices / (textureWidth / 8));
 
         var texArray = new Float32Array(4 * textureWidth * textureHeight);
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/DataTextureState.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/DataTextureState.js
@@ -950,7 +950,7 @@ class DataTextureGenerator
             };
         }
 
-        const textureWidth = 1024;
+        const textureWidth = 4096;
         const textureHeight = Math.ceil (indices.length / 3 / textureWidth);
 
         if (textureHeight == 0)
@@ -1011,7 +1011,7 @@ class DataTextureGenerator
                 textureHeight: 0,
             };
         }
-        const textureWidth = 1024;
+        const textureWidth = 4096;
         const textureHeight = Math.ceil (indices.length / 3 / textureWidth);
 
         if (textureHeight == 0)
@@ -1073,7 +1073,7 @@ class DataTextureGenerator
             };
         }
 
-        const textureWidth = 1024;
+        const textureWidth = 4096;
         const textureHeight = Math.ceil (indices.length / 3 / textureWidth);
 
         if (textureHeight == 0)
@@ -1135,7 +1135,7 @@ class DataTextureGenerator
             };
         }
 
-        const textureWidth = 1024;
+        const textureWidth = 4096;
         const textureHeight = Math.ceil (edgeIndices.length / 2 / textureWidth);
 
         if (textureHeight == 0)
@@ -1197,7 +1197,7 @@ class DataTextureGenerator
             };
         }
 
-        const textureWidth = 1024;
+        const textureWidth = 4096;
         const textureHeight = Math.ceil (edgeIndices.length / 2 / textureWidth);
 
         if (textureHeight == 0)
@@ -1259,7 +1259,7 @@ class DataTextureGenerator
             };
         }
 
-        const textureWidth = 1024;
+        const textureWidth = 4096;
         const textureHeight = Math.ceil (edgeIndices.length / 2 / textureWidth);
 
         if (textureHeight == 0)
@@ -1321,7 +1321,7 @@ class DataTextureGenerator
      */
     generateTextureForPositions (gl, positions) {
         const numVertices = positions.length / 3;
-        const textureWidth = 1024;
+        const textureWidth = 4096;
         const textureHeight =  Math.ceil (numVertices / textureWidth);
 
         if (textureHeight == 0)
@@ -1387,7 +1387,7 @@ class DataTextureGenerator
             };
         }
         const lenArray = portionIdsArray.length;
-        const textureWidth = 1024;
+        const textureWidth = 4096;
         const textureHeight = Math.ceil (lenArray / textureWidth);
 
         if (textureHeight == 0)

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/float16.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/float16.js
@@ -1,0 +1,760 @@
+/**
+ * Bundled by jsDelivr using Rollup v2.59.0 and Terser v5.9.0.
+ * Original file: /npm/@petamoriken/float16@3.5.11/src/index.mjs
+ *
+ * Do NOT use SRI with dynamically generated files! More information: https://www.jsdelivr.com/using-sri-with-dynamic-files
+ */
+function t(t)
+{
+    return (r, ...e) => n(t, r, e)
+}
+
+function r(r, n)
+{
+    return t(s(r, n).get)
+}
+const
+{
+    apply: n,
+    construct: e,
+    defineProperty: o,
+    get: i,
+    getOwnPropertyDescriptor: s,
+    getPrototypeOf: c,
+    has: u,
+    ownKeys: f,
+    set: h,
+    setPrototypeOf: l
+} = Reflect, a = Proxy, y = Number,
+{
+    isFinite: p,
+    isNaN: w
+} = y,
+{
+    iterator: g,
+    species: d,
+    toStringTag: v,
+    for: b
+} = Symbol, A = Object,
+{
+    create: m,
+    defineProperty: B,
+    freeze: x,
+    is: E
+} = A, T = A.prototype, O = t(T.isPrototypeOf), j = A.hasOwn || t(T.hasOwnProperty), I = Array, P = I.isArray, S = I.prototype, _ = t(S.join), F = t(S.push), L = t(S.toLocaleString), R = S[g], C = t(R), N = Math.trunc, U = ArrayBuffer, M = U.isView, D = t(U.prototype.slice), k = r(U.prototype, "byteLength"), W = "undefined" != typeof SharedArrayBuffer ? SharedArrayBuffer : null, V = W && r(W.prototype, "byteLength"), Y = c(Uint8Array), z = Y.from, G = Y.prototype, K = G[g], X = t(G.keys), q = t(G.values), H = t(G.entries), J = t(G.set), Q = t(G.reverse), Z = t(G.fill), $ = t(G.copyWithin), tt = t(G.sort), rt = t(G.slice), nt = t(G.subarray), et = r(G, "buffer"), ot = r(G, "byteOffset"), it = r(G, "length"), st = r(G, v), ct = Uint16Array, ut = (...t) => n(z, ct, t), ft = Uint32Array, ht = Float32Array, lt = c([][g]()), at = t(lt.next), yt = t(function*() {}().next), pt = c(lt), wt = DataView.prototype, gt = t(wt.getUint16), dt = t(wt.setUint16), vt = TypeError, bt = RangeError, At = Set, mt = At.prototype, Bt = t(mt.add), xt = t(mt.has), Et = WeakMap, Tt = Et.prototype, Ot = t(Tt.get), jt = t(Tt.has), It = t(Tt.set), Pt = new U(4), St = new ht(Pt), _t = new ft(Pt), Ft = new ft(512), Lt = new ft(512);
+for (let t = 0; t < 256; ++t)
+{
+    const r = t - 127;
+    r < -27 ? (Ft[t] = 0, Ft[256 | t] = 32768, Lt[t] = 24, Lt[256 | t] = 24) : r < -14 ? (Ft[t] = 1024 >> -r - 14, Ft[256 | t] = 1024 >> -r - 14 | 32768, Lt[t] = -r - 1, Lt[256 | t] = -r - 1) : r <= 15 ? (Ft[t] = r + 15 << 10, Ft[256 | t] = r + 15 << 10 | 32768, Lt[t] = 13, Lt[256 | t] = 13) : r < 128 ? (Ft[t] = 31744, Ft[256 | t] = 64512, Lt[t] = 24, Lt[256 | t] = 24) : (Ft[t] = 31744, Ft[256 | t] = 64512, Lt[t] = 13, Lt[256 | t] = 13)
+}
+
+function Rt(t)
+{
+    St[0] = t;
+    const r = _t[0],
+        n = r >> 23 & 511;
+    return Ft[n] + ((8388607 & r) >> Lt[n])
+}
+const Ct = new ft(2048),
+    Nt = new ft(64),
+    Ut = new ft(64);
+Ct[0] = 0;
+for (let t = 1; t < 1024; ++t)
+{
+    let r = t << 13,
+        n = 0;
+    for (; 0 == (8388608 & r);) n -= 8388608, r <<= 1;
+    r &= -8388609, n += 947912704, Ct[t] = r | n
+}
+for (let t = 1024; t < 2048; ++t) Ct[t] = 939524096 + (t - 1024 << 13);
+Nt[0] = 0;
+for (let t = 1; t < 31; ++t) Nt[t] = t << 23;
+Nt[31] = 1199570944, Nt[32] = 2147483648;
+for (let t = 33; t < 63; ++t) Nt[t] = 2147483648 + (t - 32 << 23);
+Nt[63] = 3347054592, Ut[0] = 0;
+for (let t = 1; t < 64; ++t) Ut[t] = 32 === t ? 0 : 1024;
+
+function Mt(t)
+{
+    const r = t >> 10;
+    return _t[0] = Ct[Ut[r] + (1023 & t)] + Nt[r], St[0]
+}
+
+function Dt(t)
+{
+    if ("bigint" == typeof t) throw vt("Cannot convert a BigInt value to a number");
+    if (t = y(t), !p(t) || 0 === t) return t;
+    return Mt(Rt(t))
+}
+
+function kt(t)
+{
+    if (t[g] === R) return t;
+    const r = C(t);
+    return m(null,
+    {
+        next:
+        {
+            value: function()
+            {
+                return at(r)
+            }
+        },
+        [g]:
+        {
+            value: function()
+            {
+                return this
+            }
+        }
+    })
+}
+const Wt = new Et,
+    Vt = m(pt,
+    {
+        next:
+        {
+            value: function()
+            {
+                const t = Ot(Wt, this);
+                return yt(t)
+            },
+            writable: !0,
+            configurable: !0
+        },
+        [v]:
+        {
+            value: "Array Iterator",
+            configurable: !0
+        }
+    });
+
+function Yt(t)
+{
+    const r = m(Vt);
+    return It(Wt, r, t), r
+}
+
+function zt(t)
+{
+    return null !== t && "object" == typeof t || "function" == typeof t
+}
+
+function Gt(t)
+{
+    return null !== t && "object" == typeof t
+}
+
+function Kt(t)
+{
+    return void 0 !== st(t)
+}
+
+function Xt(t)
+{
+    const r = st(t);
+    return "BigInt64Array" === r || "BigUint64Array" === r
+}
+
+function qt(t)
+{
+    if (null === W) return !1;
+    try
+    {
+        return V(t), !0
+    }
+    catch (t)
+    {
+        return !1
+    }
+}
+
+function Ht(t)
+{
+    if (!P(t)) return !1;
+    if (t[g] === R) return !0;
+    return "Array Iterator" === t[g]()[v]
+}
+
+function Jt(t)
+{
+    if ("string" != typeof t) return !1;
+    const r = y(t);
+    return t === r + "" && (!!p(r) && r === N(r))
+}
+const Qt = y.MAX_SAFE_INTEGER;
+
+function Zt(t)
+{
+    if ("bigint" == typeof t) throw vt("Cannot convert a BigInt value to a number");
+    const r = y(t);
+    return w(r) || 0 === r ? 0 : N(r)
+}
+
+function $t(t)
+{
+    const r = Zt(t);
+    return r < 0 ? 0 : r < Qt ? r : Qt
+}
+
+function tr(t, r)
+{
+    if (!zt(t)) throw vt("This is not an object");
+    const n = t.constructor;
+    if (void 0 === n) return r;
+    if (!zt(n)) throw vt("The constructor property value is not an object");
+    const e = n[d];
+    return null == e ? r : e
+}
+
+function rr(t)
+{
+    if (qt(t)) return !1;
+    try
+    {
+        return D(t, 0, 0), !1
+    }
+    catch (t)
+    {}
+    return !0
+}
+
+function nr(t, r)
+{
+    const n = w(t),
+        e = w(r);
+    if (n && e) return 0;
+    if (n) return 1;
+    if (e) return -1;
+    if (t < r) return -1;
+    if (t > r) return 1;
+    if (0 === t && 0 === r)
+    {
+        const n = E(t, 0),
+            e = E(r, 0);
+        if (!n && e) return -1;
+        if (n && !e) return 1
+    }
+    return 0
+}
+const er = b("__Float16Array__"),
+    or = new Et;
+
+function ir(t)
+{
+    return jt(or, t) || !M(t) && function(t)
+    {
+        if (!Gt(t)) return !1;
+        const r = c(t);
+        if (!Gt(r)) return !1;
+        const n = r.constructor;
+        if (void 0 === n) return !1;
+        if (!zt(n)) throw vt("The constructor property value is not an object");
+        return u(n, er)
+    }(t)
+}
+
+function sr(t)
+{
+    if (!ir(t)) throw vt("This is not a Float16Array object")
+}
+
+function cr(t, r)
+{
+    const n = ir(t),
+        e = Kt(t);
+    if (!n && !e) throw vt("Species constructor didn't return TypedArray object");
+    if ("number" == typeof r)
+    {
+        let e;
+        if (n)
+        {
+            const r = ur(t);
+            e = it(r)
+        }
+        else e = it(t);
+        if (e < r) throw vt("Derived constructor created TypedArray object which was too small length")
+    }
+    if (Xt(t)) throw vt("Cannot mix BigInt and other types, use explicit conversions")
+}
+
+function ur(t)
+{
+    const r = Ot(or, t);
+    if (void 0 !== r)
+    {
+        if (rr(et(r))) throw vt("Attempting to access detached ArrayBuffer");
+        return r
+    }
+    const n = t.buffer;
+    if (rr(n)) throw vt("Attempting to access detached ArrayBuffer");
+    const o = e(ar, [n, t.byteOffset, t.length], t.constructor);
+    return Ot(or, o)
+}
+
+function fr(t)
+{
+    const r = it(t),
+        n = [];
+    for (let e = 0; e < r; ++e) n[e] = Mt(t[e]);
+    return n
+}
+const hr = new At;
+for (const t of f(G))
+{
+    if (t === v) continue;
+    const r = s(G, t);
+    j(r, "get") && Bt(hr, t)
+}
+const lr = x(
+{
+    get: (t, r, n) => Jt(r) && j(t, r) ? Mt(i(t, r)) : xt(hr, r) && O(G, t) ? i(t, r) : i(t, r, n),
+    set: (t, r, n, e) => Jt(r) && j(t, r) ? h(t, r, Rt(n)) : h(t, r, n, e),
+    getOwnPropertyDescriptor(t, r)
+    {
+        if (Jt(r) && j(t, r))
+        {
+            const n = s(t, r);
+            return n.value = Mt(n.value), n
+        }
+        return s(t, r)
+    },
+    defineProperty: (t, r, n) => Jt(r) && j(t, r) && j(n, "value") ? (n.value = Rt(n.value), o(t, r, n)) : o(t, r, n)
+});
+class ar
+{
+    constructor(t, r, n)
+    {
+        let o;
+        if (ir(t)) o = e(ct, [ur(t)], new.target);
+        else if (zt(t) && ! function(t)
+            {
+                try
+                {
+                    return k(t), !0
+                }
+                catch (t)
+                {
+                    return !1
+                }
+            }(t))
+        {
+            let r, n;
+            if (Kt(t))
+            {
+                r = t, n = it(t);
+                const i = et(t),
+                    s = qt(i) ? U : tr(i, U);
+                if (rr(i)) throw vt("Attempting to access detached ArrayBuffer");
+                if (Xt(t)) throw vt("Cannot mix BigInt and other types, use explicit conversions");
+                const c = new s(2 * n);
+                o = e(ct, [c], new.target)
+            }
+            else
+            {
+                const i = t[g];
+                if (null != i && "function" != typeof i) throw vt("@@iterator property is not callable");
+                null != i ? Ht(t) ? (r = t, n = t.length) : (r = [...t], n = r.length) : (r = t, n = $t(r.length)), o = e(ct, [n], new.target)
+            }
+            for (let t = 0; t < n; ++t) o[t] = Rt(r[t])
+        }
+        else o = e(ct, arguments, new.target);
+        const i = new a(o, lr);
+        return It(or, i, o), i
+    }
+    static from(t, ...r)
+    {
+        const e = this;
+        if (!u(e, er)) throw vt("This constructor is not a subclass of Float16Array");
+        if (e === ar)
+        {
+            if (ir(t) && 0 === r.length)
+            {
+                const r = ur(t),
+                    n = new ct(et(r), ot(r), it(r));
+                return new ar(et(rt(n)))
+            }
+            if (0 === r.length) return new ar(et(ut(t, Rt)));
+            const e = r[0],
+                o = r[1];
+            return new ar(et(ut(t, (function(t, ...r)
+            {
+                return Rt(n(e, this, [t, ...kt(r)]))
+            }), o)))
+        }
+        let o, i;
+        const s = t[g];
+        if (null != s && "function" != typeof s) throw vt("@@iterator property is not callable");
+        if (null != s) Ht(t) ? (o = t, i = t.length) : !Kt(c = t) || c[g] !== K && "Array Iterator" !== c[g]()[v] ? (o = [...t], i = o.length) : (o = t, i = it(t));
+        else
+        {
+            if (null == t) throw vt("Cannot convert undefined or null to object");
+            o = A(t), i = $t(o.length)
+        }
+        var c;
+        const f = new e(i);
+        if (0 === r.length)
+            for (let t = 0; t < i; ++t) f[t] = o[t];
+        else
+        {
+            const t = r[0],
+                e = r[1];
+            for (let r = 0; r < i; ++r) f[r] = n(t, e, [o[r], r])
+        }
+        return f
+    }
+    static of(...t)
+    {
+        const r = this;
+        if (!u(r, er)) throw vt("This constructor is not a subclass of Float16Array");
+        const n = t.length;
+        if (r === ar)
+        {
+            const r = new ar(n),
+                e = ur(r);
+            for (let r = 0; r < n; ++r) e[r] = Rt(t[r]);
+            return r
+        }
+        const e = new r(n);
+        for (let r = 0; r < n; ++r) e[r] = t[r];
+        return e
+    }
+    keys()
+    {
+        sr(this);
+        const t = ur(this);
+        return X(t)
+    }
+    values()
+    {
+        sr(this);
+        const t = ur(this);
+        return Yt(function*()
+        {
+            for (const r of q(t)) yield Mt(r)
+        }())
+    }
+    entries()
+    {
+        sr(this);
+        const t = ur(this);
+        return Yt(function*()
+        {
+            for (const [r, n] of H(t)) yield [r, Mt(n)]
+        }())
+    }
+    at(t)
+    {
+        sr(this);
+        const r = ur(this),
+            n = it(r),
+            e = Zt(t),
+            o = e >= 0 ? e : n + e;
+        if (!(o < 0 || o >= n)) return Mt(r[o])
+    }
+    map(t, ...r)
+    {
+        sr(this);
+        const e = ur(this),
+            o = it(e),
+            i = r[0],
+            s = tr(e, ar);
+        if (s === ar)
+        {
+            const r = new ar(o),
+                s = ur(r);
+            for (let r = 0; r < o; ++r)
+            {
+                const o = Mt(e[r]);
+                s[r] = Rt(n(t, i, [o, r, this]))
+            }
+            return r
+        }
+        const c = new s(o);
+        cr(c, o);
+        for (let r = 0; r < o; ++r)
+        {
+            const o = Mt(e[r]);
+            c[r] = n(t, i, [o, r, this])
+        }
+        return c
+    }
+    filter(t, ...r)
+    {
+        sr(this);
+        const e = ur(this),
+            o = it(e),
+            i = r[0],
+            s = [];
+        for (let r = 0; r < o; ++r)
+        {
+            const o = Mt(e[r]);
+            n(t, i, [o, r, this]) && F(s, o)
+        }
+        const c = new(tr(e, ar))(s);
+        return cr(c), c
+    }
+    reduce(t, ...r)
+    {
+        sr(this);
+        const n = ur(this),
+            e = it(n);
+        if (0 === e && 0 === r.length) throw vt("Reduce of empty array with no initial value");
+        let o, i;
+        0 === r.length ? (o = Mt(n[0]), i = 1) : (o = r[0], i = 0);
+        for (let r = i; r < e; ++r) o = t(o, Mt(n[r]), r, this);
+        return o
+    }
+    reduceRight(t, ...r)
+    {
+        sr(this);
+        const n = ur(this),
+            e = it(n);
+        if (0 === e && 0 === r.length) throw vt("Reduce of empty array with no initial value");
+        let o, i;
+        0 === r.length ? (o = Mt(n[e - 1]), i = e - 2) : (o = r[0], i = e - 1);
+        for (let r = i; r >= 0; --r) o = t(o, Mt(n[r]), r, this);
+        return o
+    }
+    forEach(t, ...r)
+    {
+        sr(this);
+        const e = ur(this),
+            o = it(e),
+            i = r[0];
+        for (let r = 0; r < o; ++r) n(t, i, [Mt(e[r]), r, this])
+    }
+    find(t, ...r)
+    {
+        sr(this);
+        const e = ur(this),
+            o = it(e),
+            i = r[0];
+        for (let r = 0; r < o; ++r)
+        {
+            const o = Mt(e[r]);
+            if (n(t, i, [o, r, this])) return o
+        }
+    }
+    findIndex(t, ...r)
+    {
+        sr(this);
+        const e = ur(this),
+            o = it(e),
+            i = r[0];
+        for (let r = 0; r < o; ++r)
+        {
+            const o = Mt(e[r]);
+            if (n(t, i, [o, r, this])) return r
+        }
+        return -1
+    }
+    findLast(t, ...r)
+    {
+        sr(this);
+        const e = ur(this),
+            o = it(e),
+            i = r[0];
+        for (let r = o - 1; r >= 0; --r)
+        {
+            const o = Mt(e[r]);
+            if (n(t, i, [o, r, this])) return o
+        }
+    }
+    findLastIndex(t, ...r)
+    {
+        sr(this);
+        const e = ur(this),
+            o = it(e),
+            i = r[0];
+        for (let r = o - 1; r >= 0; --r)
+        {
+            const o = Mt(e[r]);
+            if (n(t, i, [o, r, this])) return r
+        }
+        return -1
+    }
+    every(t, ...r)
+    {
+        sr(this);
+        const e = ur(this),
+            o = it(e),
+            i = r[0];
+        for (let r = 0; r < o; ++r)
+            if (!n(t, i, [Mt(e[r]), r, this])) return !1;
+        return !0
+    }
+    some(t, ...r)
+    {
+        sr(this);
+        const e = ur(this),
+            o = it(e),
+            i = r[0];
+        for (let r = 0; r < o; ++r)
+            if (n(t, i, [Mt(e[r]), r, this])) return !0;
+        return !1
+    }
+    set(t, ...r)
+    {
+        sr(this);
+        const n = ur(this),
+            e = Zt(r[0]);
+        if (e < 0) throw bt("Offset is out of bounds");
+        if (null == t) throw vt("Cannot convert undefined or null to object");
+        if (Xt(t)) throw vt("Cannot mix BigInt and other types, use explicit conversions");
+        if (ir(t)) return J(ur(this), ur(t), e);
+        if (Kt(t))
+        {
+            if (rr(et(t))) throw vt("Attempting to access detached ArrayBuffer")
+        }
+        const o = it(n),
+            i = A(t),
+            s = $t(i.length);
+        if (e === 1 / 0 || s + e > o) throw bt("Offset is out of bounds");
+        for (let t = 0; t < s; ++t) n[t + e] = Rt(i[t])
+    }
+    reverse()
+    {
+        sr(this);
+        const t = ur(this);
+        return Q(t), this
+    }
+    fill(t, ...r)
+    {
+        sr(this);
+        const n = ur(this);
+        return Z(n, Rt(t), ...kt(r)), this
+    }
+    copyWithin(t, r, ...n)
+    {
+        sr(this);
+        const e = ur(this);
+        return $(e, t, r, ...kt(n)), this
+    }
+    sort(...t)
+    {
+        sr(this);
+        const r = ur(this),
+            n = void 0 !== t[0] ? t[0] : nr;
+        return tt(r, ((t, r) => n(Mt(t), Mt(r)))), this
+    }
+    slice(...t)
+    {
+        sr(this);
+        const r = ur(this),
+            n = tr(r, ar);
+        if (n === ar)
+        {
+            const n = new ct(et(r), ot(r), it(r));
+            return new ar(et(rt(n, ...kt(t))))
+        }
+        const e = it(r),
+            o = Zt(t[0]),
+            i = void 0 === t[1] ? e : Zt(t[1]);
+        let s, c;
+        s = o === -1 / 0 ? 0 : o < 0 ? e + o > 0 ? e + o : 0 : e < o ? e : o, c = i === -1 / 0 ? 0 : i < 0 ? e + i > 0 ? e + i : 0 : e < i ? e : i;
+        const u = c - s > 0 ? c - s : 0,
+            f = new n(u);
+        if (cr(f, u), 0 === u) return f;
+        if (rr(et(r))) throw vt("Attempting to access detached ArrayBuffer");
+        let h = 0;
+        for (; s < c;) f[h] = Mt(r[s]), ++s, ++h;
+        return f
+    }
+    subarray(...t)
+    {
+        sr(this);
+        const r = ur(this),
+            n = tr(r, ar),
+            e = new ct(et(r), ot(r), it(r)),
+            o = nt(e, ...kt(t)),
+            i = new n(et(o), ot(o), it(o));
+        return cr(i), i
+    }
+    indexOf(t, ...r)
+    {
+        sr(this);
+        const n = ur(this),
+            e = it(n);
+        let o = Zt(r[0]);
+        if (o === 1 / 0) return -1;
+        o < 0 && (o += e, o < 0 && (o = 0));
+        for (let r = o; r < e; ++r)
+            if (j(n, r) && Mt(n[r]) === t) return r;
+        return -1
+    }
+    lastIndexOf(t, ...r)
+    {
+        sr(this);
+        const n = ur(this),
+            e = it(n);
+        let o = r.length >= 1 ? Zt(r[0]) : e - 1;
+        if (o === -1 / 0) return -1;
+        o >= 0 ? o = o < e - 1 ? o : e - 1 : o += e;
+        for (let r = o; r >= 0; --r)
+            if (j(n, r) && Mt(n[r]) === t) return r;
+        return -1
+    }
+    includes(t, ...r)
+    {
+        sr(this);
+        const n = ur(this),
+            e = it(n);
+        let o = Zt(r[0]);
+        if (o === 1 / 0) return !1;
+        o < 0 && (o += e, o < 0 && (o = 0));
+        const i = w(t);
+        for (let r = o; r < e; ++r)
+        {
+            const e = Mt(n[r]);
+            if (i && w(e)) return !0;
+            if (e === t) return !0
+        }
+        return !1
+    }
+    join(...t)
+    {
+        sr(this);
+        const r = fr(ur(this));
+        return _(r, ...kt(t))
+    }
+    toLocaleString(...t)
+    {
+        sr(this);
+        const r = fr(ur(this));
+        return L(r, ...kt(t))
+    }
+    get[v]()
+    {
+        if (ir(this)) return "Float16Array"
+    }
+}
+B(ar, "BYTES_PER_ELEMENT",
+{
+    value: 2
+}), B(ar, er,
+{}), l(ar, Y);
+const yr = ar.prototype;
+
+function pr(t, r, ...n)
+{
+    return Mt(gt(t, r, ...kt(n)))
+}
+
+function wr(t, r, n, ...e)
+{
+    return dt(t, r, Rt(n), ...kt(e))
+}
+B(yr, "BYTES_PER_ELEMENT",
+{
+    value: 2
+}), B(yr, g,
+{
+    value: yr.values,
+    writable: !0,
+    configurable: !0
+}), l(yr, G);
+export
+{
+    ar as Float16Array, pr as getFloat16, Dt as hfround, ir as isFloat16Array, wr as setFloat16
+};

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/LodCullingManager.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/LodCullingManager.js
@@ -1,0 +1,329 @@
+import { DataTexturePeformanceModel }  from "../../../DataTexturePeformanceModel.js"
+
+// For JSDoc autocompletion
+import { PerformanceNode } from "../../PerformanceNode.js"
+import { Scene } from "../../../../scene/Scene.js"
+
+/**
+ * Wheter the FPS tracker was already installed.
+ */
+let _attachedFPSTracker = false;
+
+/**
+ * The list of ````LodCullingManager````'s subscribed to FPS tracking.
+ * 
+ * @type {Array <LodCullingManager>}
+ */
+const _fpsTrackingManagers = [];
+
+/**
+ * 
+ * @param {Scene} scene 
+ * @param {LodCullingManager} cullingManager
+ */
+function attachFPSTracker (scene, cullingManager) {   
+    if (!_attachedFPSTracker) {
+        _attachedFPSTracker = true;
+
+        const MAX_NUM_TICKS = 10;
+        let tickTimeArray = new Array (MAX_NUM_TICKS);
+        let numTick = 0;
+
+        let currentFPS = -1;
+
+        scene.on ("tick", function (tickEvent) {
+            let cullApplied = false;
+
+            if (currentFPS != -1)
+            {
+                // Call LOD-culling tasks
+                for (let i = 0, len = _fpsTrackingManagers.length; i < len; i++)
+                {
+                    cullApplied |= _fpsTrackingManagers[i].applyLodCulling (currentFPS);
+                }
+            }
+
+            // If culling was applied, do not count this frame towards FPS stats
+            if (cullApplied)
+            {
+                return;
+            }
+
+            tickTimeArray[numTick % MAX_NUM_TICKS] = tickEvent.deltaTime;
+
+            let sumTickTimes = 0;
+
+            if (numTick > MAX_NUM_TICKS)
+            {
+                for (let i = 0; i < MAX_NUM_TICKS; i++)
+                {
+                    sumTickTimes += tickTimeArray[i];
+                }
+        
+                currentFPS = MAX_NUM_TICKS / sumTickTimes * 1000;
+            }
+
+            numTick++;
+        });
+    }
+
+    _fpsTrackingManagers.push (cullingManager);
+}
+
+/**
+ * Data structure containing pre-initialized `LOD` data.
+ * 
+ * Will be used by the rest of `LOD` related code.
+ */
+ class LodState {
+    /**
+     * @param {Array<number>} lodLevels The triangle counts for the LOD levels, for example ```[ 2000, 600, 150, 80, 20 ]```
+     * @param {number} targetFps The target FPS (_Frames Per Second_) for the dynamic culling of objects in the different LOD levels.
+     */
+    constructor (lodLevels, targetFps) {
+        /**
+         * An array ordered DESC with the number of triangles allowed in each LOD bucket.
+         * 
+         * @type {Array<number>}
+         */
+        this.triangleLODLevels = lodLevels;
+
+        /**
+         * A computed dictionary for `triangle-number-buckets` where:
+         * - key: the number of triangles allowed for the objects in the bucket.
+         * - value: all PerformanceNodes that have the number of triangles or more.
+         * 
+         * @type {Map<number, Array<PerformanceNode>>}
+         */
+        this.nodesInLOD = {};
+
+        /**
+         * A computed dictionary for `triangle-number-buckets` where:
+         * - key: the number of triangles allowed for the objects in the bucket.
+         * - value: the sum of triangles counts for all PeformanceNodes in the bucket.
+         * 
+         * @type {Map<number, number>}
+         */
+        this.triangleCountInLOD = {};
+
+        /**
+         * The target FPS for the `LOD` mechanism:
+         * - if real FPS are below this number, the next `LOD` level will be applied.
+         * 
+         * - if real FPS are...
+         *   - above this number plus a margin
+         *   - and for some consecutive frames
+         *  ... then the previous `LOD` level will be applied.
+         * 
+         * @type {number}
+         */
+        this.targetFps = targetFps;
+
+        // /**
+        //  * Not used at the moment.
+        //  */
+        // this.restoreTime = LOD_RESTORE_TIME;
+
+        /**
+         * Current `LOD` level. Starts at 0.
+         * 
+         * @type {number}
+         */
+        this.lodLevelIndex = 0;
+
+        /**
+         * Number of consecutive frames in current `LOD` level where FPS was above `targetFps`
+         * 
+         * @type {number}
+         */
+        this.consecutiveFramesWithTargetFps = 0;
+
+        /**
+         * Number of consecutive frames in current `LOD` level where FPS was below `targetFps`
+         * 
+         * @type {number}
+         */
+        this.consecutiveFramesWithoutTargetFps = 0;
+    }
+
+    /**
+     * @param {DataTexturePeformanceModel} model
+     */
+    initializeLodState (model) {
+        if (model._nodeList.length == 0)
+        {
+            return;
+        }
+
+        //      const LOD_LEVELS = [ 2000, 600, 150, 80, 20 ];
+        //      const LOD_RESTORE_TIME = 600;
+        //      const LOD_TARGET_FPS = 20;
+        const nodeList = model._nodeList;
+        
+        let nodesInLOD = {};
+        let triangleCountInLOD = {};
+
+        for (let i = 0, len = nodeList.length; i < len; i++)
+        {
+            const node = nodeList[i];
+
+            let lodLevel, len;
+
+            for (lodLevel = 0, len = this.triangleLODLevels.length; lodLevel < len; lodLevel++)
+            {
+                if (node.numTriangles >= this.triangleLODLevels [lodLevel])
+                {
+                    break;
+                }
+            }
+
+            var lodPolys = this.triangleLODLevels [lodLevel] || 0;
+
+            if (!(lodPolys in nodesInLOD))
+            {
+                nodesInLOD [lodPolys] = [];
+            }
+
+            nodesInLOD [lodPolys].push (node);
+
+            if (!(lodPolys in triangleCountInLOD))
+            {
+                triangleCountInLOD [lodPolys] = 0;
+            }
+
+            triangleCountInLOD [lodPolys] += node.numTriangles;
+        }
+
+        this.nodesInLOD = nodesInLOD;
+        this.triangleCountInLOD = triangleCountInLOD;
+    }
+}
+
+class LodCullingManager {
+    /**
+     * @param {DataTexturePeformanceModel} model 
+     * @param {Array<number>} lodLevels 
+     * @param {number} targetFps 
+     */
+    constructor (model, lodLevels, targetFps) {
+        /**
+         * @type {DataTexturePeformanceModel}
+         */
+        this.model = model;
+
+        /**
+         * @private
+         */
+        this.lodState = new LodState (
+            lodLevels,
+            targetFps
+        );
+
+        console.time ("initializeLodState");
+        
+        this.lodState.initializeLodState (model);
+        
+        console.timeEnd ("initializeLodState");
+
+        attachFPSTracker (this.model.scene, this);
+    }
+
+    /** 
+     * Cull any objects belonging to the current `LOD` level, and increase the `LOD` level.
+     * 
+     * @private
+     */
+    _increaseLODLevelIndex ()
+    {
+        const lodState = this.lodState;
+
+        if (lodState.lodLevelIndex == lodState.triangleLODLevels.length)
+        {
+            return false;
+        }
+
+        const nodesInLOD = lodState.nodesInLOD [lodState.triangleLODLevels[lodState.lodLevelIndex]] || [];
+
+        for (let i = 0, len = nodesInLOD.length; i < len; i++)
+        {
+            nodesInLOD[i].culledLOD = true;
+        }
+
+        lodState.lodLevelIndex++;
+
+        return true;
+    }
+
+    /** 
+     * Un-cull any objects belonging to the current `LOD` level, and decrease the `LOD` level.
+     */
+    _decreaseLODLevelIndex ()
+    {
+        const lodState = this.lodState;
+
+        if (lodState.lodLevelIndex == 0)
+        {
+            return false;
+        }
+
+        const nodesInLOD = lodState.nodesInLOD [lodState.triangleLODLevels[lodState.lodLevelIndex - 1]] || [];
+
+        for (let i = 0, len = nodesInLOD.length; i < len; i++)
+        {
+            nodesInLOD[i].culledLOD = false;
+        }
+
+        lodState.lodLevelIndex--;
+
+        return true;
+    }
+
+    /**
+     * Apply LOD culling.
+     * 
+     * Will update LOD level, if needed, based in...
+     * - current FPS
+     * - target FPS
+     * 
+     * ... and then will cull/uncull the needed objects according to the LOD level.
+     * 
+     * @param {number} currentFPS The current FPS (frames per second)
+     * @returns {boolean} Whether the LOD level was changed. This is, if some object was culled/unculled
+     */
+    applyLodCulling (currentFPS)
+    {
+        let lodState = this.lodState;
+        const model = this.model;
+
+        model.beginDeferredFlagsInAllLayers ();
+
+        let retVal = false;
+
+        if (currentFPS < lodState.targetFps)
+        {
+            if (++lodState.consecutiveFramesWithoutTargetFps > 8)
+            {
+                lodState.consecutiveFramesWithoutTargetFps = 0;
+                retVal = this._increaseLODLevelIndex();
+            }
+        }
+        else if (currentFPS > (lodState.targetFps + 4))
+        {
+            if (++lodState.consecutiveFramesWithTargetFps > 20)
+            {
+                lodState.consecutiveFramesWithTargetFps = 0;
+                retVal = this._decreaseLODLevelIndex();
+            }
+        }
+
+        model.commitDeferredFlagsInAllLayers ();
+
+        if (retVal) {
+            console.log ("LOD level = " + lodState.lodLevelIndex);
+        }
+
+        return retVal;
+    }
+}
+
+export { LodCullingManager }

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/LodCullingManager.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/LodCullingManager.js
@@ -256,6 +256,8 @@ class LodCullingManager {
 
     /** 
      * Un-cull any objects belonging to the current `LOD` level, and decrease the `LOD` level.
+     * 
+     * @private
      */
     _decreaseLODLevelIndex ()
     {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/LodCullingManager.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/LodCullingManager.js
@@ -1,8 +1,8 @@
 import { DataTexturePeformanceModel }  from "../../../DataTexturePeformanceModel.js"
 
 // For JSDoc autocompletion
-import { PerformanceNode } from "../../PerformanceNode.js"
-import { Scene } from "../../../../scene/Scene.js"
+import { VBOSceneModelNode } from "../../VBOSceneModelNode.js"
+import { Scene } from "../../../../../scene/Scene.js"
 
 /**
  * Wheter the FPS tracker was already installed.
@@ -93,7 +93,7 @@ function attachFPSTracker (scene, cullingManager) {
          * - key: the number of triangles allowed for the objects in the bucket.
          * - value: all PerformanceNodes that have the number of triangles or more.
          * 
-         * @type {Map<number, Array<PerformanceNode>>}
+         * @type {Map<number, Array<VBOSceneModelNode>>}
          */
         this.nodesInLOD = {};
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureBuffer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureBuffer.js
@@ -1,0 +1,43 @@
+import {WEBGL_INFO} from "../../../../webglInfo.js";
+
+const bigIndicesSupported = WEBGL_INFO.SUPPORTED_EXTENSIONS["OES_element_index_uint"];
+
+/**
+ * @private
+ */
+class TrianglesDataTextureBuffer {
+
+    constructor() {
+
+        this.positions = [];
+        this.metallicRoughness = [];
+
+        this.offsets = [];
+        this.indices8Bits = [];
+        this.indices16Bits = [];
+        this.indices32Bits = [];
+        this.edgeIndices8Bits = [];
+        this.edgeIndices16Bits = [];
+        this.edgeIndices32Bits = [];
+
+        this.perObjectColors = [];
+        this.perObjectPickColors = [];
+
+        this.perObjectPositionsDecodeMatrices = []; // chipmunk
+        this.perObjectInstancePositioningMatrices = [];
+        this.perObjectInstanceNormalsMatrices = [];
+
+        this.perObjectVertexBases = [];
+        this.perObjectIndexBaseOffsets = [];
+        this.perObjectEdgeIndexBaseOffsets = [];
+
+        this.perTriangleNumberPortionId8Bits = []; // chipmunk
+        this.perTriangleNumberPortionId16Bits = []; // chipmunk
+        this.perTriangleNumberPortionId32Bits = []; // chipmunk
+        this.perEdgeNumberPortionId8Bits = []; // chipmunk
+        this.perEdgeNumberPortionId16Bits = []; // chipmunk
+        this.perEdgeNumberPortionId32Bits = []; // chipmunk
+    }
+}
+
+export {TrianglesDataTextureBuffer};

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureBuffer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureBuffer.js
@@ -1,4 +1,4 @@
-import {WEBGL_INFO} from "../../../../webglInfo.js";
+import {WEBGL_INFO} from "../../../../../webglInfo.js";
 
 const bigIndicesSupported = WEBGL_INFO.SUPPORTED_EXTENSIONS["OES_element_index_uint"];
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureBuffer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureBuffer.js
@@ -12,7 +12,6 @@ class TrianglesDataTextureBuffer {
         this.positions = [];
         this.metallicRoughness = [];
 
-        this.offsets = [];
         this.indices8Bits = [];
         this.indices16Bits = [];
         this.indices32Bits = [];
@@ -22,6 +21,8 @@ class TrianglesDataTextureBuffer {
 
         this.perObjectColors = [];
         this.perObjectPickColors = [];
+
+        this.perObjectOffsets = [];
 
         this.perObjectPositionsDecodeMatrices = []; // chipmunk
         this.perObjectInstancePositioningMatrices = [];

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureBuffer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureBuffer.js
@@ -26,7 +26,6 @@ class TrianglesDataTextureBuffer {
 
         this.perObjectPositionsDecodeMatrices = []; // chipmunk
         this.perObjectInstancePositioningMatrices = [];
-        this.perObjectInstanceNormalsMatrices = [];
 
         this.perObjectVertexBases = [];
         this.perObjectIndexBaseOffsets = [];

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureBuffer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureBuffer.js
@@ -22,6 +22,8 @@ class TrianglesDataTextureBuffer {
         this.perObjectColors = [];
         this.perObjectPickColors = [];
 
+        this.perObjectSolid = [];
+
         this.perObjectOffsets = [];
 
         this.perObjectPositionsDecodeMatrices = []; // chipmunk

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js
@@ -1,0 +1,1702 @@
+import {WEBGL_INFO} from "../../../../webglInfo.js";
+import {ENTITY_FLAGS} from '../../ENTITY_FLAGS.js';
+import {RENDER_PASSES} from '../../RENDER_PASSES.js';
+
+import {math} from "../../../../math/math.js";
+import {RenderState} from "../../../../webgl/RenderState.js";
+import {ArrayBuf} from "../../../../webgl/ArrayBuf.js";
+import {geometryCompressionUtils} from "../../../../math/geometryCompressionUtils.js";
+import {getDataTextureRenderers} from "./TrianglesDataTextureRenderers.js";
+import {TrianglesDataTextureBuffer} from "./TrianglesDataTextureBuffer.js";
+import {quantizePositions, transformAndOctEncodeNormals} from "../../compression.js";
+import * as uniquifyPositions from "./calculateUniquePositions.js";
+import { rebucketPositions } from "./rebucketPositions.js";
+import {
+    dataTextureRamStats,
+    DataTextureState,
+    DataTextureGenerator
+} from "../DataTextureState.js"
+
+/**
+ * 12-bits allowed for object ids.
+ * 
+ * Limits the per-object texture height in the layer.
+ */
+const MAX_NUMBER_OF_OBJECTS_IN_LAYER = (1 << 12);
+
+/**
+ * 2048 is max data texture height
+ * 
+ * Limits the aggregated geometry texture height in the layer.
+ */
+const MAX_DATA_TEXTURE_HEIGHT = (1 << 11);
+
+/**
+ * Align `indices` and `edgeIndices` memory layout to 8 elements.
+ * 
+ * Used as an optimization for the `...portionIds...` texture, so it
+ * can just be stored 1 out of 8 `portionIds` corresponding to a given
+ * `triangle-index` or `edge-index`.
+ */
+const INDICES_EDGE_INDICES_ALIGNEMENT_SIZE = 8;
+
+const identityMatrix = math.identityMat4();
+const tempMat4 = math.mat4();
+const tempMat4b = math.mat4();
+const tempVec4a = math.vec4([0, 0, 0, 1]);
+const tempVec4b = math.vec4([0, 0, 0, 1]);
+const tempVec4c = math.vec4([0, 0, 0, 1]);
+const tempOBB3 = math.OBB3();
+
+const tempUint8Array4 = new Uint8Array (4);
+
+const tempVec3a = math.vec3();
+const tempVec3b = math.vec3();
+const tempVec3c = math.vec3();
+const tempVec3d = math.vec3();
+const tempVec3e = math.vec3();
+const tempVec3f = math.vec3();
+const tempVec3g = math.vec3();
+
+let _numberOfLayers = 0;
+
+/**
+ * @private
+ */
+class TrianglesDataTextureLayer {
+    /**
+     * @param model
+     * @param cfg
+     * @param cfg.layerIndex
+     * @param cfg.positionsDecodeMatrix
+     * @param cfg.origin
+     * @param cfg.scratchMemory
+     * @param cfg.solid
+     */
+    constructor(model, cfg) {
+        this._layerNumber = _numberOfLayers++;
+        dataTextureRamStats.numberOfLayers++;
+
+        /**
+         * State sorting key.
+         * @type {string}
+         */
+        this.sortId = "TrianglesDataTextureLayer" + (cfg.solid ? "-solid" : "-surface");
+
+        /**
+         * Index of this TrianglesDataTextureLayer in {@link PerformanceModel#_layerList}.
+         * @type {Number}
+         */
+        this.layerIndex = cfg.layerIndex;
+
+        this._dataTextureRenderers = getDataTextureRenderers(model.scene);
+        this.model = model;
+        this._buffer = new TrianglesDataTextureBuffer();
+        this._scratchMemory = cfg.scratchMemory;
+
+        /**
+         * @type {DataTextureState}
+         */
+        this._dataTextureState = new DataTextureState ();
+
+        /**
+         * @type {DataTextureGenerator}
+         */
+        this.dataTextureGenerator = new DataTextureGenerator();
+
+        this._state = new RenderState({
+            offsetsBuf: null,
+            metallicRoughnessBuf: null,
+            positionsDecodeMatrix: math.mat4(),
+            textureState: this._dataTextureState,
+            numIndices8Bits: 0,
+            numIndices16Bits: 0,
+            numIndices32Bits: 0,
+            numEdgeIndices8Bits: 0,
+            numEdgeIndices16Bits: 0,
+            numEdgeIndices32Bits: 0,
+            numVertices: 0,
+        });
+
+        // These counts are used to avoid unnecessary render passes
+        this._numPortions = 0;
+        this._numVisibleLayerPortions = 0;
+        this._numTransparentLayerPortions = 0;
+        this._numXRayedLayerPortions = 0;
+        this._numSelectedLayerPortions = 0;
+        this._numHighlightedLayerPortions = 0;
+        this._numClippableLayerPortions = 0;
+        this._numEdgesLayerPortions = 0;
+        this._numPickableLayerPortions = 0;
+        this._numCulledLayerPortions = 0;
+
+        this._modelAABB = math.collapseAABB3(); // Model-space AABB
+        this._portions = [];
+
+        this._finalized = false;
+
+        /**
+         * Due to `index rebucketting` process in ```prepareMeshGeometry``` function, it's possible that a single
+         * portion is expanded to more than 1 real sub-portion.
+         * 
+         * This Array tracks the mapping between:
+         * 
+         * - external `portionIds` as seen by consumers of this class.
+         * - internal `sub-portionIds` acutally managed by this class.
+         * 
+         * The outer index of this array is the externally seen `portionId`.
+         * The inner value of the array, are `sub-portionIds` corresponding to the `portionId`.
+         * 
+         * @type {Array<Array<int>>}
+         * @private
+         */
+        this._subPortionIdMapping = [];
+
+        this._instancedGeometrySubPortionData = {};
+
+        /**
+         * The axis-aligned World-space boundary of this TrianglesDataTextureLayer's positions.
+         * @type {*|Float64Array}
+         */
+        this.aabb = math.collapseAABB3();
+
+        /**
+         * When true, this layer contains solid triangle meshes, otherwise this layer contains surface triangle meshes
+         * @type {boolean}
+         */
+        this.solid = !!cfg.solid;
+    }
+
+    /**
+     * Returns wheter the ```TrianglesDataTextureLayer``` has room for more portions.
+     * 
+     * @param {object} geometryCfg An object containing the geometrical data (`positions`, `indices`, `edgeIndices`) for the portion.
+     * @param {object} instancingGeometryId In case an instanced portion is to be checked, this must be the `geometryId`
+     * 
+     * @returns {Boolean} Wheter the requested portion can be created
+     */
+    canCreatePortion(geometryCfg, instancingGeometryId = null) {
+        if (this._finalized) {
+            throw "Already finalized";
+        }
+        
+        const state = this._state;
+
+        const newPortions = geometryCfg.preparedBuckets.length;
+
+        if ((this._numPortions + newPortions) > MAX_NUMBER_OF_OBJECTS_IN_LAYER)
+        {
+            dataTextureRamStats.cannotCreatePortion.because10BitsObjectId++;
+        }
+
+        let retVal = (this._numPortions + newPortions) <= MAX_NUMBER_OF_OBJECTS_IN_LAYER;
+
+        const alreadyHasPortionGeometry =
+            instancingGeometryId !== null &&
+            (instancingGeometryId + "#0") in this._instancedGeometrySubPortionData;
+
+        if (!alreadyHasPortionGeometry) {
+            const maxIndicesOfAnyBits = Math.max (
+                state.numIndices8Bits,
+                state.numIndices16Bits,
+                state.numIndices32Bits,
+            ) ;
+    
+            let numVertices = 0;
+            let numIndices = geometryCfg.indices.length / 3;
+    
+            geometryCfg.preparedBuckets.forEach(bucket => {
+                numVertices += bucket.positions.length / 3;
+            });
+        
+            if ((state.numVertices + numVertices) > MAX_DATA_TEXTURE_HEIGHT * 1024 ||
+                (maxIndicesOfAnyBits + numIndices) > MAX_DATA_TEXTURE_HEIGHT * 1024)
+            {
+                dataTextureRamStats.cannotCreatePortion.becauseTextureSize++;
+            }
+
+            retVal &&=
+                (state.numVertices + numVertices) <= MAX_DATA_TEXTURE_HEIGHT * 1024 &&
+                (maxIndicesOfAnyBits + numIndices) <= MAX_DATA_TEXTURE_HEIGHT * 1024;
+        }
+
+        // if (!retVal)
+        // {
+        //     console.log ("Cannot create portion!");
+        // }
+
+        return retVal;
+    }
+
+    /**
+     * Creates a new portion within this TrianglesDataTextureLayer, returns the new portion ID.
+     *
+     * Gives the portion the specified geometry, color and matrix.
+     *
+     * @param cfg.positions Flat float Local-space positions array.
+     * @param [cfg.normals] Flat float normals array.
+     * @param [cfg.colors] Flat float colors array.
+     * @param cfg.indices  Flat int indices array.
+     * @param [cfg.edgeIndices] Flat int edges indices array.
+     * @param cfg.color Quantized RGB color [0..255,0..255,0..255,0..255]
+     * @param cfg.metallic Metalness factor [0..255]
+     * @param cfg.roughness Roughness factor [0..255]
+     * @param cfg.opacity Opacity [0..255]
+     * @param [cfg.meshMatrix] Flat float 4x4 matrix
+     * @param [cfg.worldMatrix] Flat float 4x4 matrix
+     * @param cfg.worldAABB Flat float AABB World-space AABB
+     * @param cfg.pickColor Quantized pick color
+     * @returns {number} Portion ID
+     */
+    createPortion (geometryCfg, objectCfg = null) {
+        if (this._finalized) {
+            throw "Already finalized";
+        }
+
+        const instancing = objectCfg !== null;
+
+        let portionId = this._subPortionIdMapping.length;
+
+        const portionIdFanout = [];
+        this._subPortionIdMapping.push (portionIdFanout);
+
+        const objectAABB = instancing ? objectCfg.aabb : geometryCfg.aabb;
+        
+        geometryCfg.preparedBuckets.forEach((bucketGeometry, bucketIndex) => {
+            let geometrySubPortionData;
+
+            if (instancing) {
+                const key = geometryCfg.id + "#" + bucketIndex;
+
+                if (!(key in this._instancedGeometrySubPortionData)) {
+                    this._instancedGeometrySubPortionData[key] = this.createSubPortionGeometry (bucketGeometry);
+                }
+
+                geometrySubPortionData = this._instancedGeometrySubPortionData[key];
+            } else {
+                geometrySubPortionData = this.createSubPortionGeometry (bucketGeometry);
+            }
+            
+            const aabb = math.collapseAABB3();
+
+            const subPortionId = this.createSubPortionObject (
+                instancing ? objectCfg : geometryCfg,
+                geometrySubPortionData,
+                bucketGeometry.positions,
+                geometryCfg.positionsDecodeMatrix,
+                geometryCfg.origin,
+                aabb,
+                instancing
+            );
+
+            math.expandAABB3(objectAABB, aabb);
+
+            portionIdFanout.push (subPortionId);
+        });
+
+        this.model.numPortions++;
+
+        return portionId;
+    }
+
+    createSubPortionGeometry(cfg) {
+        const state = this._state;
+
+        // Indices alignement
+        // This will make every mesh consume a multiple of INDICES_EDGE_INDICES_ALIGNEMENT_SIZE
+        // array items for storing the triangles of the mesh, and it supports:
+        // - a memory optimization of factor INDICES_EDGE_INDICES_ALIGNEMENT_SIZE
+        // - in exchange for a small RAM overhead
+        //   (by adding some padding until a size that is multiple of INDICES_EDGE_INDICES_ALIGNEMENT_SIZE)
+        if (cfg.indices)
+        {
+            const alignedIndicesLen = Math.ceil ((cfg.indices.length / 3) / INDICES_EDGE_INDICES_ALIGNEMENT_SIZE) * INDICES_EDGE_INDICES_ALIGNEMENT_SIZE * 3;
+
+            // Take notice of the introduced GPU storage overhead
+            dataTextureRamStats.overheadSizeAlignementIndices += 2 * (alignedIndicesLen - cfg.indices.length);
+
+            const alignedIndices = new Uint32Array(alignedIndicesLen);
+            alignedIndices.fill(0);
+            alignedIndices.set (cfg.indices);
+
+            cfg.indices = alignedIndices;
+        }
+
+        // EdgeIndices alignement
+        // This will make every mesh consume a multiple of INDICES_EDGE_INDICES_ALIGNEMENT_SIZE
+        // array items for storing the edges of the mesh, and it supports:
+        // - a memory optimization of factor INDICES_EDGE_INDICES_ALIGNEMENT_SIZE
+        // - in exchange for a small RAM overhead
+        //   (by adding some padding until a size that is multiple of INDICES_EDGE_INDICES_ALIGNEMENT_SIZE)
+        if (cfg.edgeIndices)
+        {
+            const alignedEdgeIndicesLen = Math.ceil ((cfg.edgeIndices.length / 2) / INDICES_EDGE_INDICES_ALIGNEMENT_SIZE) * INDICES_EDGE_INDICES_ALIGNEMENT_SIZE * 2;
+
+            // Take notice of the introduced GPU storage overhead
+            dataTextureRamStats.overheadSizeAlignementEdgeIndices += 2 * (alignedEdgeIndicesLen - cfg.edgeIndices.length);
+
+            const alignedEdgeIndices = new Uint32Array(alignedEdgeIndicesLen);
+            alignedEdgeIndices.fill(0);
+            alignedEdgeIndices.set (cfg.edgeIndices);
+            cfg.edgeIndices = alignedEdgeIndices;
+        }
+
+        const positions = cfg.positions;
+        const indices = cfg.indices;
+        const edgeIndices = cfg.edgeIndices;
+
+        const buffer = this._buffer;
+        const positionsVertexBase = buffer.positions.length / 3;
+        const numVerts = positions.length / 3;
+
+        // console.log (positions);
+
+        // Load positions data into buffer
+        for (let i = 0, len = positions.length; i < len; i++) {
+            buffer.positions.push(positions[i]);
+        }
+        
+        // Load triangle indices data into buffer
+        let indicesBase;
+
+        let numTriangles = 0;
+
+        if (indices) {
+            numTriangles = indices.length / 3;
+
+            let indicesBuffer;
+
+            // Select the appropiate bitness-based bucket for indices
+            if (numVerts <= (1<< 8)) {
+                indicesBuffer = buffer.indices8Bits;
+            } else if (numVerts <= (1<< 16)) {
+                indicesBuffer = buffer.indices16Bits;
+            } else {
+                indicesBuffer = buffer.indices32Bits;
+            }
+
+            indicesBase = indicesBuffer.length / 3;
+
+            for (let i = 0, len = indices.length; i < len; i++) {
+                indicesBuffer.push(indices[i]);
+            }
+        }
+        
+        // Load edge indices data into buffer
+        let edgeIndicesBase;
+
+        let numEdges = 0;
+
+        if (edgeIndices) {
+            numEdges = edgeIndices.length / 2;
+
+            let edgeIndicesBuffer;
+
+            // Select the appropiate bitness-based bucket for edgeIndices
+            if (numVerts <= (1<< 8)) {
+                edgeIndicesBuffer = buffer.edgeIndices8Bits;
+            } else if (numVerts <= (1<< 16)) {
+                edgeIndicesBuffer = buffer.edgeIndices16Bits;
+            } else {
+                edgeIndicesBuffer = buffer.edgeIndices32Bits;
+            }
+    
+            edgeIndicesBase = edgeIndicesBuffer.length / 2;
+
+            for (let i = 0, len = edgeIndices.length; i < len; i++) {
+                edgeIndicesBuffer.push(edgeIndices[i]);
+            }
+        }
+
+        state.numVertices += numVerts;
+
+        dataTextureRamStats.numberOfGeometries++;
+
+        return {
+            vertexBase: positionsVertexBase,
+            numVertices: numVerts,
+            numTriangles,
+            numEdges,
+            indicesBase,
+            edgeIndicesBase
+        };
+    }
+
+    /**
+     * @private
+     */
+    createSubPortionObject(cfg, geometrySubPortionData, positions, positionsDecodeMatrix, origin, worldAABB, instancing) {
+        const color = cfg.color;
+        const metallic = cfg.metallic;
+        const roughness = cfg.roughness;
+        const colors = cfg.colors;
+        const opacity = cfg.opacity;
+        const meshMatrix = cfg.meshMatrix;
+        const worldMatrix = cfg.worldMatrix;
+        const pickColor = cfg.pickColor;
+        // const positionsDecodeMatrix = cfg.positionsDecodeMatrix;
+
+        const scene = this.model.scene;
+        const buffer = this._buffer;
+
+        const state = this._state;
+
+        // Positions decode Matrix
+        buffer.perObjectPositionsDecodeMatrices.push (positionsDecodeMatrix);
+
+        if (instancing) {
+            // Mesh instance matrix
+            buffer.perObjectInstancePositioningMatrices.push (
+                meshMatrix
+            );
+
+            // Mesh instance normal matrix
+            {
+                // Note: order of inverse and transpose doesn't matter
+                let transposedMat = math.transposeMat4(meshMatrix, math.mat4()); // TODO: Use cached matrix
+                let normalMatrix = math.inverseMat4(transposedMat);
+
+                buffer.perObjectInstanceNormalsMatrices.push (
+                    normalMatrix
+                );
+            }
+        } else {
+            buffer.perObjectInstancePositioningMatrices.push (identityMatrix);
+            buffer.perObjectInstanceNormalsMatrices.push (identityMatrix);
+        }
+
+        // const positions = cfg.positions;
+        // const positionsIndex = buffer.positions.length;
+        // const vertsIndex = positionsIndex / 3;
+
+        // Expand the world AABB with the concrete location of the object
+        if (instancing) {
+            const localAABB = math.collapseAABB3();
+            math.expandAABB3Points3(localAABB, positions);
+            geometryCompressionUtils.decompressAABB(localAABB, positionsDecodeMatrix);
+            const geometryOBB = math.AABB3ToOBB3(localAABB);
+    
+            for (let i = 0, len = geometryOBB.length;  i < len; i += 4) {
+                tempVec4a[0] = geometryOBB[i + 0];
+                tempVec4a[1] = geometryOBB[i + 1];
+                tempVec4a[2] = geometryOBB[i + 2];
+
+                math.transformPoint4(meshMatrix, tempVec4a, tempVec4b);
+
+                if (worldMatrix) {
+                    math.transformPoint4(worldMatrix, tempVec4b, tempVec4c);
+                    math.expandAABB3Point3(worldAABB, tempVec4c);
+                } else {
+                    math.expandAABB3Point3(worldAABB, tempVec4b);
+                }
+            }
+        } else if (positionsDecodeMatrix) {
+            const bounds = geometryCompressionUtils.getPositionsBounds(positions);
+
+            const min = geometryCompressionUtils.decompressPosition(bounds.min, positionsDecodeMatrix, []);
+            const max = geometryCompressionUtils.decompressPosition(bounds.max, positionsDecodeMatrix, []);
+
+            worldAABB[0] = min[0];
+            worldAABB[1] = min[1];
+            worldAABB[2] = min[2];
+            worldAABB[3] = max[0];
+            worldAABB[4] = max[1];
+            worldAABB[5] = max[2];
+
+            if (worldMatrix) {
+                math.AABB3ToOBB3(worldAABB, tempOBB3);
+                math.transformOBB3(worldMatrix, tempOBB3);
+                math.OBB3ToAABB3(tempOBB3, worldAABB);
+            }
+
+        } else {
+            if (meshMatrix) {
+                for (let i = 0, len = positions.length; i < len; i += 3) {
+
+                    tempVec4a[0] = positions[i + 0];
+                    tempVec4a[1] = positions[i + 1];
+                    tempVec4a[2] = positions[i + 2];
+
+                    math.transformPoint4(meshMatrix, tempVec4a, tempVec4b);
+
+                    positions[i + 0] = tempVec4b[0];
+                    positions[i + 1] = tempVec4b[1];
+                    positions[i + 2] = tempVec4b[2];
+
+                    math.expandAABB3Point3(this._modelAABB, tempVec4b);
+
+                    if (worldMatrix) {
+                        math.transformPoint4(worldMatrix, tempVec4b, tempVec4c);
+                        math.expandAABB3Point3(worldAABB, tempVec4c);
+                    } else {
+                        math.expandAABB3Point3(worldAABB, tempVec4b);
+                    }
+                }
+            } else {
+                for (let i = 0, len = positions.length; i < len; i += 3) {
+
+                    tempVec4a[0] = positions[i + 0];
+                    tempVec4a[1] = positions[i + 1];
+                    tempVec4a[2] = positions[i + 2];
+
+                    math.expandAABB3Point3(this._modelAABB, tempVec4a);
+
+                    if (worldMatrix) {
+                        math.transformPoint4(worldMatrix, tempVec4a, tempVec4b);
+                        math.expandAABB3Point3(worldAABB, tempVec4b);
+                    } else {
+                        math.expandAABB3Point3(worldAABB, tempVec4a);
+                    }
+                }
+            }
+        }
+
+        // Adjust the world AABB with the object `origin`
+        if (origin) {
+            this._state.origin = origin;
+            worldAABB[0] += origin[0];
+            worldAABB[1] += origin[1];
+            worldAABB[2] += origin[2];
+            worldAABB[3] += origin[0];
+            worldAABB[4] += origin[1];
+            worldAABB[5] += origin[2];
+        }
+
+        math.expandAABB3(this.aabb, worldAABB);
+
+        if (colors) {
+            buffer.perObjectColors.push ([
+                colors[0] * 255,
+                colors[1] * 255,
+                colors[2] * 255,
+                255
+            ]);
+        } else if (color) {
+            buffer.perObjectColors.push ([
+                color[0], // Color is pre-quantized by PerformanceModel
+                color[1],
+                color[2],
+                opacity
+            ]);
+        }
+
+        buffer.perObjectPickColors.push (pickColor);
+
+        buffer.perObjectVertexBases.push (geometrySubPortionData.vertexBase);
+
+        {
+            let currentNumIndices;
+
+            // Select the appropiate bitness-based bucket for indices
+            if (geometrySubPortionData.numVertices <= (1<< 8)) {
+                currentNumIndices = state.numIndices8Bits;
+            } else if (geometrySubPortionData.numVertices <= (1<< 16)) {
+                currentNumIndices = state.numIndices16Bits;
+            } else {
+                currentNumIndices = state.numIndices32Bits;
+            }
+
+            buffer.perObjectIndexBaseOffsets.push (currentNumIndices / 3 - geometrySubPortionData.indicesBase);
+        }
+
+        {
+            let currentNumEdgeIndices;
+
+            // Select the appropiate bitness-based bucket for indices
+            if (geometrySubPortionData.numVertices <= (1<< 8)) {
+                currentNumEdgeIndices = state.numEdgeIndices8Bits;
+            } else if (geometrySubPortionData.numVertices <= (1<< 16)) {
+                currentNumEdgeIndices = state.numEdgeIndices16Bits;
+            } else {
+                currentNumEdgeIndices = state.numEdgeIndices32Bits;
+            }
+
+            buffer.perObjectEdgeIndexBaseOffsets.push (currentNumEdgeIndices / 2 - geometrySubPortionData.edgeIndicesBase);
+        }
+
+        const subPortionId = this._portions.length;
+
+        if (geometrySubPortionData.numTriangles > 0) {
+            let numIndices = geometrySubPortionData.numTriangles * 3;
+
+            let indicesPortionIdBuffer;
+    
+            if (geometrySubPortionData.numVertices <= (1<< 8)) {
+                indicesPortionIdBuffer = buffer.perTriangleNumberPortionId8Bits;
+                state.numIndices8Bits += numIndices;
+                dataTextureRamStats.totalPolygons8Bits += geometrySubPortionData.numTriangles;
+            } else if (geometrySubPortionData.numVertices <= (1<< 16)) {
+                indicesPortionIdBuffer = buffer.perTriangleNumberPortionId16Bits;
+                state.numIndices16Bits += numIndices;
+                dataTextureRamStats.totalPolygons16Bits += geometrySubPortionData.numTriangles;
+            } else {
+                indicesPortionIdBuffer = buffer.perTriangleNumberPortionId32Bits;
+                state.numIndices32Bits += numIndices;
+                dataTextureRamStats.totalPolygons32Bits += geometrySubPortionData.numTriangles;
+            }
+
+            dataTextureRamStats.totalPolygons += geometrySubPortionData.numTriangles;
+
+            for (let i = 0; i < geometrySubPortionData.numTriangles; i += INDICES_EDGE_INDICES_ALIGNEMENT_SIZE) {
+                indicesPortionIdBuffer.push (subPortionId);
+            }
+        }
+
+        if (geometrySubPortionData.numEdges > 0) {
+            let numEdgeIndices = geometrySubPortionData.numEdges * 2;
+            let edgeIndicesPortionIdBuffer;
+
+            if (geometrySubPortionData.numVertices <= (1<< 8)) {
+                edgeIndicesPortionIdBuffer = buffer.perEdgeNumberPortionId8Bits;
+                state.numEdgeIndices8Bits += numEdgeIndices;
+                dataTextureRamStats.totalEdges8Bits += geometrySubPortionData.numEdges;
+            } else if (geometrySubPortionData.numVertices <= (1<< 16)) {
+                edgeIndicesPortionIdBuffer = buffer.perEdgeNumberPortionId16Bits;
+                state.numEdgeIndices16Bits += numEdgeIndices;
+                dataTextureRamStats.totalEdges16Bits += geometrySubPortionData.numEdges;
+            } else {
+                edgeIndicesPortionIdBuffer = buffer.perEdgeNumberPortionId32Bits;
+                state.numEdgeIndices32Bits += numEdgeIndices;
+                dataTextureRamStats.totalEdges32Bits += geometrySubPortionData.numEdges;
+            }
+
+            dataTextureRamStats.totalEdges += geometrySubPortionData.numEdges;
+
+            for (let i = 0; i < geometrySubPortionData.numEdges; i += INDICES_EDGE_INDICES_ALIGNEMENT_SIZE) {
+                edgeIndicesPortionIdBuffer.push (subPortionId);
+            }
+        }
+
+        // if (scene.entityOffsetsEnabled) {
+        //     for (let i = 0; i < numVerts; i++) {
+        //         buffer.offsets.push(0);
+        //         buffer.offsets.push(0);
+        //         buffer.offsets.push(0);
+        //     }
+        // }
+
+        // if (scene.pickSurfacePrecisionEnabled) {
+        //     // Quantized in-memory positions are initialized in finalize()
+        //     if (indices) {
+        //         portion.indices = indices;
+        //     }
+        //     if (scene.entityOffsetsEnabled) {
+        //         portion.offset = new Float32Array(3);
+        //     }
+        // }
+
+        this._portions.push({
+            // vertsBase: vertsIndex,
+            numVerts: geometrySubPortionData.numTriangles
+        });
+
+        this._numPortions++;
+
+        dataTextureRamStats.numberOfPortions++;
+
+        return subPortionId;
+    }
+
+    /**
+     * Builds data textures from the appended geometries and loads them into the GPU.
+     * 
+     * No more portions can then be created.
+     */
+    finalize() {
+        if (this._finalized) {
+            this.model.error("Already finalized");
+            return;
+        }
+
+        const state = this._state;
+        const textureState = this._dataTextureState;
+        const gl = this.model.scene.canvas.gl;
+        const buffer = this._buffer;
+
+        state.gl = gl;
+
+        // Generate all the needed textures in the layer
+
+        // a) colors and flags texture
+        textureState.texturePerObjectIdColorsAndFlags = this.dataTextureGenerator.generateTextureForColorsAndFlags (
+            gl,
+            buffer.perObjectColors,
+            buffer.perObjectPickColors,
+            buffer.perObjectVertexBases,
+            buffer.perObjectIndexBaseOffsets,
+            buffer.perObjectEdgeIndexBaseOffsets
+        );
+
+        // b) positions decode matrices texture
+        textureState.texturePerObjectIdPositionsDecodeMatrix = this.dataTextureGenerator.generateTextureForPositionsDecodeMatrices (
+            gl,
+            buffer.perObjectPositionsDecodeMatrices,
+            buffer.perObjectInstancePositioningMatrices,
+            buffer.perObjectInstanceNormalsMatrices
+        ); 
+
+        // c) position coordinates texture
+        textureState.texturePerVertexIdCoordinates = this.dataTextureGenerator.generateTextureForPositions (
+            gl,
+            buffer.positions
+        );
+
+        // d) portion Id triangles texture
+        textureState.texturePerPolygonIdPortionIds8Bits = this.dataTextureGenerator.generateTextureForPackedPortionIds (
+            gl,
+            buffer.perTriangleNumberPortionId8Bits
+        );
+
+        textureState.texturePerPolygonIdPortionIds16Bits = this.dataTextureGenerator.generateTextureForPackedPortionIds (
+            gl,
+            buffer.perTriangleNumberPortionId16Bits
+        );
+
+        textureState.texturePerPolygonIdPortionIds32Bits = this.dataTextureGenerator.generateTextureForPackedPortionIds (
+            gl,
+            buffer.perTriangleNumberPortionId32Bits
+        );
+
+        // e) portion Id texture for edges
+        textureState.texturePerEdgeIdPortionIds8Bits = this.dataTextureGenerator.generateTextureForPackedPortionIds (
+            gl,
+            buffer.perEdgeNumberPortionId8Bits
+        );
+
+        textureState.texturePerEdgeIdPortionIds16Bits = this.dataTextureGenerator.generateTextureForPackedPortionIds (
+            gl,
+            buffer.perEdgeNumberPortionId16Bits
+        );
+
+        textureState.texturePerEdgeIdPortionIds32Bits = this.dataTextureGenerator.generateTextureForPackedPortionIds (
+            gl,
+            buffer.perEdgeNumberPortionId32Bits
+        );
+
+        // f) indices texture
+        textureState.texturePerPolygonIdIndices8Bits = this.dataTextureGenerator.generateTextureFor8BitIndices (
+            gl,
+            buffer.indices8Bits
+        );
+
+        textureState.texturePerPolygonIdIndices16Bits = this.dataTextureGenerator.generateTextureFor16BitIndices (
+            gl,
+            buffer.indices16Bits
+        );
+
+        textureState.texturePerPolygonIdIndices32Bits = this.dataTextureGenerator.generateTextureFor32BitIndices (
+            gl,
+            buffer.indices32Bits
+        );
+        
+        // g) edge indices texture
+        textureState.texturePerPolygonIdEdgeIndices8Bits = this.dataTextureGenerator.generateTextureFor8BitsEdgeIndices (
+            gl,
+            buffer.edgeIndices8Bits
+        );
+        
+        textureState.texturePerPolygonIdEdgeIndices16Bits = this.dataTextureGenerator.generateTextureFor16BitsEdgeIndices (
+            gl,
+            buffer.edgeIndices16Bits
+        );
+        
+        textureState.texturePerPolygonIdEdgeIndices32Bits = this.dataTextureGenerator.generateTextureFor32BitsEdgeIndices (
+            gl,
+            buffer.edgeIndices32Bits
+        );
+        
+        // if (buffer.metallicRoughness.length > 0) {
+        //     const metallicRoughness = new Uint8Array(buffer.metallicRoughness);
+        //     let normalized = false;
+        //     state.metallicRoughnessBuf = new ArrayBuf(gl, gl.ARRAY_BUFFER, metallicRoughness, buffer.metallicRoughness.length, 2, gl.STATIC_DRAW, normalized);
+        // }
+
+        // if (this.model.scene.entityOffsetsEnabled) {
+        //     if (buffer.offsets.length > 0) {
+        //         const offsets = new Float32Array(buffer.offsets);
+        //         state.offsetsBuf = new ArrayBuf(gl, gl.ARRAY_BUFFER, offsets, buffer.offsets.length, 3, gl.DYNAMIC_DRAW);
+        //     }
+        // }
+
+        // Model matrices texture
+        if (!this.model._modelMatricesTexture)
+        {
+            this.model._modelMatricesTexture = this.dataTextureGenerator.generatePeformanceModelDataTexture (
+                gl, this.model
+            );
+        }
+
+        textureState.textureModelMatrices = this.model._modelMatricesTexture;
+
+        // Camera textures
+        if (!this.model.cameraTexture)
+        {
+            this.model.cameraTexture = this.dataTextureGenerator.generateCameraDataTexture (
+                this.model.scene.canvas.gl,
+                this.model.scene.camera,
+                this.model.scene,
+                this._state.origin.slice ()
+            );
+        }
+
+        textureState.textureCameraMatrices = this.model.cameraTexture;
+
+        // Mark the data-texture-state as finalized
+        textureState.finalize ();
+
+        // Free up memory
+        this._buffer = null;
+        this._instancedGeometrySubPortionData = {};
+
+        this._finalized = true;
+    }
+        
+    isEmpty() {
+        return this._numPortions == 0;
+    }
+
+    initFlags(portionId, flags, meshTransparent) {
+        if (flags & ENTITY_FLAGS.VISIBLE) {
+            this._numVisibleLayerPortions++;
+            this.model.numVisibleLayerPortions++;
+        }
+        if (flags & ENTITY_FLAGS.HIGHLIGHTED) {
+            this._numHighlightedLayerPortions++;
+            this.model.numHighlightedLayerPortions++;
+        }
+        if (flags & ENTITY_FLAGS.XRAYED) {
+            this._numXRayedLayerPortions++;
+            this.model.numXRayedLayerPortions++;
+        }
+        if (flags & ENTITY_FLAGS.SELECTED) {
+            this._numSelectedLayerPortions++;
+            this.model.numSelectedLayerPortions++;
+        }
+        if (flags & ENTITY_FLAGS.CLIPPABLE) {
+            this._numClippableLayerPortions++;
+            this.model.numClippableLayerPortions++;
+        }
+        if (flags & ENTITY_FLAGS.EDGES) {
+            this._numEdgesLayerPortions++;
+            this.model.numEdgesLayerPortions++;
+        }
+        if (flags & ENTITY_FLAGS.PICKABLE) {
+            this._numPickableLayerPortions++;
+            this.model.numPickableLayerPortions++;
+        }
+        if (flags & ENTITY_FLAGS.CULLED) {
+            this._numCulledLayerPortions++;
+            this.model.numCulledLayerPortions++;
+        }
+        if (meshTransparent) {
+            this._numTransparentLayerPortions++;
+            this.model.numTransparentLayerPortions++;
+        }
+        const deferred = true;
+        this._setFlags(portionId, flags, meshTransparent, deferred);
+        this._setFlags2(portionId, flags, deferred);
+    }
+
+    flushInitFlags() {
+        this._setDeferredFlags();
+        this._setDeferredFlags2();
+    }
+
+    setVisible(portionId, flags, transparent) {
+        if (!this._finalized) {
+            throw "Not finalized";
+        }
+        if (flags & ENTITY_FLAGS.VISIBLE) {
+            this._numVisibleLayerPortions++;
+            this.model.numVisibleLayerPortions++;
+        } else {
+            this._numVisibleLayerPortions--;
+            this.model.numVisibleLayerPortions--;
+        }
+        this._setFlags(portionId, flags, transparent);
+    }
+
+    setHighlighted(portionId, flags, transparent) {
+        if (!this._finalized) {
+            throw "Not finalized";
+        }
+        if (flags & ENTITY_FLAGS.HIGHLIGHTED) {
+            this._numHighlightedLayerPortions++;
+            this.model.numHighlightedLayerPortions++;
+        } else {
+            this._numHighlightedLayerPortions--;
+            this.model.numHighlightedLayerPortions--;
+        }
+        this._setFlags(portionId, flags, transparent);
+    }
+
+    setXRayed(portionId, flags, transparent) {
+        if (!this._finalized) {
+            throw "Not finalized";
+        }
+        if (flags & ENTITY_FLAGS.XRAYED) {
+            this._numXRayedLayerPortions++;
+            this.model.numXRayedLayerPortions++;
+        } else {
+            this._numXRayedLayerPortions--;
+            this.model.numXRayedLayerPortions--;
+        }
+        this._setFlags(portionId, flags, transparent);
+    }
+
+    setSelected(portionId, flags, transparent) {
+        if (!this._finalized) {
+            throw "Not finalized";
+        }
+        if (flags & ENTITY_FLAGS.SELECTED) {
+            this._numSelectedLayerPortions++;
+            this.model.numSelectedLayerPortions++;
+        } else {
+            this._numSelectedLayerPortions--;
+            this.model.numSelectedLayerPortions--;
+        }
+        this._setFlags(portionId, flags, transparent);
+    }
+
+    setEdges(portionId, flags, transparent) {
+        if (!this._finalized) {
+            throw "Not finalized";
+        }
+        if (flags & ENTITY_FLAGS.EDGES) {
+            this._numEdgesLayerPortions++;
+            this.model.numEdgesLayerPortions++;
+        } else {
+            this._numEdgesLayerPortions--;
+            this.model.numEdgesLayerPortions--;
+        }
+        this._setFlags(portionId, flags, transparent);
+    }
+
+    setClippable(portionId, flags) {
+        if (!this._finalized) {
+            throw "Not finalized";
+        }
+        if (flags & ENTITY_FLAGS.CLIPPABLE) {
+            this._numClippableLayerPortions++;
+            this.model.numClippableLayerPortions++;
+        } else {
+            this._numClippableLayerPortions--;
+            this.model.numClippableLayerPortions--;
+        }
+        this._setFlags2(portionId, flags);
+    }
+
+    /**
+     * This will _start_ a "set-flags transaction".
+     * 
+     * After invoking this method, calling setFlags/setFlags2 will not update
+     * the colors+flags texture but only store the new flags/flag2 in the
+     * colors+flags texture.
+     * 
+     * After invoking this method, and when all desired setFlags/setFlags2 have
+     * been called on needed portions of the layer, invoke `commitDeferredFlags`
+     * to actually update the texture data.
+     * 
+     * In massive "set-flags" scenarios like VFC or LOD mechanisms, the combina-
+     * tion of `beginDeferredFlags` + `commitDeferredFlags`brings a speed-up of
+     * up to 80x when e.g. objects are massively (un)culled 🚀.
+     */
+    beginDeferredFlags ()
+    {
+        this._deferredSetFlagsActive = true;
+    }
+
+    /**
+     * This will _commit_ a "set-flags transaction".
+     * 
+     * Invoking this method will update the colors+flags texture data with new
+     * flags/flags2 set since the previous invocation of `beginDeferredFlags`.
+     */
+    commitDeferredFlags ()
+    {
+        this._deferredSetFlagsActive = false;
+
+        if (!this._deferredSetFlagsDirty)
+        {
+            return;
+        }
+
+        this._deferredSetFlagsDirty = false;
+
+        const gl = this.model.scene.canvas.gl;
+        const textureState = this._dataTextureState;
+        
+        gl.bindTexture (gl.TEXTURE_2D, textureState.texturePerObjectIdColorsAndFlags._texture);
+
+        gl.texSubImage2D(
+            gl.TEXTURE_2D,
+            0, // level
+            0, // xoffset
+            0, // yoffset
+            textureState.texturePerObjectIdColorsAndFlags._textureWidth, // width
+            textureState.texturePerObjectIdColorsAndFlags._textureHeight, // width
+            gl.RGBA_INTEGER,
+            gl.UNSIGNED_BYTE,
+            textureState.texturePerObjectIdColorsAndFlags._textureData
+        );
+    }
+
+    setCulled(portionId, flags, transparent) {
+        if (!this._finalized) {
+            throw "Not finalized";
+        }
+        
+        if (flags & ENTITY_FLAGS.CULLED) {
+            this._numCulledLayerPortions+=this._subPortionIdMapping[portionId].length;
+            this.model.numCulledLayerPortions++;
+        } else {
+            this._numCulledLayerPortions-=this._subPortionIdMapping[portionId].length;
+            this.model.numCulledLayerPortions--;
+        }
+        this._setFlags(portionId, flags, transparent);
+    }
+
+    setCollidable(portionId, flags) {
+        if (!this._finalized) {
+            throw "Not finalized";
+        }
+    }
+
+    setPickable(portionId, flags, transparent) {
+        if (!this._finalized) {
+            throw "Not finalized";
+        }
+        if (flags & ENTITY_FLAGS.PICKABLE) {
+            this._numPickableLayerPortions++;
+            this.model.numPickableLayerPortions++;
+        } else {
+            this._numPickableLayerPortions--;
+            this.model.numPickableLayerPortions--;
+        }
+        this._setFlags(portionId, flags, transparent);
+    }
+
+    setColor(portionId, color) {
+        if (!this._finalized) {
+            throw "Not finalized";
+        }
+        const portionsIdx = portionId;
+        const portion = this._portions[portionsIdx];
+        const vertexBase = portion.vertsBase;
+        const numVerts = portion.numVerts;
+        const firstColor = vertexBase * 4;
+        const lenColor = numVerts * 4;
+        const tempArray = this._scratchMemory.getUInt8Array(lenColor);
+        const r = color[0];
+        const g = color[1];
+        const b = color[2];
+        const a = color[3];
+        for (let i = 0; i < lenColor; i += 4) {
+            tempArray[i + 0] = r;
+            tempArray[i + 1] = g;
+            tempArray[i + 2] = b;
+            tempArray[i + 3] = a;
+        }
+        // TODO: migrate to texture updates
+        // if (this._state.colorsBuf) {
+        //     this._state.colorsBuf.setData(tempArray, firstColor, lenColor);
+        // }
+    }
+
+    setTransparent(portionId, flags, transparent) {
+        if (transparent) {
+            this._numTransparentLayerPortions++;
+            this.model.numTransparentLayerPortions++;
+        } else {
+            this._numTransparentLayerPortions--;
+            this.model.numTransparentLayerPortions--;
+        }
+        this._setFlags(portionId, flags, transparent);
+    }
+
+    _setFlags(portionId, flags, deferred = false) {
+        (this._subPortionIdMapping[portionId] || []).forEach (fanOut => {
+            this._fan_out_setFlags (fanOut, flags, deferred);
+        });
+    }
+
+    _fan_out_setFlags(portionId, flags, transparent, deferred = false) {
+        if (!this._finalized) {
+            throw "Not finalized";
+        }
+
+        const visible = !!(flags & ENTITY_FLAGS.VISIBLE);
+        const xrayed = !!(flags & ENTITY_FLAGS.XRAYED);
+        const highlighted = !!(flags & ENTITY_FLAGS.HIGHLIGHTED);
+        const selected = !!(flags & ENTITY_FLAGS.SELECTED);
+        const edges = !!(flags & ENTITY_FLAGS.EDGES);
+        const pickable = !!(flags & ENTITY_FLAGS.PICKABLE);
+        const culled = !!(flags & ENTITY_FLAGS.CULLED);
+
+        // Color
+
+        let f0;
+        if (!visible || culled || xrayed) { // Highlight & select are layered on top of color - not mutually exclusive
+            f0 = RENDER_PASSES.NOT_RENDERED;
+        } else {
+            if (transparent) {
+                f0 = RENDER_PASSES.COLOR_TRANSPARENT;
+            } else {
+                f0 = RENDER_PASSES.COLOR_OPAQUE;
+            }
+        }
+
+        // Silhouette
+
+        let f1;
+        if (!visible || culled) {
+            f1 = RENDER_PASSES.NOT_RENDERED;
+        } else if (selected) {
+            f1 = RENDER_PASSES.SILHOUETTE_SELECTED;
+        } else if (highlighted) {
+            f1 = RENDER_PASSES.SILHOUETTE_HIGHLIGHTED;
+        } else if (xrayed) {
+            f1 = RENDER_PASSES.SILHOUETTE_XRAYED;
+        } else {
+            f1 = RENDER_PASSES.NOT_RENDERED;
+        }
+
+        // Edges
+
+        let f2 = 0;
+        if (!visible || culled) {
+            f2 = RENDER_PASSES.NOT_RENDERED;
+        } else if (selected) {
+            f2 = RENDER_PASSES.EDGES_SELECTED;
+        } else if (highlighted) {
+            f2 = RENDER_PASSES.EDGES_HIGHLIGHTED;
+        } else if (xrayed) {
+            f2 = RENDER_PASSES.EDGES_XRAYED;
+        } else if (edges) {
+            if (transparent) {
+                f2 = RENDER_PASSES.EDGES_COLOR_TRANSPARENT;
+            } else {
+                f2 = RENDER_PASSES.EDGES_COLOR_OPAQUE;
+            }
+        } else {
+            f2 = RENDER_PASSES.NOT_RENDERED;
+        }
+
+        // Pick
+
+        let f3 = (visible && !culled && pickable) ? RENDER_PASSES.PICK : RENDER_PASSES.NOT_RENDERED;
+
+        const textureState = this._dataTextureState;
+        const gl = this.model.scene.canvas.gl;
+
+        tempUint8Array4 [0] = f0;
+        tempUint8Array4 [1] = f1;
+        tempUint8Array4 [2] = f2;
+        tempUint8Array4 [3] = f3;
+
+        // object flags
+        textureState.texturePerObjectIdColorsAndFlags._textureData.set (
+            tempUint8Array4,
+            portionId * 24 + 8
+        );
+
+        if (this._deferredSetFlagsActive)
+        {
+            this._deferredSetFlagsDirty = true;
+            return;
+        }
+
+        gl.bindTexture (gl.TEXTURE_2D, textureState.texturePerObjectIdColorsAndFlags._texture);
+
+        gl.texSubImage2D(
+            gl.TEXTURE_2D,
+            0, // level
+            2, // xoffset
+            portionId, // yoffset
+            1, // width
+            1, //height
+            gl.RGBA_INTEGER,
+            gl.UNSIGNED_BYTE,
+            tempUint8Array4
+        );
+
+        // gl.bindTexture (gl.TEXTURE_2D, null);
+    }
+
+    _setDeferredFlags() {
+    }
+
+    _setFlags2(portionId, flags, deferred = false) {
+        (this._subPortionIdMapping[portionId] || []).forEach (fanOut => {
+            this._fan_out_setFlags2 (fanOut, flags, deferred);
+        });
+    }
+
+    _fan_out_setFlags2(portionId, flags, deferred = false) {
+        if (!this._finalized) {
+            throw "Not finalized";
+        }
+
+        const clippable = !!(flags & ENTITY_FLAGS.CLIPPABLE) ? 255 : 0;
+
+        const textureState = this._dataTextureState;
+        const gl = this.model.scene.canvas.gl;
+
+        tempUint8Array4 [0] = clippable;
+        tempUint8Array4 [1] = 0;
+        tempUint8Array4 [2] = 1;
+        tempUint8Array4 [3] = 2;
+
+        // object flags2
+        textureState.texturePerObjectIdColorsAndFlags._textureData.set (
+            tempUint8Array4,
+            portionId * 24 + 12
+        );
+        
+        if (this._deferredSetFlagsActive)
+        {
+            this._deferredSetFlagsDirty = true;
+            return;
+        }
+        
+        gl.bindTexture (gl.TEXTURE_2D, textureState.texturePerObjectIdColorsAndFlags._texture);
+
+        gl.texSubImage2D(
+            gl.TEXTURE_2D,
+            0, // level
+            3, // xoffset
+            portionId, // yoffset
+            1, // width
+            1, //height
+            gl.RGBA_INTEGER,
+            gl.UNSIGNED_BYTE,
+            tempUint8Array4
+        );
+
+        // gl.bindTexture (gl.TEXTURE_2D, null);
+    }
+
+    _setDeferredFlags2() {
+        return;
+    }
+
+    setOffset(portionId, offset) {
+        if (!this._finalized) {
+            throw "Not finalized";
+        }
+        if (!this.model.scene.entityOffsetsEnabled) {
+            this.model.error("Entity#offset not enabled for this Viewer"); // See Viewer entityOffsetsEnabled
+            return;
+        }
+        const portionsIdx = portionId;
+        const portion = this._portions[portionsIdx];
+        const vertexBase = portion.vertsBase;
+        const numVerts = portion.numVerts;
+        const firstOffset = vertexBase * 3;
+        const lenOffsets = numVerts * 3;
+        const tempArray = this._scratchMemory.getFloat32Array(lenOffsets);
+        const x = offset[0];
+        const y = offset[1];
+        const z = offset[2];
+        for (let i = 0; i < lenOffsets; i += 3) {
+            tempArray[i + 0] = x;
+            tempArray[i + 1] = y;
+            tempArray[i + 2] = z;
+        }
+        if (this._state.offsetsBuf) {
+            this._state.offsetsBuf.setData(tempArray, firstOffset, lenOffsets);
+        }
+        if (this.model.scene.pickSurfacePrecisionEnabled) {
+            portion.offset[0] = offset[0];
+            portion.offset[1] = offset[1];
+            portion.offset[2] = offset[2];
+        }
+    }
+
+    // ---------------------- COLOR RENDERING -----------------------------------
+
+    drawColorOpaque(renderFlags, frameCtx) {
+        if (this._numCulledLayerPortions === this._numPortions || this._numVisibleLayerPortions === 0 || this._numTransparentLayerPortions === this._numPortions || this._numXRayedLayerPortions === this._numPortions) {
+            return;
+        }
+        this._updateBackfaceCull(renderFlags, frameCtx);
+        if (frameCtx.withSAO && this.model.saoEnabled) {
+            if (frameCtx.pbrEnabled && this.model.pbrEnabled) {
+                if (this._dataTextureRenderers.colorQualityRendererWithSAO) {
+                    this._dataTextureRenderers.colorQualityRendererWithSAO.drawLayer(frameCtx, this, RENDER_PASSES.COLOR_OPAQUE);
+                }
+            } else {
+                if (this._dataTextureRenderers.colorRendererWithSAO) {
+                    this._dataTextureRenderers.colorRendererWithSAO.drawLayer(frameCtx, this, RENDER_PASSES.COLOR_OPAQUE);
+                }
+            }
+        } else {
+            if (frameCtx.pbrEnabled && this.model.pbrEnabled) {
+                if (this._dataTextureRenderers.colorQualityRenderer) {
+                    this._dataTextureRenderers.colorQualityRenderer.drawLayer(frameCtx, this, RENDER_PASSES.COLOR_OPAQUE);
+                }
+            } else {
+                if (this._dataTextureRenderers.colorRenderer) {
+                    this._dataTextureRenderers.colorRenderer.drawLayer(frameCtx, this, RENDER_PASSES.COLOR_OPAQUE);
+                }
+            }
+        }
+    }
+
+    _updateBackfaceCull(renderFlags, frameCtx) {
+        const backfaces = this.model.backfaces || (!this.solid) || renderFlags.sectioned;
+        if (frameCtx.backfaces !== backfaces) {
+            const gl = frameCtx.gl;
+            if (backfaces) {
+                gl.disable(gl.CULL_FACE);
+            } else {
+                gl.enable(gl.CULL_FACE);
+            }
+            frameCtx.backfaces = backfaces;
+        }
+    }
+
+    drawColorTransparent(renderFlags, frameCtx) {
+        if (this._numCulledLayerPortions === this._numPortions || this._numVisibleLayerPortions === 0 || this._numTransparentLayerPortions === 0 || this._numXRayedLayerPortions === this._numPortions) {
+            return;
+        }
+        this._updateBackfaceCull(renderFlags, frameCtx);
+        if (frameCtx.pbrEnabled && this.model.pbrEnabled) {
+            if (this._dataTextureRenderers.colorQualityRenderer) {
+                this._dataTextureRenderers.colorQualityRenderer.drawLayer(frameCtx, this, RENDER_PASSES.COLOR_TRANSPARENT);
+            }
+        } else {
+            if (this._dataTextureRenderers.colorRenderer) {
+                this._dataTextureRenderers.colorRenderer.drawLayer(frameCtx, this, RENDER_PASSES.COLOR_TRANSPARENT);
+            }
+        }
+    }
+
+    // ---------------------- RENDERING SAO POST EFFECT TARGETS --------------
+
+    drawDepth(renderFlags, frameCtx) {
+        if (this._numCulledLayerPortions === this._numPortions || this._numVisibleLayerPortions === 0 || this._numTransparentLayerPortions === this._numPortions || this._numXRayedLayerPortions === this._numPortions) {
+            return;
+        }
+        this._updateBackfaceCull(renderFlags, frameCtx);
+        if (this._dataTextureRenderers.depthRenderer) {
+            this._dataTextureRenderers.depthRenderer.drawLayer(frameCtx, this, RENDER_PASSES.COLOR_OPAQUE); // Assume whatever post-effect uses depth (eg SAO) does not apply to transparent objects
+        }
+    }
+
+    drawNormals(renderFlags, frameCtx) {
+        if (this._numCulledLayerPortions === this._numPortions || this._numVisibleLayerPortions === 0 || this._numTransparentLayerPortions === this._numPortions || this._numXRayedLayerPortions === this._numPortions) {
+            return;
+        }
+        this._updateBackfaceCull(renderFlags, frameCtx);
+        if (this._dataTextureRenderers.normalsRenderer) {
+            this._dataTextureRenderers.normalsRenderer.drawLayer(frameCtx, this, RENDER_PASSES.COLOR_OPAQUE);  // Assume whatever post-effect uses normals (eg SAO) does not apply to transparent objects
+        }
+    }
+
+    // ---------------------- SILHOUETTE RENDERING -----------------------------------
+
+    drawSilhouetteXRayed(renderFlags, frameCtx) {
+        if (this._numCulledLayerPortions === this._numPortions || this._numVisibleLayerPortions === 0 || this._numXRayedLayerPortions === 0) {
+            return;
+        }
+        this._updateBackfaceCull(renderFlags, frameCtx);
+        if (this._dataTextureRenderers.silhouetteRenderer) {
+            this._dataTextureRenderers.silhouetteRenderer.drawLayer(frameCtx, this, RENDER_PASSES.SILHOUETTE_XRAYED);
+        }
+    }
+
+    drawSilhouetteHighlighted(renderFlags, frameCtx) {
+        if (this._numCulledLayerPortions === this._numPortions || this._numVisibleLayerPortions === 0 || this._numHighlightedLayerPortions === 0) {
+            return;
+        }
+        this._updateBackfaceCull(renderFlags, frameCtx);
+        if (this._dataTextureRenderers.silhouetteRenderer) {
+            this._dataTextureRenderers.silhouetteRenderer.drawLayer(frameCtx, this, RENDER_PASSES.SILHOUETTE_HIGHLIGHTED);
+        }
+    }
+
+    drawSilhouetteSelected(renderFlags, frameCtx) {
+        if (this._numCulledLayerPortions === this._numPortions || this._numVisibleLayerPortions === 0 || this._numSelectedLayerPortions === 0) {
+            return;
+        }
+        this._updateBackfaceCull(renderFlags, frameCtx);
+        if (this._dataTextureRenderers.silhouetteRenderer) {
+            this._dataTextureRenderers.silhouetteRenderer.drawLayer(frameCtx, this, RENDER_PASSES.SILHOUETTE_SELECTED);
+        }
+    }
+
+    // ---------------------- EDGES RENDERING -----------------------------------
+
+    drawEdgesColorOpaque(renderFlags, frameCtx) {
+        if (this._numCulledLayerPortions === this._numPortions || this._numVisibleLayerPortions === 0 || this._numEdgesLayerPortions === 0) {
+            return;
+        }
+        if (this._dataTextureRenderers.edgesColorRenderer) {
+            this._dataTextureRenderers.edgesColorRenderer.drawLayer(frameCtx, this, RENDER_PASSES.EDGES_COLOR_OPAQUE);
+        }
+    }
+
+    drawEdgesColorTransparent(renderFlags, frameCtx) {
+        if (this._numCulledLayerPortions === this._numPortions || this._numVisibleLayerPortions === 0 || this._numEdgesLayerPortions === 0 || this._numTransparentLayerPortions === 0) {
+            return;
+        }
+        if (this._dataTextureRenderers.edgesColorRenderer) {
+            this._dataTextureRenderers.edgesColorRenderer.drawLayer(frameCtx, this, RENDER_PASSES.EDGES_COLOR_TRANSPARENT);
+        }
+    }
+
+    drawEdgesHighlighted(renderFlags, frameCtx) {
+        if (this._numCulledLayerPortions === this._numPortions || this._numVisibleLayerPortions === 0 || this._numHighlightedLayerPortions === 0) {
+            return;
+        }
+        if (this._dataTextureRenderers.edgesRenderer) {
+            this._dataTextureRenderers.edgesRenderer.drawLayer(frameCtx, this, RENDER_PASSES.EDGES_HIGHLIGHTED);
+        }
+    }
+
+    drawEdgesSelected(renderFlags, frameCtx) {
+        if (this._numCulledLayerPortions === this._numPortions || this._numVisibleLayerPortions === 0 || this._numSelectedLayerPortions === 0) {
+            return;
+        }
+        if (this._dataTextureRenderers.edgesRenderer) {
+            this._dataTextureRenderers.edgesRenderer.drawLayer(frameCtx, this, RENDER_PASSES.EDGES_SELECTED);
+        }
+    }
+
+    drawEdgesXRayed(renderFlags, frameCtx) {
+        if (this._numCulledLayerPortions === this._numPortions || this._numVisibleLayerPortions === 0 || this._numXRayedLayerPortions === 0) {
+            return;
+        }
+        if (this._dataTextureRenderers.edgesRenderer) {
+            this._dataTextureRenderers.edgesRenderer.drawLayer(frameCtx, this, RENDER_PASSES.EDGES_XRAYED);
+        }
+    }
+
+    // ---------------------- OCCLUSION CULL RENDERING -----------------------------------
+
+    drawOcclusion(renderFlags, frameCtx) {
+        if (this._numCulledLayerPortions === this._numPortions || this._numVisibleLayerPortions === 0) {
+            return;
+        }
+        this._updateBackfaceCull(renderFlags, frameCtx);
+        if (this._dataTextureRenderers.occlusionRenderer) {
+            this._dataTextureRenderers.occlusionRenderer.drawLayer(frameCtx, this, RENDER_PASSES.COLOR_OPAQUE);
+        }
+    }
+
+    // ---------------------- SHADOW BUFFER RENDERING -----------------------------------
+
+    drawShadow(renderFlags, frameCtx) {
+        if (this._numCulledLayerPortions === this._numPortions || this._numVisibleLayerPortions === 0) {
+            return;
+        }
+        this._updateBackfaceCull(renderFlags, frameCtx);
+        if (this._dataTextureRenderers.shadowRenderer) {
+            this._dataTextureRenderers.shadowRenderer.drawLayer(frameCtx, this, RENDER_PASSES.COLOR_OPAQUE);
+        }
+    }
+
+    //---- PICKING ----------------------------------------------------------------------------------------------------
+
+    drawPickMesh(renderFlags, frameCtx) {
+        if (this._numCulledLayerPortions === this._numPortions || this._numVisibleLayerPortions === 0) {
+            return;
+        }
+        this._updateBackfaceCull(renderFlags, frameCtx);
+        if (this._dataTextureRenderers.pickMeshRenderer) {
+            this._dataTextureRenderers.pickMeshRenderer.drawLayer(frameCtx, this, RENDER_PASSES.PICK);
+        }
+    }
+
+    drawPickDepths(renderFlags, frameCtx) {
+        if (this._numCulledLayerPortions === this._numPortions || this._numVisibleLayerPortions === 0) {
+            return;
+        }
+        this._updateBackfaceCull(renderFlags, frameCtx);
+        if (this._dataTextureRenderers.pickDepthRenderer) {
+            this._dataTextureRenderers.pickDepthRenderer.drawLayer(frameCtx, this, RENDER_PASSES.PICK);
+        }
+    }
+
+    drawPickNormals(renderFlags, frameCtx) {
+        if (this._numCulledLayerPortions === this._numPortions || this._numVisibleLayerPortions === 0) {
+            return;
+        }
+        this._updateBackfaceCull(renderFlags, frameCtx);
+        if (this._dataTextureRenderers.pickNormalsRenderer) {
+            this._dataTextureRenderers.pickNormalsRenderer.drawLayer(frameCtx, this, RENDER_PASSES.PICK);
+        }
+    }
+
+    //------------------------------------------------------------------------------------------------
+
+    precisionRayPickSurface(portionId, worldRayOrigin, worldRayDir, worldSurfacePos, worldNormal) {
+
+        if (!this.model.scene.pickSurfacePrecisionEnabled) {
+            return false;
+        }
+
+        const state = this._state;
+        const portion = this._portions[portionId];
+
+        if (!portion) {
+            this.model.error("portion not found: " + portionId);
+            return false;
+        }
+
+        const positions = portion.quantizedPositions;
+        const indices = portion.indices;
+        const origin = state.origin;
+        const offset = portion.offset;
+
+        const rtcRayOrigin = tempVec3a;
+        const rtcRayDir = tempVec3b;
+
+        rtcRayOrigin.set(origin ? math.subVec3(worldRayOrigin, origin, tempVec3c) : worldRayOrigin);  // World -> RTC
+        rtcRayDir.set(worldRayDir);
+
+        if (offset) {
+            math.subVec3(rtcRayOrigin, offset);
+        }
+
+        math.transformRay(this.model.worldNormalMatrix, rtcRayOrigin, rtcRayDir, rtcRayOrigin, rtcRayDir); // RTC -> local
+
+        const a = tempVec3d;
+        const b = tempVec3e;
+        const c = tempVec3f;
+
+        let gotIntersect = false;
+        let closestDist = 0;
+        const closestIntersectPos = tempVec3g;
+
+        for (let i = 0, len = indices.length; i < len; i += 3) {
+
+            const ia = indices[i] * 3;
+            const ib = indices[i + 1] * 3;
+            const ic = indices[i + 2] * 3;
+
+            a[0] = positions[ia];
+            a[1] = positions[ia + 1];
+            a[2] = positions[ia + 2];
+
+            b[0] = positions[ib];
+            b[1] = positions[ib + 1];
+            b[2] = positions[ib + 2];
+
+            c[0] = positions[ic];
+            c[1] = positions[ic + 1];
+            c[2] = positions[ic + 2];
+
+            math.decompressPosition(a, state.positionsDecodeMatrix);
+            math.decompressPosition(b, state.positionsDecodeMatrix);
+            math.decompressPosition(c, state.positionsDecodeMatrix);
+
+            if (math.rayTriangleIntersect(rtcRayOrigin, rtcRayDir, a, b, c, closestIntersectPos)) {
+
+                math.transformPoint3(this.model.worldMatrix, closestIntersectPos, closestIntersectPos);
+
+                if (offset) {
+                    math.addVec3(closestIntersectPos, offset);
+                }
+
+                if (origin) {
+                    math.addVec3(closestIntersectPos, origin);
+                }
+
+                const dist = Math.abs(math.lenVec3(math.subVec3(closestIntersectPos, worldRayOrigin, [])));
+
+                if (!gotIntersect || dist > closestDist) {
+                    closestDist = dist;
+                    worldSurfacePos.set(closestIntersectPos);
+                    if (worldNormal) { // Not that wasteful to eagerly compute - unlikely to hit >2 surfaces on most geometry
+                        math.triangleNormal(a, b, c, worldNormal);
+                    }
+                    gotIntersect = true;
+                }
+            }
+        }
+
+        if (gotIntersect && worldNormal) {
+            math.transformVec3(this.model.worldNormalMatrix, worldNormal, worldNormal);
+            math.normalizeVec3(worldNormal);
+        }
+
+        return gotIntersect;
+    }
+
+    // ---------
+
+    destroy() {
+        const state = this._state;
+        if (state.offsetsBuf) {
+            state.offsetsBuf.destroy();
+            state.offsetsBuf = null;
+        }
+        if (state.metallicRoughnessBuf) {
+            state.metallicRoughnessBuf.destroy();
+            state.metallicRoughnessBuf = null;
+        }
+        state.destroy();
+    }
+}
+
+/**
+ * This function applies two steps to the provided mesh geometry data:
+ * 
+ * - 1st, it reduces its `.positions` to unique positions, thus removing duplicate vertices. It will adjust the `.indices` and `.edgeIndices` array accordingly to the unique `.positions`.
+ * 
+ * - 2nd, it tries to do an optimization called `index rebucketting`
+ * 
+ *   _Rebucketting minimizes the amount of RAM usage for a given mesh geometry by trying do demote its needed index bitness._
+ * 
+ *   - _for 32 bit indices, will try to demote them to 16 bit indices_
+ *   - _for 16 bit indices, will try to demote them to 8 bits indices_
+ *   - _8 bits indices are kept as-is_
+ * 
+ *   The fact that 32/16/8 bits are needed for indices, depends on the number of maximumm indexable vertices within the mesh geometry: this is, the number of vertices in the mesh geometry.
+ * 
+ * The function returns the same provided input `geometryCfg`, enrichened with the additional key `.preparedBukets`.
+ * 
+ * @param {object} geometryCfg The mesh information containing `.positions`, `.indices`, `.edgeIndices` arrays.
+ * 
+ * @returns {object} The mesh information enrichened with `.preparedBuckets` key.
+ */
+function prepareMeshGeometry (geometryCfg) {
+    let uniquePositions, uniqueIndices, uniqueEdgeIndices;
+
+    [
+        uniquePositions,
+        uniqueIndices,
+        uniqueEdgeIndices,
+    ] = uniquifyPositions.uniquifyPositions ({
+        positions: geometryCfg.positions,
+        indices: geometryCfg.indices,
+        edgeIndices: geometryCfg.edgeIndices
+    });
+
+    let numUniquePositions = uniquePositions.length / 3;
+
+    let buckets = rebucketPositions (
+        {
+            positions: uniquePositions,
+            indices: uniqueIndices,
+            edgeIndices: uniqueEdgeIndices,
+        },
+        (numUniquePositions > (1<< 16)) ? 16 : 8,
+        // true
+    );
+
+    geometryCfg.preparedBuckets = buckets;
+
+    // chipmunk
+    // geometryCfg.preparedBuckets = [{
+    //     positions: uniquePositions,
+    //     indices: uniqueIndices,
+    //     edgeIndices: uniqueEdgeIndices,
+    // }];
+
+    return geometryCfg;
+}
+
+export {  prepareMeshGeometry, TrianglesDataTextureLayer };

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js
@@ -1149,11 +1149,11 @@ class TrianglesDataTextureLayer {
         this._setFlags(portionId, flags, transparent);
     }
 
-    _setFlags(portionId, flags, deferred = false) {
+    _setFlags(portionId, flags, transparent, deferred = false) {
         const subPortionMapping = this._subPortionIdMapping[portionId];
 
         for (let i = 0, len = subPortionMapping.length; i < len; i++) {
-            this._subPortionSetFlags (subPortionMapping[i], flags);
+            this._subPortionSetFlags (subPortionMapping[i], flags, transparent);
         }
     }
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js
@@ -22,7 +22,7 @@ import {
  * 
  * Limits the per-object texture height in the layer.
  */
-const MAX_NUMBER_OF_OBJECTS_IN_LAYER = (1 << 12);
+const MAX_NUMBER_OF_OBJECTS_IN_LAYER = (1 << 16);
 
 /**
  * 4096 is max data texture height

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js
@@ -450,20 +450,8 @@ class TrianglesDataTextureLayer {
             buffer.perObjectInstancePositioningMatrices.push (
                 meshMatrix
             );
-
-            // Mesh instance normal matrix
-            {
-                // Note: order of inverse and transpose doesn't matter
-                let transposedMat = math.transposeMat4(meshMatrix, math.mat4()); // TODO: Use cached matrix
-                let normalMatrix = math.inverseMat4(transposedMat);
-
-                buffer.perObjectInstanceNormalsMatrices.push (
-                    normalMatrix
-                );
-            }
         } else {
             buffer.perObjectInstancePositioningMatrices.push (identityMatrix);
-            buffer.perObjectInstanceNormalsMatrices.push (identityMatrix);
         }
 
         // const positions = cfg.positions;
@@ -733,8 +721,7 @@ class TrianglesDataTextureLayer {
         textureState.texturePerObjectIdPositionsDecodeMatrix = this.dataTextureGenerator.generateTextureForPositionsDecodeMatrices (
             gl,
             buffer.perObjectPositionsDecodeMatrices,
-            buffer.perObjectInstancePositioningMatrices,
-            buffer.perObjectInstanceNormalsMatrices
+            buffer.perObjectInstancePositioningMatrices
         ); 
 
         // position coordinates texture

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js
@@ -844,9 +844,18 @@ class TrianglesDataTextureLayer {
                 this.model.scene,
                 this._state.origin.slice ()
             );
+
+            this.model.pickCameraTexture = this.dataTextureGenerator.generateCameraDataTexture (
+                this.model.scene.canvas.gl,
+                this.model.scene.camera,
+                this.model.scene,
+                this._state.origin.slice (),
+                false
+            );
         }
 
         textureState.textureCameraMatrices = this.model.cameraTexture;
+        textureState.texturePickCameraMatrices = this.model.pickCameraTexture;
 
         // Mark the data-texture-state as finalized
         textureState.finalize ();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js
@@ -29,7 +29,7 @@ const MAX_NUMBER_OF_OBJECTS_IN_LAYER = (1 << 12);
  * 
  * Limits the aggregated geometry texture height in the layer.
  */
-const MAX_DATA_TEXTURE_HEIGHT = (1 << 11);
+const MAX_DATA_TEXTURE_HEIGHT = (1 << 12);
 
 /**
  * Align `indices` and `edgeIndices` memory layout to 8 elements.
@@ -210,15 +210,15 @@ class TrianglesDataTextureLayer {
                 numVertices += bucket.positions.length / 3;
             });
         
-            if ((state.numVertices + numVertices) > MAX_DATA_TEXTURE_HEIGHT * 1024 ||
-                (maxIndicesOfAnyBits + numIndices) > MAX_DATA_TEXTURE_HEIGHT * 1024)
+            if ((state.numVertices + numVertices) > MAX_DATA_TEXTURE_HEIGHT * 4096 ||
+                (maxIndicesOfAnyBits + numIndices) > MAX_DATA_TEXTURE_HEIGHT * 4096)
             {
                 dataTextureRamStats.cannotCreatePortion.becauseTextureSize++;
             }
 
             retVal &&=
-                (state.numVertices + numVertices) <= MAX_DATA_TEXTURE_HEIGHT * 1024 &&
-                (maxIndicesOfAnyBits + numIndices) <= MAX_DATA_TEXTURE_HEIGHT * 1024;
+                (state.numVertices + numVertices) <= MAX_DATA_TEXTURE_HEIGHT * 4096 &&
+                (maxIndicesOfAnyBits + numIndices) <= MAX_DATA_TEXTURE_HEIGHT * 4096;
         }
 
         // if (!retVal)
@@ -747,52 +747,80 @@ class TrianglesDataTextureLayer {
         );
 
         // portion Id texture for edges
-        textureState.texturePerEdgeIdPortionIds8Bits = this.dataTextureGenerator.generateTextureForPackedPortionIds (
-            gl,
-            buffer.perEdgeNumberPortionId8Bits
-        );
+        if (buffer.perEdgeNumberPortionId8Bits.length > 0)
+        {
+            textureState.texturePerEdgeIdPortionIds8Bits = this.dataTextureGenerator.generateTextureForPackedPortionIds (
+                gl,
+                buffer.perEdgeNumberPortionId8Bits
+            );
+        }
 
-        textureState.texturePerEdgeIdPortionIds16Bits = this.dataTextureGenerator.generateTextureForPackedPortionIds (
-            gl,
-            buffer.perEdgeNumberPortionId16Bits
-        );
+        if (buffer.perEdgeNumberPortionId16Bits.length > 0)
+        {
+            textureState.texturePerEdgeIdPortionIds16Bits = this.dataTextureGenerator.generateTextureForPackedPortionIds (
+               gl,
+               buffer.perEdgeNumberPortionId16Bits
+           );
+        }
 
-        textureState.texturePerEdgeIdPortionIds32Bits = this.dataTextureGenerator.generateTextureForPackedPortionIds (
-            gl,
-            buffer.perEdgeNumberPortionId32Bits
-        );
+
+        if (buffer.perEdgeNumberPortionId32Bits.length > 0)
+        {
+            textureState.texturePerEdgeIdPortionIds32Bits = this.dataTextureGenerator.generateTextureForPackedPortionIds (
+                gl,
+                buffer.perEdgeNumberPortionId32Bits
+            );
+        }
 
         // indices texture
-        textureState.texturePerPolygonIdIndices8Bits = this.dataTextureGenerator.generateTextureFor8BitIndices (
-            gl,
-            buffer.indices8Bits
-        );
+        if (buffer.indices8Bits.length > 0)
+        {
+            textureState.texturePerPolygonIdIndices8Bits = this.dataTextureGenerator.generateTextureFor8BitIndices (
+                gl,
+                buffer.indices8Bits
+            );
+        }
 
-        textureState.texturePerPolygonIdIndices16Bits = this.dataTextureGenerator.generateTextureFor16BitIndices (
-            gl,
-            buffer.indices16Bits
-        );
+        if (buffer.indices16Bits.length > 0)
+        {
+            textureState.texturePerPolygonIdIndices16Bits = this.dataTextureGenerator.generateTextureFor16BitIndices (
+                gl,
+                buffer.indices16Bits
+            );
+        }
 
-        textureState.texturePerPolygonIdIndices32Bits = this.dataTextureGenerator.generateTextureFor32BitIndices (
-            gl,
-            buffer.indices32Bits
-        );
+        if (buffer.indices32Bits.length > 0)
+        {
+            textureState.texturePerPolygonIdIndices32Bits = this.dataTextureGenerator.generateTextureFor32BitIndices (
+                gl,
+                buffer.indices32Bits
+            );
+        }
         
         // edge indices texture
-        textureState.texturePerPolygonIdEdgeIndices8Bits = this.dataTextureGenerator.generateTextureFor8BitsEdgeIndices (
-            gl,
-            buffer.edgeIndices8Bits
-        );
+        if (buffer.edgeIndices8Bits.length > 0)
+        {
+            textureState.texturePerPolygonIdEdgeIndices8Bits = this.dataTextureGenerator.generateTextureFor8BitsEdgeIndices (
+                gl,
+                buffer.edgeIndices8Bits
+            );
+        }
         
-        textureState.texturePerPolygonIdEdgeIndices16Bits = this.dataTextureGenerator.generateTextureFor16BitsEdgeIndices (
-            gl,
-            buffer.edgeIndices16Bits
-        );
+        if (buffer.edgeIndices16Bits.length > 0)
+        {
+            textureState.texturePerPolygonIdEdgeIndices16Bits = this.dataTextureGenerator.generateTextureFor16BitsEdgeIndices (
+                gl,
+                buffer.edgeIndices16Bits
+            );
+        }
         
-        textureState.texturePerPolygonIdEdgeIndices32Bits = this.dataTextureGenerator.generateTextureFor32BitsEdgeIndices (
-            gl,
-            buffer.edgeIndices32Bits
-        );
+        if (buffer.edgeIndices32Bits.length > 0)
+        {
+            textureState.texturePerPolygonIdEdgeIndices32Bits = this.dataTextureGenerator.generateTextureFor32BitsEdgeIndices (
+                gl,
+                buffer.edgeIndices32Bits
+            );
+        }
         
         // if (buffer.metallicRoughness.length > 0) {
         //     const metallicRoughness = new Uint8Array(buffer.metallicRoughness);

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js
@@ -1142,8 +1142,8 @@ class TrianglesDataTextureLayer {
         gl.texSubImage2D(
             gl.TEXTURE_2D,
             0, // level
-            0, // xoffset
-            portionId, // yoffset
+            (portionId % 512) * 7, // xoffset
+            Math.floor (portionId / 512), // yoffset
             1, // width
             1, //height
             gl.RGBA_INTEGER,
@@ -1267,8 +1267,8 @@ class TrianglesDataTextureLayer {
         gl.texSubImage2D(
             gl.TEXTURE_2D,
             0, // level
-            2, // xoffset
-            portionId, // yoffset
+            (portionId % 512) * 7 + 2, // xoffset
+            Math.floor (portionId / 512), // yoffset
             1, // width
             1, //height
             gl.RGBA_INTEGER,
@@ -1322,8 +1322,8 @@ class TrianglesDataTextureLayer {
         gl.texSubImage2D(
             gl.TEXTURE_2D,
             0, // level
-            3, // xoffset
-            portionId, // yoffset
+            (portionId % 512) * 7 + 3, // xoffset
+            Math.floor (portionId / 512), // yoffset
             1, // width
             1, //height
             gl.RGBA_INTEGER,

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js
@@ -844,7 +844,12 @@ class TrianglesDataTextureLayer {
                 this.model.scene,
                 this._state.origin.slice ()
             );
+        }
 
+        textureState.textureCameraMatrices = this.model.cameraTexture;
+
+        if (!this.model.pickCameraTexture)
+        {
             this.model.pickCameraTexture = this.dataTextureGenerator.generateCameraDataTexture (
                 this.model.scene.canvas.gl,
                 this.model.scene.camera,
@@ -854,7 +859,6 @@ class TrianglesDataTextureLayer {
             );
         }
 
-        textureState.textureCameraMatrices = this.model.cameraTexture;
         textureState.texturePickCameraMatrices = this.model.pickCameraTexture;
 
         // Mark the data-texture-state as finalized

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js
@@ -25,7 +25,7 @@ import {
 const MAX_NUMBER_OF_OBJECTS_IN_LAYER = (1 << 12);
 
 /**
- * 2048 is max data texture height
+ * 4096 is max data texture height
  * 
  * Limits the aggregated geometry texture height in the layer.
  */
@@ -714,7 +714,7 @@ class TrianglesDataTextureLayer {
         // per-object XYZ offsets
         textureState.texturePerObjectIdOffsets = this.dataTextureGenerator.generateTextureForObjectOffsets (
             gl,
-            buffer.perObjectOffsets,
+            this._numPortions
         );
 
         // per-object positions decode matrices texture

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js
@@ -1,11 +1,11 @@
-import {WEBGL_INFO} from "../../../../webglInfo.js";
+import {WEBGL_INFO} from "../../../../../webglInfo.js";
 import {ENTITY_FLAGS} from '../../ENTITY_FLAGS.js';
 import {RENDER_PASSES} from '../../RENDER_PASSES.js';
 
-import {math} from "../../../../math/math.js";
-import {RenderState} from "../../../../webgl/RenderState.js";
-import {ArrayBuf} from "../../../../webgl/ArrayBuf.js";
-import {geometryCompressionUtils} from "../../../../math/geometryCompressionUtils.js";
+import {math} from "../../../../../math/math.js";
+import {RenderState} from "../../../../../webgl/RenderState.js";
+import {ArrayBuf} from "../../../../../webgl/ArrayBuf.js";
+import {geometryCompressionUtils} from "../../../../../math/geometryCompressionUtils.js";
 import {getDataTextureRenderers} from "./TrianglesDataTextureRenderers.js";
 import {TrianglesDataTextureBuffer} from "./TrianglesDataTextureBuffer.js";
 import {quantizePositions, transformAndOctEncodeNormals} from "../../compression.js";
@@ -285,7 +285,7 @@ class TrianglesDataTextureLayer {
                 geometrySubPortionData,
                 bucketGeometry.positions,
                 geometryCfg.positionsDecodeMatrix,
-                geometryCfg.origin,
+                instancing ? objectCfg.origin : geometryCfg.origin,
                 aabb,
                 instancing
             );
@@ -553,6 +553,7 @@ class TrianglesDataTextureLayer {
         }
 
         // Adjust the world AABB with the object `origin`
+
         if (origin) {
             this._state.origin = origin;
             worldAABB[0] += origin[0];

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureRenderers.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureRenderers.js
@@ -1,0 +1,278 @@
+import {TrianglesDataTextureColorRenderer} from "./renderers/TrianglesDataTextureColorRenderer.js";
+import {TrianglesDataTextureSilhouetteRenderer} from "./renderers/TrianglesDataTextureSilhouetteRenderer.js";
+import {TrianglesDataTextureEdgesRenderer} from "./renderers/TrianglesDataTextureEdgesRenderer.js";
+import {TrianglesDataTextureEdgesColorRenderer} from "./renderers/TrianglesDataTextureEdgesColorRenderer.js";
+import {TrianglesDataTexturePickMeshRenderer} from "./renderers/TrianglesDataTexturePickMeshRenderer.js";
+import {TrianglesDataTexturePickDepthRenderer} from "./renderers/TrianglesDataTexturePickDepthRenderer.js";
+import {TrianglesDataTexturePickNormalsRenderer} from "./renderers/TrianglesDataTexturePickNormalsRenderer.js";
+import {TrianglesDataTextureOcclusionRenderer} from "./renderers/TrianglesDataTextureOcclusionRenderer.js";
+import {TrianglesDataTextureDepthRenderer} from "./renderers/TrianglesDataTextureDepthRenderer.js";
+import {TrianglesDataTextureNormalsRenderer} from "./renderers/TrianglesDataTextureNormalsRenderer.js";
+import {TrianglesDataTextureShadowRenderer} from "./renderers/TrianglesDataTextureShadowRenderer.js";
+import {TrianglesDataTextureColorQualityRenderer} from "./renderers/TrianglesDataTextureColorQualityRenderer.js";
+import {TrianglesDataTexturePickNormalsFlatRenderer} from "./renderers/TrianglesDataTexturePickNormalsFlatRenderer.js";
+
+/**
+ * @private
+ */
+class TrianglesDataTextureRenderers {
+
+    constructor(scene) {
+        this._scene = scene;
+    }
+
+    _compile() {
+        if (this._colorRenderer && (!this._colorRenderer.getValid())) {
+            this._colorRenderer.destroy();
+            this._colorRenderer = null;
+        }
+        if (this._colorRendererWithSAO && (!this._colorRendererWithSAO.getValid())) {
+            this._colorRendererWithSAO.destroy();
+            this._colorRendererWithSAO = null;
+        }
+        if (this._flatColorRenderer && (!this._flatColorRenderer.getValid())) {
+            this._flatColorRenderer.destroy();
+            this._flatColorRenderer = null;
+        }
+        if (this._flatColorRendererWithSAO && (!this._flatColorRendererWithSAO.getValid())) {
+            this._flatColorRendererWithSAO.destroy();
+            this._flatColorRendererWithSAO = null;
+        }
+        if (this._colorQualityRenderer && (!this._colorQualityRenderer.getValid())) {
+            this._colorQualityRenderer.destroy();
+            this._colorQualityRenderer = null;
+        }
+        if (this._colorQualityRendererWithSAO && (!this._colorQualityRendererWithSAO.getValid())) {
+            this._colorQualityRendererWithSAO.destroy();
+            this._colorQualityRendererWithSAO = null;
+        }
+        if (this._depthRenderer && (!this._depthRenderer.getValid())) {
+            this._depthRenderer.destroy();
+            this._depthRenderer = null;
+        }
+        if (this._normalsRenderer && (!this._normalsRenderer.getValid())) {
+            this._normalsRenderer.destroy();
+            this._normalsRenderer = null;
+        }
+        if (this._silhouetteRenderer && (!this._silhouetteRenderer.getValid())) {
+            this._silhouetteRenderer.destroy();
+            this._silhouetteRenderer = null;
+        }
+        if (this._edgesRenderer && (!this._edgesRenderer.getValid())) {
+            this._edgesRenderer.destroy();
+            this._edgesRenderer = null;
+        }
+        if (this._edgesColorRenderer && (!this._edgesColorRenderer.getValid())) {
+            this._edgesColorRenderer.destroy();
+            this._edgesColorRenderer = null;
+        }
+        if (this._pickMeshRenderer && (!this._pickMeshRenderer.getValid())) {
+            this._pickMeshRenderer.destroy();
+            this._pickMeshRenderer = null;
+        }
+        if (this._pickDepthRenderer && (!this._pickDepthRenderer.getValid())) {
+            this._pickDepthRenderer.destroy();
+            this._pickDepthRenderer = null;
+        }
+        if (this._pickNormalsRenderer && this._pickNormalsRenderer.getValid() === false) {
+            this._pickNormalsRenderer.destroy();
+            this._pickNormalsRenderer = null;
+        }
+        if (this._pickNormalsFlatRenderer && this._pickNormalsFlatRenderer.getValid() === false) {
+            this._pickNormalsFlatRenderer.destroy();
+            this._pickNormalsFlatRenderer = null;
+        }
+        if (this._occlusionRenderer && this._occlusionRenderer.getValid() === false) {
+            this._occlusionRenderer.destroy();
+            this._occlusionRenderer = null;
+        }
+        if (this._shadowRenderer && (!this._shadowRenderer.getValid())) {
+            this._shadowRenderer.destroy();
+            this._shadowRenderer = null;
+        }
+    }
+
+    get colorRenderer() {
+        if (!this._colorRenderer) {
+            this._colorRenderer = new TrianglesDataTextureColorRenderer(this._scene, false);
+        }
+        return this._colorRenderer;
+    }
+
+    get colorRendererWithSAO() {
+        if (!this._colorRendererWithSAO) {
+            this._colorRendererWithSAO = new TrianglesDataTextureColorRenderer(this._scene, true);
+        }
+        return this._colorRendererWithSAO;
+    }
+
+    get colorQualityRenderer() {
+        if (!this._colorQualityRenderer) {
+            this._colorQualityRenderer = new TrianglesDataTextureColorQualityRenderer(this._scene, false);
+        }
+        return this._colorQualityRenderer;
+    }
+
+    get colorQualityRendererWithSAO() {
+        if (!this._colorQualityRendererWithSAO) {
+            this._colorQualityRendererWithSAO = new TrianglesDataTextureColorQualityRenderer(this._scene, true);
+        }
+        return this._colorQualityRendererWithSAO;
+    }
+
+    get silhouetteRenderer() {
+        if (!this._silhouetteRenderer) {
+            this._silhouetteRenderer = new TrianglesDataTextureSilhouetteRenderer(this._scene);
+        }
+        return this._silhouetteRenderer;
+    }
+
+    get depthRenderer() {
+        if (!this._depthRenderer) {
+            this._depthRenderer = new TrianglesDataTextureDepthRenderer(this._scene);
+        }
+        return this._depthRenderer;
+    }
+
+    get normalsRenderer() {
+        if (!this._normalsRenderer) {
+            this._normalsRenderer = new TrianglesDataTextureNormalsRenderer(this._scene);
+        }
+        return this._normalsRenderer;
+    }
+
+    get edgesRenderer() {
+        if (!this._edgesRenderer) {
+            this._edgesRenderer = new TrianglesDataTextureEdgesRenderer(this._scene);
+        }
+        return this._edgesRenderer;
+    }
+
+    get edgesColorRenderer() {
+        if (!this._edgesColorRenderer) {
+            this._edgesColorRenderer = new TrianglesDataTextureEdgesColorRenderer(this._scene);
+        }
+        return this._edgesColorRenderer;
+    }
+
+    get pickMeshRenderer() {
+        if (!this._pickMeshRenderer) {
+            this._pickMeshRenderer = new TrianglesDataTexturePickMeshRenderer(this._scene);
+        }
+        return this._pickMeshRenderer;
+    }
+
+    get pickNormalsRenderer() {
+        if (!this._pickNormalsRenderer) {
+            this._pickNormalsRenderer = new TrianglesDataTexturePickNormalsRenderer(this._scene);
+        }
+        return this._pickNormalsRenderer;
+    }
+
+    get pickNormalsFlatRenderer() {
+        if (!this._pickNormalsFlatRenderer) {
+            this._pickNormalsFlatRenderer = new TrianglesDataTexturePickNormalsFlatRenderer(this._scene);
+        }
+        return this._pickNormalsFlatRenderer;
+    }
+
+    get pickDepthRenderer() {
+        if (!this._pickDepthRenderer) {
+            this._pickDepthRenderer = new TrianglesDataTexturePickDepthRenderer(this._scene);
+        }
+        return this._pickDepthRenderer;
+    }
+
+    get occlusionRenderer() {
+        if (!this._occlusionRenderer) {
+            this._occlusionRenderer = new TrianglesDataTextureOcclusionRenderer(this._scene);
+        }
+        return this._occlusionRenderer;
+    }
+
+    get shadowRenderer() {
+        if (!this._shadowRenderer) {
+            this._shadowRenderer = new TrianglesDataTextureShadowRenderer(this._scene);
+        }
+        return this._shadowRenderer;
+    }
+
+    _destroy() {
+        if (this._colorRenderer) {
+            this._colorRenderer.destroy();
+        }
+        if (this._colorRendererWithSAO) {
+            this._colorRendererWithSAO.destroy();
+        }
+        if (this._flatColorRenderer) {
+            this._flatColorRenderer.destroy();
+        }
+        if (this._flatColorRendererWithSAO) {
+            this._flatColorRendererWithSAO.destroy();
+        }
+        if (this._colorQualityRenderer) {
+            this._colorQualityRenderer.destroy();
+        }
+        if (this._colorQualityRendererWithSAO) {
+            this._colorQualityRendererWithSAO.destroy();
+        }
+        if (this._depthRenderer) {
+            this._depthRenderer.destroy();
+        }
+        if (this._normalsRenderer) {
+            this._normalsRenderer.destroy();
+        }
+        if (this._silhouetteRenderer) {
+            this._silhouetteRenderer.destroy();
+        }
+        if (this._edgesRenderer) {
+            this._edgesRenderer.destroy();
+        }
+        if (this._edgesColorRenderer) {
+            this._edgesColorRenderer.destroy();
+        }
+        if (this._pickMeshRenderer) {
+            this._pickMeshRenderer.destroy();
+        }
+        if (this._pickDepthRenderer) {
+            this._pickDepthRenderer.destroy();
+        }
+        if (this._pickNormalsRenderer) {
+            this._pickNormalsRenderer.destroy();
+        }
+        if (this._pickNormalsFlatRenderer) {
+            this._pickNormalsFlatRenderer.destroy();
+        }
+        if (this._occlusionRenderer) {
+            this._occlusionRenderer.destroy();
+        }
+        if (this._shadowRenderer) {
+            this._shadowRenderer.destroy();
+        }
+    }
+}
+
+const cachdRenderers = {};
+
+/**
+ * @private
+ */
+function getDataTextureRenderers(scene) {
+    const sceneId = scene.id;
+    let dataTextureRenderers = cachdRenderers[sceneId];
+    if (!dataTextureRenderers) {
+        dataTextureRenderers = new TrianglesDataTextureRenderers(scene);
+        cachdRenderers[sceneId] = dataTextureRenderers;
+        dataTextureRenderers._compile();
+        scene.on("compile", () => {
+            dataTextureRenderers._compile();
+        });
+        scene.on("destroyed", () => {
+            delete cachdRenderers[sceneId];
+            dataTextureRenderers._destroy();
+        });
+    }
+    return dataTextureRenderers;
+}
+
+export {getDataTextureRenderers};

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/ViewFrustumCullingManager.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/ViewFrustumCullingManager.js
@@ -253,6 +253,10 @@ const VISIBILITY_CHECK_ENVOLVES_V = (1 << 14);
             throw "Not finalized";
         }
 
+        if (!this._aabbTree) {
+            return;
+        }
+        
         if (!this._canvasElement) {
             /**
              * @type {HTMLCanvasElement}
@@ -297,6 +301,11 @@ const VISIBILITY_CHECK_ENVOLVES_V = (1 << 14);
         {
             return;
         }
+
+        if (!this._aabbTree) {
+            return;
+        }
+
         const allAabbNodes = this._aabbTree.all();
 
         let maxEntityId = 0;

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/ViewFrustumCullingManager.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/ViewFrustumCullingManager.js
@@ -1,11 +1,10 @@
 import { clusterizeV2 } from "./cluster-helper.js";
-import { math } from "../../../../math/math.js";
+import { math } from "../../../../../math/math.js";
 
 // For JSDoc autocompletion
 import { DataTexturePeformanceModel }  from "../../../DataTexturePeformanceModel.js"
-import { Camera } from "../../../../camera/Camera.js"
 import { RBush3D } from "./rbush3d.js";
-import { PerformanceNode } from "../../PerformanceNode.js";
+import { VBOSceneModelNode } from "../../VBOSceneModelNode.js";
 
 let tempVec3 = math.vec3 ();
 
@@ -266,10 +265,6 @@ const VISIBILITY_CHECK_ENVOLVES_V = (1 << 14);
         }
 
         if (!this._camera) {
-            /**
-             * @type {Camera}
-             * @private
-             */
             this._camera = model.scene.camera;
         }
 
@@ -326,7 +321,7 @@ const VISIBILITY_CHECK_ENVOLVES_V = (1 << 14);
         });
 
         /**
-         * @type {Array<PerformanceNode>}
+         * @type {Array<VBOSceneModelNode>}
          * @private
          */
         this._internalNodesList = internalNodesList;

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/ViewFrustumCullingManager.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/ViewFrustumCullingManager.js
@@ -1,0 +1,724 @@
+import { clusterizeV2 } from "./cluster-helper.js";
+import { math } from "../../../../math/math.js";
+
+// For JSDoc autocompletion
+import { DataTexturePeformanceModel }  from "../../../DataTexturePeformanceModel.js"
+import { Camera } from "../../../../camera/Camera.js"
+import { RBush3D } from "./rbush3d.js";
+import { PerformanceNode } from "../../PerformanceNode.js";
+
+let tempVec3 = math.vec3 ();
+
+/**
+ * Number of bits per-dimension in the 2-dimensional LUT fast atan table
+ */
+const ATAN2_LUT_BITS = 9;
+
+const ATAN2_FACTOR = 1 << (ATAN2_LUT_BITS - 1);
+
+/**
+ * Constant for quick conversion of radians to degrees
+ */
+const _180_DIV_MATH_PI = 180 / Math.PI;
+
+const atan2LUT = new Float32Array ((1 << ATAN2_LUT_BITS) * (1 << ATAN2_LUT_BITS));
+
+// Initialize the Look Up Table
+for (let i = -ATAN2_FACTOR; i < ATAN2_FACTOR; i++)
+{
+    for (let j = -ATAN2_FACTOR; j < ATAN2_FACTOR; j++)
+    {
+        const index = ((i+ATAN2_FACTOR) << ATAN2_LUT_BITS) + (j+ATAN2_FACTOR);
+
+        const max = Math.max (
+            Math.abs (i),
+            Math.abs (j)
+        );
+
+        atan2LUT [index] = Math.atan2 (
+            i/max,
+            j/max
+        );
+    }
+}
+
+/**
+ * Fast ````Math.atan2```` implementation based in Look Up Tables.
+ * 
+ * @param {number} x 
+ * @param {number} y 
+ * 
+ * @returns {number}
+ */
+function fastAtan2(x, y)
+{
+    const max_factor = ATAN2_FACTOR / Math.max (
+        Math.abs (x),
+        Math.abs (y)
+    );
+
+    const xx = Math.round (
+        x * max_factor
+    ) + (ATAN2_FACTOR - 1);
+
+    const yy = Math.round (
+        y * max_factor
+    ) + (ATAN2_FACTOR - 1);
+
+    return atan2LUT [(xx << ATAN2_LUT_BITS) + yy];
+}
+
+const VISIBILITY_CHECK_ALL_D = (1 << 0);
+const VISIBILITY_CHECK_NONE_D = (1 << 1);
+const VISIBILITY_CHECK_D_LESS = (1 << 2);
+const VISIBILITY_CHECK_D_MORE = (1 << 3);
+
+const VISIBILITY_CHECK_ALL_H = (1 << 4);
+const VISIBILITY_CHECK_NONE_H = (1 << 5);
+const VISIBILITY_CHECK_H_LESS = (1 << 6);
+const VISIBILITY_CHECK_H_MORE = (1 << 7);
+
+const VISIBILITY_CHECK_ALL_V = (1 << 8);
+const VISIBILITY_CHECK_NONE_V = (1 << 9);
+const VISIBILITY_CHECK_V_LESS = (1 << 10);
+const VISIBILITY_CHECK_V_MORE = (1 << 11);
+
+const VISIBILITY_CHECK_ENVOLVES_D = (1 << 12);
+const VISIBILITY_CHECK_ENVOLVES_H = (1 << 13);
+const VISIBILITY_CHECK_ENVOLVES_V = (1 << 14);
+
+/**
+ * Data structure containing pre-initialized `View Frustum Culling` data.
+ * 
+ * Will be used by the rest of `View Frustum Culling` related code.
+ */
+ class ViewFrustumCullingState {
+    constructor () {
+        /**
+         * The pre-computed AABB tree that will be used for efficient View Frustum Culling.
+         * 
+         * @type {RBush3D}
+         * @private
+         */
+        this._aabbTree = null;
+
+        /**
+         * @type {Array<{mesh: object, clusterNumber: number}>}
+         * @private
+         */
+        this._orderedMeshList = [];
+
+        /**
+         * @type {Array<object>}
+         * @private
+         */
+        this._orderedEntityList = [];
+
+        /**
+         * @private
+         */
+        this._frustumProps = {
+            dirty: true,
+            wMultiply: 1.0,
+            hMultiply: 1.0,
+        };
+
+        /**
+         * @private
+         */
+        this._cullFrame = 0;
+
+        /**
+         * @type {boolean}
+         * @private
+         */
+        this.finalized = false;
+    }
+
+    /**
+     * 
+     * @param {Array<object>} entityList 
+     * @param {Array<object>} meshList 
+     */
+    initializeVfcState (entityList, meshList) {
+        if (this.finalized) {
+            throw "Already finalized";
+        }
+
+        const clusterResult = clusterizeV2 (entityList, meshList);
+
+        this._aabbTree = clusterResult.rTreeBasedAabbTree;
+
+        for (let i = 0, len = clusterResult.orderedClusteredIndexes.length; i < len; i++)
+        {
+            const entityIndex = clusterResult.orderedClusteredIndexes[i];
+
+            const clusterNumber = clusterResult.entityIdToClusterIdMapping[entityIndex];
+
+            const entity = entityList[entityIndex];
+
+            const newMeshIds = [];
+
+            for (let j = 0, len2 = entity.meshIds.length; j < len2; j++)
+            {
+                const meshIndex = entity.meshIds[j];
+
+                meshList[meshIndex].id = this._orderedMeshList.length;
+
+                newMeshIds.push (this._orderedMeshList.length);
+
+                this._orderedMeshList.push ({
+                    clusterNumber: clusterNumber,
+                    mesh: meshList[meshIndex]
+                });
+            }
+
+            entity.meshIds = newMeshIds;
+
+            this._orderedEntityList.push (
+                entity
+            );
+        }
+
+        for (let i = 0, len = clusterResult.instancedIndexes.length; i < len; i++) {
+            const entityIndex = clusterResult.instancedIndexes[i];
+
+            let entity = entityList[entityIndex];
+
+            const newMeshIds = [];
+
+            for (let j = 0, len2 = entity.meshIds.length; j < len2; j++)
+            {
+                const meshIndex = entity.meshIds[j];
+
+                meshList[meshIndex].id = this._orderedMeshList.length;
+
+                newMeshIds.push (this._orderedMeshList.length);
+
+                this._orderedMeshList.push ({
+                    clusterNumber: 99999,
+                    mesh: meshList[meshIndex]
+                });
+            }
+
+            entity.meshIds = newMeshIds;
+
+            this._orderedEntityList.push (
+                entity
+            );
+        }
+    }
+
+    /**
+     * @param {DataTexturePeformanceModel} model
+     * @param {*} fnForceFinalizeLayer 
+     */
+    finalize (model, fnForceFinalizeLayer) {
+        if (this.finalized) {
+            throw "Already finalized";
+        }
+
+        let lastClusterNumber = -1;
+
+        for (let i = 0, len = this._orderedMeshList.length; i < len; i++) {
+            const { clusterNumber, mesh } = this._orderedMeshList [i];
+
+            if (lastClusterNumber != -1 && lastClusterNumber != clusterNumber) {
+                fnForceFinalizeLayer.call (model);
+            }
+
+            model.createMesh (mesh);
+
+            lastClusterNumber = clusterNumber;
+        }
+
+        // fnForceFinalizeLayer ();
+
+        for (let i = 0, len = this._orderedEntityList.length; i < len; i++) {
+            model.createEntity (this._orderedEntityList[i])
+        }
+
+        // Free memory
+        this._orderedMeshList = [];
+        this._orderedEntityList = [];
+
+        this.finalized = true;
+    }
+
+    /**
+     * @param {DataTexturePeformanceModel} model
+     */
+    applyViewFrustumCulling (model) {
+        if (!this.finalized) {
+            throw "Not finalized";
+        }
+
+        if (!this._canvasElement) {
+            /**
+             * @type {HTMLCanvasElement}
+             * @private
+             */
+            this._canvasElement = model.scene.canvas.canvas;
+        }
+
+        if (!this._camera) {
+            /**
+             * @type {Camera}
+             * @private
+             */
+            this._camera = model.scene.camera;
+        }
+
+        this._ensureFrustumPropsUpdated ();
+
+        this._initializeCullingDataIfNeeded (model);
+
+        const visibleNodes = this._searchVisibleNodesWithFrustumCulling ();
+
+        // console.log (`visibleNodes: ${visibleNodes.length} / ${this._internalNodesList.length}`);
+
+        this._cullFrame++;
+
+        this._markVisibleFrameOfVisibleNodes (
+            visibleNodes,
+            this._cullFrame
+        );
+        
+        this._cullNonVisibleNodes (
+            model,
+            this._cullFrame
+        );
+
+        // console.log (`${numIntersectionChecks} intersection checks`);
+    }
+
+    _initializeCullingDataIfNeeded (model) {
+        if (this._internalNodesList)
+        {
+            return;
+        }
+        const allAabbNodes = this._aabbTree.all();
+
+        let maxEntityId = 0;
+
+        allAabbNodes.forEach (aabbbNode => {
+            maxEntityId = Math.max (
+                maxEntityId,
+                aabbbNode.entity.id
+            )
+        });
+
+        const internalNodesList = new Array(maxEntityId + 1);
+
+        allAabbNodes.forEach (aabbbNode => {
+            internalNodesList [
+                aabbbNode.entity.id
+            ] = model._nodes[aabbbNode.entity.xeokitId];
+        });
+
+        /**
+         * @type {Array<PerformanceNode>}
+         * @private
+         */
+        this._internalNodesList = internalNodesList;
+
+        /**
+         * @private
+         */
+        this._lastVisibleFrameOfNodes = new Array (internalNodesList.length);
+
+        this._lastVisibleFrameOfNodes.fill(0);
+    }
+
+    _searchVisibleNodesWithFrustumCulling() {
+        return this._aabbTree.searchCustom(
+            (bbox, isLeaf) => this._aabbIntersectsCameraFrustum (bbox, isLeaf),
+            (bbox) => this._aabbContainedInCameraFrustum (bbox)
+        )
+    }
+
+    _markVisibleFrameOfVisibleNodes (visibleNodes, cullFrame) {
+        const lastVisibleFrameOfNodes = this._lastVisibleFrameOfNodes;
+
+        for (let i = 0, len = visibleNodes.length; i < len; i++)
+        {
+            lastVisibleFrameOfNodes [visibleNodes[i].entity.id] = cullFrame;
+        }
+    }
+
+    _cullNonVisibleNodes (model, cullFrame) {
+        const internalNodesList = this._internalNodesList;
+        const lastVisibleFrameOfNodes = this._lastVisibleFrameOfNodes;
+
+        model.beginDeferredFlagsInAllLayers ();
+
+        for (let i = 0, len = internalNodesList.length; i < len; i++)
+        {
+            if (internalNodesList[i]) {
+                internalNodesList[i].culledVFC = lastVisibleFrameOfNodes[i] !== cullFrame;
+            }
+        }
+
+        model.commitDeferredFlagsInAllLayers ();
+    }
+
+    /**
+     * Returns all 8 coordinates of an AABB.
+     * 
+     * @param {Array<number>} bbox An AABB
+     * 
+     * @private
+     */
+    _getPointsForBBox (bbox) {
+        var retVal = [];
+
+        for (var i = 0; i < 8; i++)
+        {
+            retVal.push ([
+                (i & 1) ? bbox.maxX : bbox.minX,
+                (i & 2) ? bbox.maxY : bbox.minY,
+                (i & 4) ? bbox.maxZ : bbox.minZ,
+            ]);
+        }
+
+        return retVal;
+    }
+
+    /**
+     * @param {*} bbox 
+     * @param {*} isLeaf 
+     * @returns 
+     * 
+     * @private
+     */
+    _aabbIntersectsCameraFrustum (bbox, isLeaf)
+    {
+        if (isLeaf) {
+            return true;
+        }
+
+        if (this._camera.projection == "ortho") {
+            // TODO: manage ortho views
+            this._frustumProps.dirty = false;
+            return true;
+        }
+
+        // numIntersectionChecks++;
+
+        var check = this._aabbIntersectsCameraFrustum_internal (bbox);
+
+        var interD = !(check & VISIBILITY_CHECK_ALL_D) && !(check & VISIBILITY_CHECK_NONE_D);
+        var interH = !(check & VISIBILITY_CHECK_ALL_H) && !(check & VISIBILITY_CHECK_NONE_H);
+        var interV = !(check & VISIBILITY_CHECK_ALL_V) && !(check & VISIBILITY_CHECK_NONE_V);
+
+        if (((check & VISIBILITY_CHECK_ENVOLVES_D) || interD || (check & VISIBILITY_CHECK_ALL_D)) &&
+            ((check & VISIBILITY_CHECK_ENVOLVES_H) || interH || (check & VISIBILITY_CHECK_ALL_H)) &&
+            ((check & VISIBILITY_CHECK_ENVOLVES_V) || interV || (check & VISIBILITY_CHECK_ALL_V)))
+        {
+            return true;
+        }
+        
+        return false;
+    }
+
+    /**
+     * @param {*} bbox 
+     * @returns 
+     * 
+     * @private
+     */
+    _aabbContainedInCameraFrustum (bbox)
+    {
+        if (this._camera.projection == "ortho") {
+            // TODO: manage ortho views
+            this._frustumProps.dirty = false;
+            return true;
+        }
+
+        var check = bbox._check;
+
+        return (check & VISIBILITY_CHECK_ALL_D) &&
+               (check & VISIBILITY_CHECK_ALL_H) &&
+               (check & VISIBILITY_CHECK_ALL_V);
+    }
+
+    /**
+     * @private
+     */
+    _ensureFrustumPropsUpdated ()
+    {
+        // Assuming "min" for fovAxis
+        const min = Math.min (
+            this._canvasElement.width,
+            this._canvasElement.height
+        );
+
+        this._frustumProps.wMultiply = this._canvasElement.width / min;
+        this._frustumProps.hMultiply = this._canvasElement.height / min;
+        
+        const aspect = this._canvasElement.width / this._canvasElement.height;
+
+        let fov = this._camera.perspective.fov;
+
+        if (aspect < 1)
+        {
+            fov = fov / aspect;
+        }
+
+        fov = Math.min (fov, 120);
+
+        this._frustumProps.fov = fov;
+        
+        // if (!this._frustumProps.dirty)
+        // {
+        //     return;
+        // }
+
+        this._frustumProps.forward = math.normalizeVec3 (
+            math.subVec3 (
+                this._camera.look,
+                this._camera.eye,
+                [ 0, 0, 0]
+            ),
+            [ 0, 0, 0]
+        );
+
+        this._frustumProps.up = math.normalizeVec3(
+            this._camera.up,
+            [ 0, 0, 0 ]
+        );
+
+        this._frustumProps.right = math.normalizeVec3 (
+            math.cross3Vec3 (
+                this._frustumProps.forward,
+                this._frustumProps.up,
+                [ 0, 0, 0]
+            ),
+            [ 0, 0, 0 ]
+        );
+
+        this._frustumProps.eye = this._camera.eye.slice ();
+
+        this._frustumProps.CAM_FACTOR_1 = this._frustumProps.fov / 2 * this._frustumProps.wMultiply / _180_DIV_MATH_PI;
+        this._frustumProps.CAM_FACTOR_2 = this._frustumProps.fov / 2 * this._frustumProps.hMultiply / _180_DIV_MATH_PI;
+
+        // this._frustumProps.dirty = false;
+    }
+
+    /**
+     * @param {*} bbox 
+     * @returns 
+     * 
+     * @private
+     */
+    _aabbIntersectsCameraFrustum_internal (bbox)
+    {
+        var bboxPoints = bbox._points || this._getPointsForBBox (bbox);
+
+        bbox._points = bboxPoints;
+                    
+        var retVal = 
+            VISIBILITY_CHECK_ALL_D | VISIBILITY_CHECK_NONE_D |
+            VISIBILITY_CHECK_ALL_H | VISIBILITY_CHECK_NONE_H |
+            VISIBILITY_CHECK_ALL_V | VISIBILITY_CHECK_NONE_V;
+
+        if (window._debug)
+        {
+            window._debug = false;
+
+            debugger;
+        }
+
+        for (var i = 0, len = bboxPoints.length; i < len; i++) {
+            // if ((!(retVal & VISIBILITY_CHECK_ALL_D) && !(retVal & VISIBILITY_CHECK_NONE_D)) ||
+            //     (!(retVal & VISIBILITY_CHECK_ALL_H) && !(retVal & VISIBILITY_CHECK_NONE_H)) ||
+            //     (!(retVal & VISIBILITY_CHECK_ALL_V) && !(retVal & VISIBILITY_CHECK_NONE_V)))
+            // {
+            //     break;
+            // }
+
+            var bboxPoint = bboxPoints [i];
+
+            var pointRelToCam = tempVec3;
+
+            pointRelToCam[0] = bboxPoint[0] - this._frustumProps.eye[0];
+            pointRelToCam[1] = bboxPoint[1] - this._frustumProps.eye[1];
+            pointRelToCam[2] = bboxPoint[2] - this._frustumProps.eye[2];
+
+            var forwardComponent = math.dotVec3 (
+                pointRelToCam,
+                this._frustumProps.forward
+            );
+
+            if (forwardComponent < 0)
+            {
+                retVal |= VISIBILITY_CHECK_D_LESS;
+                retVal &= ~VISIBILITY_CHECK_ALL_D;
+            }
+            else
+            {
+                retVal |= VISIBILITY_CHECK_D_MORE;
+                retVal &= ~VISIBILITY_CHECK_NONE_D;
+            }
+
+            var rightComponent = math.dotVec3 (
+                pointRelToCam,
+                this._frustumProps.right
+            );
+
+            var rightAngle = fastAtan2 (
+                rightComponent,
+                forwardComponent
+            );
+
+            if (Math.abs (rightAngle) > this._frustumProps.CAM_FACTOR_1)
+            {
+                if (rightAngle < 0)
+                    retVal |= VISIBILITY_CHECK_H_LESS;
+                else
+                    retVal |= VISIBILITY_CHECK_H_MORE;
+
+                retVal &= ~VISIBILITY_CHECK_ALL_H;
+            }
+            else
+            {
+                retVal &= ~VISIBILITY_CHECK_NONE_H;
+            }
+
+            var upComponent = math.dotVec3 (
+                pointRelToCam,
+                this._frustumProps.up
+            );
+
+            var upAngle = fastAtan2 (
+                upComponent,
+                forwardComponent
+            );
+
+            if (Math.abs (upAngle) > this._frustumProps.CAM_FACTOR_2)
+            {
+                if (upAngle < 0)
+                    retVal |= VISIBILITY_CHECK_V_LESS;
+                else
+                    retVal |= VISIBILITY_CHECK_V_MORE;
+
+                retVal &= ~VISIBILITY_CHECK_ALL_V;
+            }
+            else
+            {
+                retVal &= ~VISIBILITY_CHECK_NONE_V;
+            }
+        }
+
+        // console.log (retVal);
+        
+        if ((retVal & VISIBILITY_CHECK_D_LESS) && (retVal & VISIBILITY_CHECK_D_MORE))
+        {
+            retVal |= VISIBILITY_CHECK_ENVOLVES_D;    
+        }
+
+        if ((retVal & VISIBILITY_CHECK_H_LESS) && (retVal & VISIBILITY_CHECK_H_MORE))
+        {
+            retVal |= VISIBILITY_CHECK_ENVOLVES_H;    
+        }
+
+        if ((retVal & VISIBILITY_CHECK_V_LESS) && (retVal & VISIBILITY_CHECK_V_MORE))
+        {
+            retVal |= VISIBILITY_CHECK_ENVOLVES_V;    
+        }
+
+        bbox._check = retVal;
+
+        // console.log (retVal);
+
+        return retVal;
+    }
+}
+
+class ViewFrustumCullingManager {
+    /**
+     * @param {DataTexturePeformanceModel} model
+     */
+    constructor (model) {
+        /**
+         * @private
+         */
+        this.model = model;
+
+        /**
+         * @private
+         */
+        this.entities = [];
+
+        /**
+         * @private
+         */
+        this.meshes = [];
+
+        this.finalized = false;
+    }
+
+    /**
+     */
+    addEntity (entity) {
+        if (this.finalized) {
+            throw "Already finalized";
+        }
+
+        this.entities.push (entity);
+    }
+
+    /**
+     */
+    addMesh (mesh) {
+        if (this.finalized) {
+            throw "Already finalized";
+        }
+
+        this.meshes.push (mesh);
+    }
+    
+    finalize (fnForceFinalizeLayer) {
+        if (this.finalized) {
+            throw "Already finalized";
+        }
+                
+        this.finalized = true;
+
+        /**
+         * @private
+         */
+        this.vfcState = new ViewFrustumCullingState ();
+
+        console.time ("initializeVfcState");
+                 
+        this.vfcState.initializeVfcState (this.entities, this.meshes);
+                 
+        console.timeEnd ("initializeVfcState");
+         
+        console.time ("finalizeVfcState");
+                 
+        this.vfcState.finalize (this.model, fnForceFinalizeLayer);
+                 
+        console.timeEnd ("finalizeVfcState");
+        
+        const self = this;
+
+        const cb = () => this.applyViewFrustumCulling.call (self);
+
+        this.model.scene.on ("rendering", cb);
+    }
+
+    /**
+     * @private
+     */
+    applyViewFrustumCulling () {
+        if (!(this.finalized)) {
+            throw "Not finalized";
+        }
+
+        this.vfcState.applyViewFrustumCulling (this.model);
+     }
+}
+
+export { ViewFrustumCullingManager }

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/calculateUniquePositions.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/calculateUniquePositions.js
@@ -1,0 +1,156 @@
+/**
+ * @author https://github.com/tmarti, with support from https://tribia.com/
+ * @license MIT
+ * 
+ * This file takes a geometry given by { positions, indices }, and returns
+ * equivalent { positions, indices } arrays but which only contain unique
+ * positions.
+ * 
+ * The time is O(N logN) with the number of positions due to a pre-sorting
+ * step, but is much more GC-friendly and actually faster than the classic O(N)
+ * approach based in keeping a hash-based LUT to identify unique positions.
+ */
+ let comparePositions = null;
+
+function compareVertex (a, b) {
+    let res;
+
+    for (let i = 0; i < 3; i++) {
+        if (0!= (res = comparePositions[a*3+i] - comparePositions[b*3+i]))
+        {
+            return res;
+        }
+    }
+
+    return 0;
+};
+
+let seqInit = null;
+
+function setMaxNumberOfPositions (maxPositions)
+{
+    if (seqInit !== null && seqInit.length >= maxPositions)
+    {
+        return;
+    }
+
+    seqInit = new Uint32Array(maxPositions);
+
+    for (let i = 0; i < maxPositions; i++)
+    {
+        seqInit[i] = i;
+    }
+}
+
+/**
+ * This function obtains unique positions in the provided object
+ * .positions array and calculates an index mapping, which is then
+ * applied to the provided object .indices and .edgeindices.
+ * 
+ * The input object items are not modified, and instead new set
+ * of positions, indices and edgeIndices with the applied optimization
+ * are returned.
+ * 
+ * The algorithm, instead of being based in a hash-like LUT for
+ * identifying unique positions, is based in pre-sorting the input
+ * positions...
+ * 
+ * (it's possible to define a _"consistent ordering"_ for the positions
+ *  as positions are quantized and thus not suffer from float number
+ *  comparison artifacts)
+ * 
+ * ... so same positions are adjacent in the sorted array, and then
+ * it's easy to scan linearly the sorted array. During the linear run,
+ * we will know that we found a different position because the comparison
+ * function will return != 0 between current and previous element.
+ * 
+ * During this linear traversal of the array, a `unique counter` is used
+ * in order to calculate the mapping between original indices and unique
+ * indices.
+ * 
+ * @param {*} mesh The input mesh to process, with `positions`, `indices` and `edgeIndices` keys.
+ * 
+ * @returns An array with 3 elements: 0 => the uniquified positions; 1 and 2 => the remapped edges and edgeIndices arrays
+ */
+function uniquifyPositions(mesh)
+{
+    let _positions = mesh.positions;
+    let _indices = mesh.indices;
+    let _edgeIndices = mesh.edgeIndices;
+
+    setMaxNumberOfPositions(_positions.length / 3);
+
+    let seq = seqInit.slice (0, _positions.length / 3);
+    let remappings = seqInit.slice (0, _positions.length / 3);
+
+    comparePositions = _positions;
+
+    seq.sort(compareVertex);
+
+    let uniqueIdx = 0
+
+    remappings[seq[0]] = 0;
+
+    for (let i = 1, len = seq.length; i < len; i++)
+    {
+        if (0 != compareVertex(seq[i], seq[i-1]))
+        {
+            uniqueIdx++;
+        }
+
+        remappings[seq[i]] = uniqueIdx;
+    }
+
+    const numUniquePositions = uniqueIdx + 1;
+
+    const newPositions = new Uint16Array (numUniquePositions * 3);
+
+    uniqueIdx = 0
+
+    newPositions [uniqueIdx * 3 + 0] = _positions [seq[0] * 3 + 0];
+    newPositions [uniqueIdx * 3 + 1] = _positions [seq[0] * 3 + 1];
+    newPositions [uniqueIdx * 3 + 2] = _positions [seq[0] * 3 + 2];
+    
+    for (let i = 1, len = seq.length; i < len; i++)
+    {
+        if (0 != compareVertex(seq[i], seq[i-1]))
+        {
+            uniqueIdx++;
+
+            newPositions [uniqueIdx * 3 + 0] = _positions [seq[i] * 3 + 0];
+            newPositions [uniqueIdx * 3 + 1] = _positions [seq[i] * 3 + 1];
+            newPositions [uniqueIdx * 3 + 2] = _positions [seq[i] * 3 + 2];
+        }
+
+        remappings[seq[i]] = uniqueIdx;
+    }
+
+    comparePositions = null;
+
+    let newIndices = new Uint32Array (_indices.length);
+
+    for (let i = 0, len = _indices.length; i < len; i++)
+    {
+        newIndices[i] = remappings [
+            _indices[i]
+        ];
+    }
+
+    let newEdgeIndices = new Uint32Array (_edgeIndices.length);
+
+    for (let i = 0, len = _edgeIndices.length; i < len; i++)
+    {
+        newEdgeIndices[i] = remappings [
+            _edgeIndices[i]
+        ];
+    }
+
+    return [
+        newPositions,
+        newIndices,
+        newEdgeIndices
+    ];
+}
+
+
+export { uniquifyPositions }

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/cluster-helper.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/cluster-helper.js
@@ -1,0 +1,147 @@
+/**
+ * @author https://github.com/tmarti, with support from https://tribia.com/
+ * @license MIT
+ */
+
+import {math} from "../../../../math/math.js";
+import {geometryCompressionUtils} from "../../../../math/geometryCompressionUtils.js";
+import {RBush3D} from "./rbush3d.js";
+
+import {makeClusters} from "./xeokit-cluster.js"
+
+function generateAABB (aabbsForIndexes) {
+    const aabbsToLoad = [];
+ 
+    for (let i = 0, len = aabbsForIndexes.length; i < len; i++) {
+        const item = aabbsForIndexes [i];
+
+        if (!item) {
+            continue;
+        }
+
+        aabbsToLoad.push ({
+            minX: item.aabb [0],
+            minY: item.aabb [1],
+            minZ: item.aabb [2],
+            maxX: item.aabb [3],
+            maxY: item.aabb [4],
+            maxZ: item.aabb [5],
+            entity: {
+                id: i,
+                xeokitId: item.entityId,
+                meshes: [
+                    {
+                        numTriangles: item.numTriangles,
+                    }
+                ]
+            },
+            numTriangles: item.numTriangles,
+        });
+    }
+
+    const aabbTree = new RBush3D (4);
+
+    aabbTree.load (aabbsToLoad);
+
+    return aabbTree;
+}
+
+function clusterizeV2 (entities, meshes) {
+    // const meshesById = {};
+    // meshes.forEach(mesh => meshesById[mesh.id] = mesh);
+
+    // const positions = inflatedData.positions;
+    // const indices = inflatedData.indices;
+    // const meshPositions = inflatedData.meshPositions;
+    // const meshIndices = inflatedData.meshIndices;
+    // const entityMeshes = inflatedData.entityMeshes;
+    // const entityMeshIds = inflatedData.entityMeshIds;
+    // const entityUsesInstancing = inflatedData.entityUsesInstancing;
+    
+    // const numMeshes = meshPositions.length;
+    // const numEntities = entityMeshes.length;
+
+    const numMeshes = meshes.length;
+    const numEntities = entities.length;
+
+    const _aabbsForIndexes = [];
+    const _instancedIndexes = [];
+
+    function entityUsesInstancing (entity) {
+        for (let i = 0, len = entity.meshIds.length; i < len; i++) {
+            if (meshes[entity.meshIds[i]].geometryId) {
+                return true;
+            }
+        }
+
+        return false;
+    };
+
+    for (let i = 0; i < numEntities; i++) {
+        const entity = entities[i];
+
+        // TODO
+        if (entityUsesInstancing (entity)) {
+            _instancedIndexes.push (i);
+            continue;
+        }
+
+        const aabbEntity = math.collapseAABB3();
+        let numTriangles = 0
+
+        entity.meshIds.forEach (meshId => {
+            const mesh = meshes[meshId];
+            
+            const bounds = geometryCompressionUtils.getPositionsBounds(mesh.positions);
+
+            const min = geometryCompressionUtils.decompressPosition(bounds.min, mesh.positionsDecodeMatrix, []);
+            const max = geometryCompressionUtils.decompressPosition(bounds.max, mesh.positionsDecodeMatrix, []);
+
+            min[0] += mesh.origin[0];
+            min[1] += mesh.origin[1];
+            min[2] += mesh.origin[2];
+
+            max[0] += mesh.origin[0];
+            max[1] += mesh.origin[1];
+            max[2] += mesh.origin[2];
+
+            math.expandAABB3Point3(aabbEntity, min);
+            math.expandAABB3Point3(aabbEntity, max);
+
+            numTriangles += Math.round (mesh.indices.length / 3);
+        });
+
+        _aabbsForIndexes [i] = {
+            aabb: aabbEntity,
+            numTriangles,
+            entityId: entity.id,
+        };
+    }
+
+    let _orderedEntityIds = [];
+    let _entityIdToClusterIdMapping = {};
+    let rTreeBasedAabbTree;
+
+    if (Object.keys(_aabbsForIndexes).length > 0)
+    {
+        rTreeBasedAabbTree = generateAABB (_aabbsForIndexes);
+
+        let generateClustersResult = makeClusters ({
+            aabbTree: rTreeBasedAabbTree,
+        });
+        
+        _orderedEntityIds = generateClustersResult.orderedEntityIds;
+        _entityIdToClusterIdMapping = generateClustersResult.clusteringResult.entityIdToClusterIdMapping;
+    }
+
+    // console.log (generateClustersResult);
+
+    return { 
+        orderedClusteredIndexes: _orderedEntityIds,
+        entityIdToClusterIdMapping: _entityIdToClusterIdMapping,
+        instancedIndexes: _instancedIndexes,
+        rTreeBasedAabbTree
+    };
+}
+
+export {clusterizeV2}

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/cluster-helper.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/cluster-helper.js
@@ -3,8 +3,8 @@
  * @license MIT
  */
 
-import {math} from "../../../../math/math.js";
-import {geometryCompressionUtils} from "../../../../math/geometryCompressionUtils.js";
+import {math} from "../../../../../math/math.js";
+import {geometryCompressionUtils} from "../../../../../math/geometryCompressionUtils.js";
 import {RBush3D} from "./rbush3d.js";
 
 import {makeClusters} from "./xeokit-cluster.js"
@@ -91,7 +91,7 @@ function clusterizeV2 (entities, meshes) {
 
         entity.meshIds.forEach (meshId => {
             const mesh = meshes[meshId];
-            
+
             const bounds = geometryCompressionUtils.getPositionsBounds(mesh.positions);
 
             const min = geometryCompressionUtils.decompressPosition(bounds.min, mesh.positionsDecodeMatrix, []);

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/rbush3d.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/rbush3d.js
@@ -1,0 +1,814 @@
+var module = {};
+var exports = {};
+
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.RBush3D = f()}})(function(){var define,module,exports;return (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var quickselect = require('quickselect');
+var nodePool = [];
+var freeNode = function (node) { return nodePool.push(node); };
+var freeAllNode = function (node) {
+    if (node) {
+        freeNode(node);
+        if (!isLeaf(node)) {
+            node.children.forEach(freeAllNode);
+        }
+    }
+};
+var allowNode = function (children) {
+    var node = nodePool.pop();
+    if (node) {
+        node.children = children;
+        node.height = 1;
+        node.leaf = true;
+        node.minX = Infinity;
+        node.minY = Infinity;
+        node.minZ = Infinity;
+        node.maxX = -Infinity;
+        node.maxY = -Infinity;
+        node.maxZ = -Infinity;
+    }
+    else {
+        node = {
+            children: children,
+            height: 1,
+            leaf: true,
+            minX: Infinity,
+            minY: Infinity,
+            minZ: Infinity,
+            maxX: -Infinity,
+            maxY: -Infinity,
+            maxZ: -Infinity,
+        };
+    }
+    return node;
+};
+var distNodePool = [];
+var freeDistNode = function (node) { return distNodePool.push(node); };
+var allowDistNode = function (dist, node) {
+    var heapNode = distNodePool.pop();
+    if (heapNode) {
+        heapNode.dist = dist;
+        heapNode.node = node;
+    }
+    else {
+        heapNode = { dist: dist, node: node };
+    }
+    return heapNode;
+};
+var isLeaf = function (node) {
+    return node.leaf;
+};
+var isLeafChild = function (node, child) {
+    return node.leaf;
+};
+var findItem = function (item, items, equalsFn) {
+    if (!equalsFn)
+        return items.indexOf(item);
+    for (var i = 0; i < items.length; i++) {
+        if (equalsFn(item, items[i]))
+            return i;
+    }
+    return -1;
+};
+var calcBBox = function (node) {
+    distBBox(node, 0, node.children.length, node);
+};
+var distBBox = function (node, k, p, destNode) {
+    var dNode = destNode;
+    if (dNode) {
+        dNode.minX = Infinity;
+        dNode.minY = Infinity;
+        dNode.minZ = Infinity;
+        dNode.maxX = -Infinity;
+        dNode.maxY = -Infinity;
+        dNode.maxZ = -Infinity;
+    }
+    else {
+        dNode = allowNode([]);
+    }
+    for (var i = k, child = void 0; i < p; i++) {
+        child = node.children[i];
+        extend(dNode, child);
+    }
+    return dNode;
+};
+var extend = function (a, b) {
+    a.minX = Math.min(a.minX, b.minX);
+    a.minY = Math.min(a.minY, b.minY);
+    a.minZ = Math.min(a.minZ, b.minZ);
+    a.maxX = Math.max(a.maxX, b.maxX);
+    a.maxY = Math.max(a.maxY, b.maxY);
+    a.maxZ = Math.max(a.maxZ, b.maxZ);
+    return a;
+};
+var bboxVolume = function (a) {
+    return (a.maxX - a.minX) *
+        (a.maxY - a.minY) *
+        (a.maxZ - a.minZ);
+};
+var bboxMargin = function (a) {
+    return (a.maxX - a.minX) +
+        (a.maxY - a.minY) +
+        (a.maxZ - a.minZ);
+};
+var enlargedVolume = function (a, b) {
+    var minX = Math.min(a.minX, b.minX), minY = Math.min(a.minY, b.minY), minZ = Math.min(a.minZ, b.minZ), maxX = Math.max(a.maxX, b.maxX), maxY = Math.max(a.maxY, b.maxY), maxZ = Math.max(a.maxZ, b.maxZ);
+    return (maxX - minX) *
+        (maxY - minY) *
+        (maxZ - minZ);
+};
+var intersectionVolume = function (a, b) {
+    var minX = Math.max(a.minX, b.minX), minY = Math.max(a.minY, b.minY), minZ = Math.max(a.minZ, b.minZ), maxX = Math.min(a.maxX, b.maxX), maxY = Math.min(a.maxY, b.maxY), maxZ = Math.min(a.maxZ, b.maxZ);
+    return Math.max(0, maxX - minX) *
+        Math.max(0, maxY - minY) *
+        Math.max(0, maxZ - minZ);
+};
+var contains = function (a, b) {
+    return a.minX <= b.minX &&
+        a.minY <= b.minY &&
+        a.minZ <= b.minZ &&
+        b.maxX <= a.maxX &&
+        b.maxY <= a.maxY &&
+        b.maxZ <= a.maxZ;
+};
+exports.intersects = function (a, b) {
+    return b.minX <= a.maxX &&
+        b.minY <= a.maxY &&
+        b.minZ <= a.maxZ &&
+        b.maxX >= a.minX &&
+        b.maxY >= a.minY &&
+        b.maxZ >= a.minZ;
+};
+exports.boxRayIntersects = function (box, ox, oy, oz, idx, idy, idz) {
+    var tx0 = (box.minX - ox) * idx;
+    var tx1 = (box.maxX - ox) * idx;
+    var ty0 = (box.minY - oy) * idy;
+    var ty1 = (box.maxY - oy) * idy;
+    var tz0 = (box.minZ - oz) * idz;
+    var tz1 = (box.maxZ - oz) * idz;
+    var z0 = Math.min(tz0, tz1);
+    var z1 = Math.max(tz0, tz1);
+    var y0 = Math.min(ty0, ty1);
+    var y1 = Math.max(ty0, ty1);
+    var x0 = Math.min(tx0, tx1);
+    var x1 = Math.max(tx0, tx1);
+    var tmin = Math.max(0, x0, y0, z0);
+    var tmax = Math.min(x1, y1, z1);
+    return tmax >= tmin ? tmin : Infinity;
+};
+var multiSelect = function (arr, left, right, n, compare) {
+    var stack = [left, right];
+    var mid;
+    while (stack.length) {
+        right = stack.pop();
+        left = stack.pop();
+        if (right - left <= n)
+            continue;
+        mid = left + Math.ceil((right - left) / n / 2) * n;
+        quickselect(arr, mid, left, right, compare);
+        stack.push(left, mid, mid, right);
+    }
+};
+var compareMinX = function (a, b) { return a.minX - b.minX; };
+var compareMinY = function (a, b) { return a.minY - b.minY; };
+var compareMinZ = function (a, b) { return a.minZ - b.minZ; };
+var RBush3D = (function () {
+    function RBush3D(maxEntries) {
+        if (maxEntries === void 0) { maxEntries = 16; }
+        this.maxEntries = Math.max(maxEntries, 8);
+        this.minEntries = Math.max(4, Math.ceil(this.maxEntries * 0.4));
+        this.clear();
+    }
+    RBush3D.alloc = function () {
+        return this.pool.pop() || new this();
+    };
+    RBush3D.free = function (rbush) {
+        rbush.clear();
+        this.pool.push(rbush);
+    };
+    // Start of chipmunk
+    RBush3D.prototype.searchCustom = function (customIntersects, customContains) {
+        var node = this.data;
+        var result = [];
+        if (!customIntersects(node, isLeafChild(node, child)))
+            return result;
+        var nodesToSearch = [];
+        while (node) {
+            for (var i = 0, len = node.children.length; i < len; i++) {
+                var child = node.children[i];
+                if (customIntersects(child, isLeafChild(node, child))) {
+                    if (isLeafChild(node, child))
+                        result.push(child);
+                    else if (customContains(child))
+                        this._all(child, result);
+                    else
+                        nodesToSearch.push(child);
+                }
+            }
+            node = nodesToSearch.pop();
+        }
+        return result;
+    };
+    RBush3D.prototype.analyzeTriangles = function (node) {
+        if (node === undefined)
+        {
+            node = this.data;
+        }
+
+        var totalTriangles = 0;
+
+        if (isLeaf(node))
+        {
+            for (var i = 0, len = node.children.length; i < len; i++) {
+                totalTriangles += node.children [i].numTriangles;
+            }
+        }
+        else
+        {
+            for (var i = 0, len = node.children.length; i < len; i++) {
+                totalTriangles += this.analyzeTriangles (node.children [i]);
+            }
+        }
+
+        return node.totalTriangles = totalTriangles;
+    };
+    RBush3D.prototype.groupNodesByNumTrianglesThreshold = function (numTrianglesThreshold, node)
+    {
+        if (node === undefined)
+        {
+            this.analyzeTriangles ();     
+            node = this.data;
+        }
+
+        var totalTriangles = 0;
+
+        var items = [];
+
+        for (var i = 0, len = node.children.length; i < len; i++) {
+            var child = node.children[i];
+            items.push ({
+                item: child,
+                triangles: child.totalTriangles || child.numTriangles,
+            });
+        }
+
+        items.sort (function (a, b) {
+            return -(a.item.triangles - b.item.triangles);
+        });
+
+        var retVal = [];
+        var retValItem = [];
+        var retValItemTris = 0;
+
+        var c = 0;
+
+        for (var i = 0, len = items.length; i < len; i++) {
+            var item = items[i];
+
+            if ((retValItemTris + item.triangles) < numTrianglesThreshold)
+            {
+                retValItem.push (item);
+                retValItemTris += item.triangles;
+                continue;
+            }
+
+            if (retValItem.length)
+            {
+                retVal.push (retValItem);
+                retValItem = [];
+                retValItemTris = 0;
+            }
+
+            if ((retValItemTris + item.triangles) < numTrianglesThreshold)
+            {
+                i--;
+                continue;
+            }
+
+            if (isLeafChild(node, item.item))
+            {
+                retVal.push ([
+                    item,
+                ]);
+            }
+            else
+            {
+                var tmp = this.groupNodesByNumTrianglesThreshold (
+                    numTrianglesThreshold,
+                    item.item
+                );
+
+                var tmp2 = [];
+                var accum2 = 0;
+
+                for (var j = 0, len2 = tmp.length; j < len2 - 1; j++)
+                {
+                    retVal.push (tmp [i]);
+                }
+
+                if (tmp.length > 1)
+                {
+                    tmp = tmp [tmp.length - 1];
+
+                    for (var j = 0, len2 = tmp.length; j < len2; j++)
+                    {
+                        accum2 = accum2 + tmp [j].triangles;
+
+                        if (accum2 < numTrianglesThreshold)
+                        {
+                            tmp2.push (tmp[j]);
+                        }
+                        else
+                        {
+                            if (accum2 == 0)
+                            {
+                                tmp2.push (tmp[j]);
+                            }
+
+                            retVal.push (tmp2);
+
+                            accum2 = 0;
+                            tmp2 = [];
+                        }
+                    }
+
+                    tmp2.forEach (function (subItem) {
+                        retValItem.push (subItem);
+                        retValItemTris += subItem.triangles;
+                    });
+                }
+            }
+        }
+
+        if (retValItem.length)
+        {
+            retVal.push (retValItem);
+        }
+
+        return retVal;
+    }
+    // End of chipmunk
+    RBush3D.prototype.search = function (bbox) {
+        var node = this.data;
+        var result = [];
+        if (!exports.intersects(bbox, node))
+            return result;
+        var nodesToSearch = [];
+        while (node) {
+            for (var i = 0, len = node.children.length; i < len; i++) {
+                var child = node.children[i];
+                if (exports.intersects(bbox, child)) {
+                    if (isLeafChild(node, child))
+                        result.push(child);
+                    else if (contains(bbox, child))
+                        this._all(child, result);
+                    else
+                        nodesToSearch.push(child);
+                }
+            }
+            node = nodesToSearch.pop();
+        }
+        return result;
+    };
+    RBush3D.prototype.collides = function (bbox) {
+        var node = this.data;
+        if (!exports.intersects(bbox, node))
+            return false;
+        var nodesToSearch = [];
+        while (node) {
+            for (var i = 0, len = node.children.length; i < len; i++) {
+                var child = node.children[i];
+                if (exports.intersects(bbox, child)) {
+                    if (isLeafChild(node, child) || contains(bbox, child))
+                        return true;
+                    nodesToSearch.push(child);
+                }
+            }
+            node = nodesToSearch.pop();
+        }
+        return false;
+    };
+    RBush3D.prototype.raycastInv = function (ox, oy, oz, idx, idy, idz, maxLen) {
+        if (maxLen === void 0) { maxLen = Infinity; }
+        var node = this.data;
+        if (idx === Infinity && idy === Infinity && idz === Infinity)
+            return allowDistNode(Infinity, undefined);
+        if (exports.boxRayIntersects(node, ox, oy, oz, idx, idy, idz) === Infinity)
+            return allowDistNode(Infinity, undefined);
+        var heap = [allowDistNode(0, node)];
+        var swap = function (a, b) {
+            var t = heap[a];
+            heap[a] = heap[b];
+            heap[b] = t;
+        };
+        var pop = function () {
+            var top = heap[0];
+            var newLen = heap.length - 1;
+            heap[0] = heap[newLen];
+            heap.length = newLen;
+            var idx = 0;
+            while (true) {
+                var left = (idx << 1) | 1;
+                if (left >= newLen)
+                    break;
+                var right = left + 1;
+                if (right < newLen && heap[right].dist < heap[left].dist) {
+                    left = right;
+                }
+                if (heap[idx].dist < heap[left].dist)
+                    break;
+                swap(idx, left);
+                idx = left;
+            }
+            freeDistNode(top);
+            return top.node;
+        };
+        var push = function (dist, node) {
+            var idx = heap.length;
+            heap.push(allowDistNode(dist, node));
+            while (idx > 0) {
+                var p = (idx - 1) >> 1;
+                if (heap[p].dist <= heap[idx].dist)
+                    break;
+                swap(idx, p);
+                idx = p;
+            }
+        };
+        var dist = maxLen;
+        var result;
+        while (heap.length && heap[0].dist < dist) {
+            node = pop();
+            for (var i = 0, len = node.children.length; i < len; i++) {
+                var child = node.children[i];
+                var d = exports.boxRayIntersects(child, ox, oy, oz, idx, idy, idz);
+                if (!isLeafChild(node, child)) {
+                    push(d, child);
+                }
+                else if (d < dist) {
+                    if (d === 0) {
+                        return allowDistNode(d, child);
+                    }
+                    dist = d;
+                    result = child;
+                }
+            }
+        }
+        return allowDistNode(dist < maxLen ? dist : Infinity, result);
+    };
+    RBush3D.prototype.raycast = function (ox, oy, oz, dx, dy, dz, maxLen) {
+        if (maxLen === void 0) { maxLen = Infinity; }
+        return this.raycastInv(ox, oy, oz, 1 / dx, 1 / dy, 1 / dz, maxLen);
+    };
+    RBush3D.prototype.all = function () {
+        return this._all(this.data, []);
+    };
+    RBush3D.prototype.load = function (data) {
+        if (!(data && data.length))
+            return this;
+        if (data.length < this.minEntries) {
+            for (var i = 0, len = data.length; i < len; i++) {
+                this.insert(data[i]);
+            }
+            return this;
+        }
+        var node = this.build(data.slice(), 0, data.length - 1, 0);
+        if (!this.data.children.length) {
+            this.data = node;
+        }
+        else if (this.data.height === node.height) {
+            this.splitRoot(this.data, node);
+        }
+        else {
+            if (this.data.height < node.height) {
+                var tmpNode = this.data;
+                this.data = node;
+                node = tmpNode;
+            }
+            this._insert(node, this.data.height - node.height - 1, true);
+        }
+        return this;
+    };
+    RBush3D.prototype.insert = function (item) {
+        if (item)
+            this._insert(item, this.data.height - 1);
+        return this;
+    };
+    RBush3D.prototype.clear = function () {
+        if (this.data) {
+            freeAllNode(this.data);
+        }
+        this.data = allowNode([]);
+        return this;
+    };
+    RBush3D.prototype.remove = function (item, equalsFn) {
+        if (!item)
+            return this;
+        var node = this.data;
+        var i = 0;
+        var goingUp = false;
+        var index;
+        var parent;
+        var path = [];
+        var indexes = [];
+        while (node || path.length) {
+            if (!node) {
+                node = path.pop();
+                i = indexes.pop();
+                parent = path[path.length - 1];
+                goingUp = true;
+            }
+            if (isLeaf(node)) {
+                index = findItem(item, node.children, equalsFn);
+                if (index !== -1) {
+                    node.children.splice(index, 1);
+                    path.push(node);
+                    this.condense(path);
+                    return this;
+                }
+            }
+            if (!goingUp && !isLeaf(node) && contains(node, item)) {
+                path.push(node);
+                indexes.push(i);
+                i = 0;
+                parent = node;
+                node = node.children[0];
+            }
+            else if (parent) {
+                i++;
+                node = parent.children[i];
+                goingUp = false;
+            }
+            else {
+                node = undefined;
+            }
+        }
+        return this;
+    };
+    RBush3D.prototype.toJSON = function () {
+        return this.data;
+    };
+    RBush3D.prototype.fromJSON = function (data) {
+        freeAllNode(this.data);
+        this.data = data;
+        return this;
+    };
+    RBush3D.prototype.build = function (items, left, right, height) {
+        var N = right - left + 1;
+        var M = this.maxEntries;
+        var node;
+        if (N <= M) {
+            node = allowNode(items.slice(left, right + 1));
+            calcBBox(node);
+            return node;
+        }
+        if (!height) {
+            height = Math.ceil(Math.log(N) / Math.log(M));
+            M = Math.ceil(N / Math.pow(M, height - 1));
+        }
+        node = allowNode([]);
+        node.leaf = false;
+        node.height = height;
+        var N3 = Math.ceil(N / M), N2 = N3 * Math.ceil(Math.pow(M, 2 / 3)), N1 = N3 * Math.ceil(Math.pow(M, 1 / 3));
+        multiSelect(items, left, right, N1, compareMinX);
+        for (var i = left; i <= right; i += N1) {
+            var right2 = Math.min(i + N1 - 1, right);
+            multiSelect(items, i, right2, N2, compareMinY);
+            for (var j = i; j <= right2; j += N2) {
+                var right3 = Math.min(j + N2 - 1, right2);
+                multiSelect(items, j, right3, N3, compareMinZ);
+                for (var k = j; k <= right3; k += N3) {
+                    var right4 = Math.min(k + N3 - 1, right3);
+                    node.children.push(this.build(items, k, right4, height - 1));
+                }
+            }
+        }
+        calcBBox(node);
+        return node;
+    };
+    RBush3D.prototype._all = function (node, result) {
+        var nodesToSearch = [];
+        while (node) {
+            if (isLeaf(node))
+                result.push.apply(result, node.children);
+            else
+                nodesToSearch.push.apply(nodesToSearch, node.children);
+            node = nodesToSearch.pop();
+        }
+        return result;
+    };
+    RBush3D.prototype.chooseSubtree = function (bbox, node, level, path) {
+        var minVolume;
+        var minEnlargement;
+        var targetNode;
+        while (true) {
+            path.push(node);
+            if (isLeaf(node) || path.length - 1 === level)
+                break;
+            minVolume = minEnlargement = Infinity;
+            for (var i = 0, len = node.children.length; i < len; i++) {
+                var child = node.children[i];
+                var volume = bboxVolume(child);
+                var enlargement = enlargedVolume(bbox, child) - volume;
+                if (enlargement < minEnlargement) {
+                    minEnlargement = enlargement;
+                    minVolume = volume < minVolume ? volume : minVolume;
+                    targetNode = child;
+                }
+                else if (enlargement === minEnlargement) {
+                    if (volume < minVolume) {
+                        minVolume = volume;
+                        targetNode = child;
+                    }
+                }
+            }
+            node = targetNode || node.children[0];
+        }
+        return node;
+    };
+    RBush3D.prototype.split = function (insertPath, level) {
+        var node = insertPath[level];
+        var M = node.children.length;
+        var m = this.minEntries;
+        this.chooseSplitAxis(node, m, M);
+        var splitIndex = this.chooseSplitIndex(node, m, M);
+        var newNode = allowNode(node.children.splice(splitIndex, node.children.length - splitIndex));
+        newNode.height = node.height;
+        newNode.leaf = node.leaf;
+        calcBBox(node);
+        calcBBox(newNode);
+        if (level)
+            insertPath[level - 1].children.push(newNode);
+        else
+            this.splitRoot(node, newNode);
+    };
+    RBush3D.prototype.splitRoot = function (node, newNode) {
+        this.data = allowNode([node, newNode]);
+        this.data.height = node.height + 1;
+        this.data.leaf = false;
+        calcBBox(this.data);
+    };
+    RBush3D.prototype.chooseSplitIndex = function (node, m, M) {
+        var minOverlap = Infinity;
+        var minVolume = Infinity;
+        var index;
+        for (var i = m; i <= M - m; i++) {
+            var bbox1 = distBBox(node, 0, i);
+            var bbox2 = distBBox(node, i, M);
+            var overlap = intersectionVolume(bbox1, bbox2);
+            var volume = bboxVolume(bbox1) + bboxVolume(bbox2);
+            if (overlap < minOverlap) {
+                minOverlap = overlap;
+                index = i;
+                minVolume = volume < minVolume ? volume : minVolume;
+            }
+            else if (overlap === minOverlap) {
+                if (volume < minVolume) {
+                    minVolume = volume;
+                    index = i;
+                }
+            }
+        }
+        return index;
+    };
+    RBush3D.prototype.chooseSplitAxis = function (node, m, M) {
+        var xMargin = this.allDistMargin(node, m, M, compareMinX);
+        var yMargin = this.allDistMargin(node, m, M, compareMinY);
+        var zMargin = this.allDistMargin(node, m, M, compareMinZ);
+        if (xMargin < yMargin && xMargin < zMargin) {
+            node.children.sort(compareMinX);
+        }
+        else if (yMargin < xMargin && yMargin < zMargin) {
+            node.children.sort(compareMinY);
+        }
+    };
+    RBush3D.prototype.allDistMargin = function (node, m, M, compare) {
+        node.children.sort(compare);
+        var leftBBox = distBBox(node, 0, m);
+        var rightBBox = distBBox(node, M - m, M);
+        var margin = bboxMargin(leftBBox) + bboxMargin(rightBBox);
+        for (var i = m; i < M - m; i++) {
+            var child = node.children[i];
+            extend(leftBBox, child);
+            margin += bboxMargin(leftBBox);
+        }
+        for (var i = M - m - 1; i >= m; i--) {
+            var child = node.children[i];
+            extend(rightBBox, child);
+            margin += bboxMargin(rightBBox);
+        }
+        return margin;
+    };
+    RBush3D.prototype.adjustParentBBoxes = function (bbox, path, level) {
+        for (var i = level; i >= 0; i--) {
+            extend(path[i], bbox);
+        }
+    };
+    RBush3D.prototype.condense = function (path) {
+        for (var i = path.length - 1, siblings = void 0; i >= 0; i--) {
+            if (path[i].children.length === 0) {
+                if (i > 0) {
+                    siblings = path[i - 1].children;
+                    siblings.splice(siblings.indexOf(path[i]), 1);
+                    freeNode(path[i]);
+                }
+                else {
+                    this.clear();
+                }
+            }
+            else {
+                calcBBox(path[i]);
+            }
+        }
+    };
+    RBush3D.prototype._insert = function (item, level, isNode) {
+        var insertPath = [];
+        var node = this.chooseSubtree(item, this.data, level, insertPath);
+        node.children.push(item);
+        extend(node, item);
+        while (level >= 0) {
+            if (insertPath[level].children.length > this.maxEntries) {
+                this.split(insertPath, level);
+                level--;
+            }
+            else
+                break;
+        }
+        this.adjustParentBBoxes(item, insertPath, level);
+    };
+    RBush3D.pool = [];
+    return RBush3D;
+}());
+exports.RBush3D = RBush3D;
+
+},{"quickselect":2}],2:[function(require,module,exports){
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(global.quickselect = factory());
+}(this, (function () { 'use strict';
+
+function quickselect(arr, k, left, right, compare) {
+    quickselectStep(arr, k, left || 0, right || (arr.length - 1), compare || defaultCompare);
+}
+
+function quickselectStep(arr, k, left, right, compare) {
+
+    while (right > left) {
+        if (right - left > 600) {
+            var n = right - left + 1;
+            var m = k - left + 1;
+            var z = Math.log(n);
+            var s = 0.5 * Math.exp(2 * z / 3);
+            var sd = 0.5 * Math.sqrt(z * s * (n - s) / n) * (m - n / 2 < 0 ? -1 : 1);
+            var newLeft = Math.max(left, Math.floor(k - m * s / n + sd));
+            var newRight = Math.min(right, Math.floor(k + (n - m) * s / n + sd));
+            quickselectStep(arr, k, newLeft, newRight, compare);
+        }
+
+        var t = arr[k];
+        var i = left;
+        var j = right;
+
+        swap(arr, left, k);
+        if (compare(arr[right], t) > 0) swap(arr, left, right);
+
+        while (i < j) {
+            swap(arr, i, j);
+            i++;
+            j--;
+            while (compare(arr[i], t) < 0) i++;
+            while (compare(arr[j], t) > 0) j--;
+        }
+
+        if (compare(arr[left], t) === 0) swap(arr, left, j);
+        else {
+            j++;
+            swap(arr, j, right);
+        }
+
+        if (j <= k) left = j + 1;
+        if (k <= j) right = j - 1;
+    }
+}
+
+function swap(arr, i, j) {
+    var tmp = arr[i];
+    arr[i] = arr[j];
+    arr[j] = tmp;
+}
+
+function defaultCompare(a, b) {
+    return a < b ? -1 : a > b ? 1 : 0;
+}
+
+return quickselect;
+
+})));
+
+},{}]},{},[1])(1)
+});
+
+var tmp0 = module.exports.RBush3D;
+
+export {tmp0 as RBush3D};

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/rebucketPositions.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/rebucketPositions.js
@@ -1,0 +1,449 @@
+/**
+ * @author https://github.com/tmarti, with support from https://tribia.com/
+ * @license MIT
+ **/
+
+const MAX_RE_BUCKET_FAN_OUT = 8;
+
+let bucketsForIndices = null;
+
+function compareBuckets (a, b) {
+    let aa = a*3;
+    let bb = b*3;
+
+    let aa1, aa2, aa3, bb1, bb2, bb3;
+
+    const minBucketA = Math.min (
+        aa1 = bucketsForIndices[aa],
+        aa2 = bucketsForIndices[aa+1],
+        aa3 = bucketsForIndices[aa+2]
+    );
+
+    const minBucketB = Math.min (
+        bb1 = bucketsForIndices[bb],
+        bb2 = bucketsForIndices[bb+1],
+        bb3 = bucketsForIndices[bb+2]
+    );
+
+    if (minBucketA != minBucketB)
+    {
+        return minBucketA - minBucketB;
+    }
+
+    const maxBucketA = Math.max (
+        aa1,
+        aa2,
+        aa3,
+    );
+
+    const maxBucketB = Math.max (
+        bb1,
+        bb2,
+        bb3,
+    );
+
+    if (maxBucketA != maxBucketB)
+    {
+        return maxBucketA - maxBucketB;
+    }
+
+    return 0;
+};
+
+function preSortIndices(indices, bitsPerBucket)
+{
+    let seq = new Int32Array (indices.length / 3);
+
+    for (let i = 0, len = seq.length; i < len; i++)
+    {
+        seq[i] = i;
+    }
+
+    bucketsForIndices = new Int32Array (indices.length);
+
+    for (let i = 0, len = indices.length; i < len; i++)
+    {
+        bucketsForIndices[i] = indices[i] >> bitsPerBucket;
+    }
+
+    seq.sort(compareBuckets);
+
+    const sortedIndices = new Int32Array(indices.length);
+
+    for (let i = 0, len = seq.length; i < len; i++)
+    {
+        sortedIndices[i*3+0] = indices[seq[i]*3+0];
+        sortedIndices[i*3+1] = indices[seq[i]*3+1];
+        sortedIndices[i*3+2] = indices[seq[i]*3+2];
+    }
+
+    return sortedIndices;
+}
+
+let compareEdgeIndices = null;
+
+function compareIndices(a, b)
+{
+    let retVal = compareEdgeIndices[a*2] - compareEdgeIndices[b*2];
+
+    if (retVal != 0)
+    {
+        return retVal;
+    }
+
+    return compareEdgeIndices[a*2+1] - compareEdgeIndices[b*2+1];
+}
+
+function preSortEdgeIndices(edgeIndices)
+{
+    if ((edgeIndices || []).length == 0)
+    {
+        return [];
+    }
+
+    let seq = new Int32Array (edgeIndices.length / 2);
+
+    for (let i = 0, len = seq.length; i < len; i++)
+    {
+        seq[i] = i;
+    }
+
+    for (let i = 0, j = 0, len = edgeIndices.length; i < len; i+=2)
+    {
+        if (edgeIndices[i] > edgeIndices[i+1]) {
+            let tmp = edgeIndices[i];
+            edgeIndices[i] = edgeIndices[i+1];
+            edgeIndices[i+1] = tmp;
+        }
+    }
+    
+    compareEdgeIndices = new Int32Array (edgeIndices);
+
+    seq.sort(compareIndices);
+
+    const sortedEdgeIndices = new Int32Array(edgeIndices.length);
+
+    for (let i = 0, len = seq.length; i < len; i++)
+    {
+        sortedEdgeIndices[i*2+0] = edgeIndices[seq[i]*2+0];
+        sortedEdgeIndices[i*2+1] = edgeIndices[seq[i]*2+1];
+    }
+
+    return sortedEdgeIndices;
+}
+ 
+function rebucketPositions(mesh, bitsPerBucket, checkResult = false)
+{
+    const positions = (mesh.positions || []);
+
+    const indices = preSortIndices (mesh.indices || [], bitsPerBucket);
+
+    const edgeIndices = preSortEdgeIndices (mesh.edgeIndices || []);
+
+    /**
+     * Code adapted from https://stackoverflow.com/questions/22697936/binary-search-in-javascript
+     */
+    function edgeSearch(el0, el1) {
+        if (el0 > el1)
+        {
+            let tmp = el0;
+            el0 = el1;
+            el1 = tmp;
+        }
+
+        function compare_fn (a, b) {
+            if (a != el0)
+            {
+                return el0 - a;
+            }
+
+            if (b != el1)
+            {
+                return el1 - b;
+            }
+
+            return 0;
+        };
+
+        var m = 0;
+        var n = (edgeIndices.length >> 1) - 1;
+        while (m <= n) {
+            var k = (n + m) >> 1;
+            var cmp = compare_fn(edgeIndices[k*2], edgeIndices[k*2+1]);
+            if (cmp > 0) {
+                m = k + 1;
+            } else if(cmp < 0) {
+                n = k - 1;
+            } else {
+                return k;
+            }
+        }
+        return -m - 1;
+    }
+
+    // console.log (edgeIndices);
+
+    // throw (e);
+
+    // console.log (`${mesh.edgeIndices.length / 2} edge indices`);
+    // console.log (`${edgeIndices.length / 2} edge indices sorted`);
+
+    const alreadyOutputEdgeIndices = new Int32Array(edgeIndices.length/2);
+    alreadyOutputEdgeIndices.fill(0);
+
+    const numPositions = positions.length / 3;
+
+    if (numPositions > ((1 << bitsPerBucket) * MAX_RE_BUCKET_FAN_OUT))
+    {
+        return [ mesh ];
+    }
+
+    const bucketIndicesRemap = new Int32Array(numPositions);
+    bucketIndicesRemap.fill(-1);
+
+    const buckets = [];
+
+    function addEmptyBucket ()
+    {
+        bucketIndicesRemap.fill(-1);
+
+        let newBucket = {
+            positions: [],
+            indices: [],
+            edgeIndices: [],
+            maxNumPositions: (1 << bitsPerBucket) - bitsPerBucket,
+            numPositions: 0,
+            bucketNumber: buckets.length,
+        };
+
+        buckets.push (newBucket);
+
+        return newBucket;
+    }
+
+    let currentBucket = addEmptyBucket ();
+
+    // let currentBucket = 0;
+ 
+    let retVal = 0;
+
+    for (let i = 0, len = indices.length; i < len; i+=3)
+    {
+        let additonalPositionsInBucket = 0;
+
+        const ii0 = indices[i];
+        const ii1 = indices[i+1];
+        const ii2 = indices[i+2];
+
+        if (bucketIndicesRemap[ii0] == -1) {
+            additonalPositionsInBucket++;
+        }
+
+        if (bucketIndicesRemap[ii1] == -1) {
+            additonalPositionsInBucket++;
+        }
+
+        if (bucketIndicesRemap[ii2] == -1) {
+            additonalPositionsInBucket++;
+        }
+
+        if ((additonalPositionsInBucket + currentBucket.numPositions) > currentBucket.maxNumPositions)
+        {
+            currentBucket = addEmptyBucket();
+        }
+
+        if (currentBucket.bucketNumber > MAX_RE_BUCKET_FAN_OUT)
+        {
+            return [ mesh ];
+        }
+ 
+        if (bucketIndicesRemap[ii0] == -1)
+        {
+            bucketIndicesRemap[ii0] = currentBucket.numPositions++;
+            currentBucket.positions.push (positions[ii0*3]);
+            currentBucket.positions.push (positions[ii0*3+1]);
+            currentBucket.positions.push (positions[ii0*3+2]);
+        }
+ 
+        if (bucketIndicesRemap[ii1] == -1) {
+            bucketIndicesRemap[ii1] = currentBucket.numPositions++;
+            currentBucket.positions.push (positions[ii1*3]);
+            currentBucket.positions.push (positions[ii1*3+1]);
+            currentBucket.positions.push (positions[ii1*3+2]);
+        }
+
+        if (bucketIndicesRemap[ii2] == -1) {
+            bucketIndicesRemap[ii2] = currentBucket.numPositions++;
+            currentBucket.positions.push (positions[ii2*3]);
+            currentBucket.positions.push (positions[ii2*3+1]);
+            currentBucket.positions.push (positions[ii2*3+2]);
+        }
+
+        currentBucket.indices.push(bucketIndicesRemap[ii0]);
+        currentBucket.indices.push(bucketIndicesRemap[ii1]);
+        currentBucket.indices.push(bucketIndicesRemap[ii2]);
+
+        // Check possible edge1
+        let edgeIndex;
+ 
+        if ((edgeIndex = edgeSearch(ii0, ii1)) >= 0)
+        {
+            if (alreadyOutputEdgeIndices[edgeIndex] == 0)
+            {
+                alreadyOutputEdgeIndices[edgeIndex] = 1;
+
+                currentBucket.edgeIndices.push(bucketIndicesRemap[edgeIndices[edgeIndex*2]]);
+                currentBucket.edgeIndices.push(bucketIndicesRemap[edgeIndices[edgeIndex*2+1]]);
+            }
+        }
+
+        if ((edgeIndex = edgeSearch(ii0, ii2)) >= 0)
+        {
+            if (alreadyOutputEdgeIndices[edgeIndex] == 0)
+            {
+                alreadyOutputEdgeIndices[edgeIndex] = 1;
+
+                currentBucket.edgeIndices.push(bucketIndicesRemap[edgeIndices[edgeIndex*2]]);
+                currentBucket.edgeIndices.push(bucketIndicesRemap[edgeIndices[edgeIndex*2+1]]);
+            }
+        }
+
+        if ((edgeIndex = edgeSearch(ii1, ii2)) >= 0)
+        {
+            if (alreadyOutputEdgeIndices[edgeIndex] == 0)
+            {
+                alreadyOutputEdgeIndices[edgeIndex] = 1;
+
+                currentBucket.edgeIndices.push(bucketIndicesRemap[edgeIndices[edgeIndex*2]]);
+                currentBucket.edgeIndices.push(bucketIndicesRemap[edgeIndices[edgeIndex*2+1]]);
+            }
+        }
+    }
+ 
+    const prevBytesPerIndex = bitsPerBucket / 8 * 2;
+    const newBytesPerIndex = bitsPerBucket / 8;
+
+    const originalSize = positions.length * 2 + (indices.length + edgeIndices.length) * prevBytesPerIndex;
+
+    let newSize = 0;
+    let newPositions = - positions.length / 3;
+
+    buckets.forEach (bucket => {
+        newSize += bucket.positions.length * 2 + (bucket.indices.length + bucket.edgeIndices.length) * newBytesPerIndex;
+        newPositions += bucket.positions.length / 3;
+    });
+
+    if (newSize > originalSize)
+    {
+        return [ mesh ];
+    }
+
+    // console.log ("added positions " + newPositions + ", buckets: " + buckets.length);
+
+    if (checkResult)
+    {
+        doCheckResult (buckets, mesh);
+    }
+
+    // return [ mesh ];
+
+    return buckets;
+ }
+ 
+function unbucket (buckets)
+{
+    let positions = [];
+    let indices = [];
+    let edgeIndices = [];
+
+    let positionsBase = 0;
+
+    buckets.forEach (bucket => {
+        bucket.positions.forEach (coord => {
+            positions.push (coord);
+        });
+
+        bucket.indices.forEach (index => {
+            indices.push (index + positionsBase);
+        });
+
+        bucket.edgeIndices.forEach (edgeIndex => {
+            edgeIndices.push (edgeIndex + positionsBase);
+        });
+
+        positionsBase += positions.length / 3;
+    });
+
+    return {
+        positions,
+        indices,
+        edgeIndices
+    };
+}
+
+ function doCheckResult (buckets, mesh)
+ {
+     const meshDict = {};
+     const edgesDict = {};
+ 
+     let edgeIndicesCount = 0;
+ 
+     buckets.forEach (bucket => {
+         let indices = bucket.indices;
+         let edgeIndices = bucket.edgeIndices;
+         let positions = bucket.positions;
+ 
+         for (var i = 0, len = indices.length; i < len; i+=3)
+         {
+             var key = positions[indices[i]*3] + "_" + positions[indices[i]*3+1] + "_" + positions[indices[i]*3+2] + "/" + 
+                       positions[indices[i+1]*3] + "_" + positions[indices[i+1]*3+1] + "_" + positions[indices[i+1]*3+2] + "/" + 
+                       positions[indices[i+2]*3] + "_" + positions[indices[i+2]*3+1] + "_" + positions[indices[i+2]*3+2];
+ 
+             meshDict[key] = true;
+         }
+ 
+         edgeIndicesCount += bucket.edgeIndices.length / 2;
+ 
+         for (var i = 0, len = edgeIndices.length; i < len; i+=2)
+         {
+             var key = positions[edgeIndices[i]*3] + "_" + positions[edgeIndices[i]*3+1] + "_" + positions[edgeIndices[i]*3+2] + "/" + 
+                       positions[edgeIndices[i+1]*3] + "_" + positions[edgeIndices[i+1]*3+1] + "_" + positions[edgeIndices[i+1]*3+2] + "/";
+ 
+             edgesDict[key] = true;
+         }
+     });
+ 
+     {
+         let indices = mesh.indices;
+         let edgeIndices = mesh.edgeIndices;
+         let positions = mesh.positions;
+ 
+         for (var i = 0, len = indices.length; i < len; i+=3)
+         {
+             var key = positions[indices[i]*3] + "_" + positions[indices[i]*3+1] + "_" + positions[indices[i]*3+2] + "/" + 
+                       positions[indices[i+1]*3] + "_" + positions[indices[i+1]*3+1] + "_" + positions[indices[i+1]*3+2] + "/" + 
+                       positions[indices[i+2]*3] + "_" + positions[indices[i+2]*3+1] + "_" + positions[indices[i+2]*3+2];
+ 
+             if (!(key in meshDict)) {
+                 console.log ("Not found " + key);
+                 throw "Ohhhh!";
+             }
+         }
+ 
+        //  for (var i = 0, len = edgeIndices.length; i < len; i+=2)
+        //  {
+        //      var key = positions[edgeIndices[i]*3] + "_" + positions[edgeIndices[i]*3+1] + "_" + positions[edgeIndices[i]*3+2] + "/" + 
+        //                positions[edgeIndices[i+1]*3] + "_" + positions[edgeIndices[i+1]*3+1] + "_" + positions[edgeIndices[i+1]*3+2] + "/";
+ 
+        //      if (!(key in edgesDict)) {
+        //          var key2 = edgeIndices[i] + "_" + edgeIndices[i+1];
+ 
+        //          console.log ("   - Not found " + key);
+        //          console.log ("   - Not found " + key2);
+        //         //  throw "Ohhhh2!";
+        //      }
+        //  }
+     }
+ }
+ 
+ export { rebucketPositions }

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorQualityRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorQualityRenderer.js
@@ -1,7 +1,7 @@
-import {Program} from "../../../../../webgl/Program.js";
-import {math} from "../../../../../math/math.js";
-import {createRTCViewMat, getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
-import {WEBGL_INFO} from "../../../../../webglInfo.js";
+import {Program} from "../../../../../../webgl/Program.js";
+import {math} from "../../../../../../math/math.js";
+import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
+import {WEBGL_INFO} from "../../../../../../webglInfo.js";
 
 const tempVec4 = math.vec4();
 const tempVec3a = math.vec3();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorQualityRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorQualityRenderer.js
@@ -1,0 +1,817 @@
+import {Program} from "../../../../../webgl/Program.js";
+import {math} from "../../../../../math/math.js";
+import {createRTCViewMat, getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
+import {WEBGL_INFO} from "../../../../../webglInfo.js";
+
+const tempVec4 = math.vec4();
+const tempVec3a = math.vec3();
+
+const TEXTURE_DECODE_FUNCS = {
+    "linear": "linearToLinear",
+    "sRGB": "sRGBToLinear",
+    "gamma": "gammaToLinear"
+};
+
+/**
+ * @private
+ */
+class TrianglesDataTextureColorQualityRenderer {
+
+    constructor(scene, withSAO) {
+        this._scene = scene;
+        this._withSAO = withSAO;
+        this._hash = this._getHash();
+        this._allocate();
+    }
+
+    getValid() {
+        return this._hash === this._getHash();
+    };
+
+    _getHash() {
+        const scene = this._scene;
+        return [scene.gammaOutput, scene._lightsState.getHash(), scene._sectionPlanesState.getHash(), (this._withSAO ? "sao" : "nosao")].join(";");
+    }
+
+    drawLayer(frameCtx, dataTextureLayer, renderPass) {
+
+        const scene = this._scene;
+        const camera = scene.camera;
+        const model = dataTextureLayer.model;
+        const gl = scene.canvas.gl;
+        const state = dataTextureLayer._state;
+        const origin = dataTextureLayer._state.origin;
+
+        if (!this._program) {
+            this._allocate();
+            if (this.errors) {
+                return;
+            }
+        }
+
+        if (frameCtx.lastProgramId !== this._program.id) {
+            frameCtx.lastProgramId = this._program.id;
+            this._bindProgram(frameCtx);
+        }
+
+        gl.uniform1i(this._uRenderPass, renderPass);
+
+        gl.uniformMatrix4fv(this._uViewMatrix, false, (origin) ? createRTCViewMat(camera.viewMatrix, origin) : camera.viewMatrix);
+        gl.uniformMatrix4fv(this._uViewNormalMatrix, false, camera.viewNormalMatrix);
+
+        gl.uniformMatrix4fv(this._uWorldMatrix, false, model.worldMatrix);
+        gl.uniformMatrix4fv(this._uWorldNormalMatrix, false, model.worldNormalMatrix);
+
+        const numSectionPlanes = scene._sectionPlanesState.sectionPlanes.length;
+        if (numSectionPlanes > 0) {
+            const sectionPlanes = scene._sectionPlanesState.sectionPlanes;
+            const baseIndex = dataTextureLayer.layerIndex * numSectionPlanes;
+            const renderFlags = model.renderFlags;
+            for (let sectionPlaneIndex = 0; sectionPlaneIndex < numSectionPlanes; sectionPlaneIndex++) {
+                const sectionPlaneUniforms = this._uSectionPlanes[sectionPlaneIndex];
+                if (sectionPlaneUniforms) {
+                    const active = renderFlags.sectionPlanesActivePerLayer[baseIndex + sectionPlaneIndex];
+                    gl.uniform1i(sectionPlaneUniforms.active, active ? 1 : 0);
+                    if (active) {
+                        const sectionPlane = sectionPlanes[sectionPlaneIndex];
+                        if (origin) {
+                            const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a);
+                            gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
+                        } else {
+                            gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);
+                        }
+                        gl.uniform3fv(sectionPlaneUniforms.dir, sectionPlane.dir);
+                    }
+                }
+            }
+        }
+
+        gl.uniformMatrix4fv(this._uPositionsDecodeMatrix, false, dataTextureLayer._state.positionsDecodeMatrix);
+
+        this._aPosition.bindArrayBuffer(state.positionsBuf);
+
+        if (this._aNormal) {
+            this._aNormal.bindArrayBuffer(state.normalsBuf);
+        }
+
+        if (this._aColor) {
+            this._aColor.bindArrayBuffer(state.colorsBuf);
+        }
+
+        if (this._aMetallicRoughness) {
+            this._aMetallicRoughness.bindArrayBuffer(state.metallicRoughnessBuf);
+        }
+
+        if (this._aFlags) {
+            this._aFlags.bindArrayBuffer(state.flagsBuf);
+        }
+
+        if (this._aFlags2) {
+            this._aFlags2.bindArrayBuffer(state.flags2Buf);
+        }
+
+        if (this._aOffset) {
+            this._aOffset.bindArrayBuffer(state.offsetsBuf);
+        }
+
+        state.indicesBuf.bind();
+
+        gl.drawElements(gl.TRIANGLES, state.indicesBuf.numItems, state.indicesBuf.itemType, 0);
+
+        frameCtx.drawElements++;
+    }
+
+    _allocate() {
+
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+        const lightsState = scene._lightsState;
+
+        this._program = new Program(gl, this._buildShader());
+
+        if (this._program.errors) {
+            this.errors = this._program.errors;
+            return;
+        }
+
+        const program = this._program;
+
+        this._uRenderPass = program.getLocation("renderPass");
+        this._uPositionsDecodeMatrix = program.getLocation("positionsDecodeMatrix");
+        this._uWorldMatrix = program.getLocation("worldMatrix");
+        this._uWorldNormalMatrix = program.getLocation("worldNormalMatrix");
+        this._uViewMatrix = program.getLocation("viewMatrix");
+        this._uViewNormalMatrix = program.getLocation("viewNormalMatrix");
+        this._uProjMatrix = program.getLocation("projMatrix");
+
+        this._uGammaFactor = program.getLocation("gammaFactor");
+
+        this._uLightAmbient = program.getLocation("lightAmbient");
+        this._uLightColor = [];
+        this._uLightDir = [];
+        this._uLightPos = [];
+        this._uLightAttenuation = [];
+
+        const lights = lightsState.lights;
+        let light;
+
+        for (let i = 0, len = lights.length; i < len; i++) {
+            light = lights[i];
+            switch (light.type) {
+                case "dir":
+                    this._uLightColor[i] = program.getLocation("lightColor" + i);
+                    this._uLightPos[i] = null;
+                    this._uLightDir[i] = program.getLocation("lightDir" + i);
+                    break;
+                case "point":
+                    this._uLightColor[i] = program.getLocation("lightColor" + i);
+                    this._uLightPos[i] = program.getLocation("lightPos" + i);
+                    this._uLightDir[i] = null;
+                    this._uLightAttenuation[i] = program.getLocation("lightAttenuation" + i);
+                    break;
+                case "spot":
+                    this._uLightColor[i] = program.getLocation("lightColor" + i);
+                    this._uLightPos[i] = program.getLocation("lightPos" + i);
+                    this._uLightDir[i] = program.getLocation("lightDir" + i);
+                    this._uLightAttenuation[i] = program.getLocation("lightAttenuation" + i);
+                    break;
+            }
+        }
+
+        if (lightsState.reflectionMaps.length > 0) {
+            this._uReflectionMap = "reflectionMap";
+        }
+
+        if (lightsState.lightMaps.length > 0) {
+            this._uLightMap = "lightMap";
+        }
+
+        this._uSectionPlanes = [];
+
+        for (let i = 0, len = scene._sectionPlanesState.sectionPlanes.length; i < len; i++) {
+            this._uSectionPlanes.push({
+                active: program.getLocation("sectionPlaneActive" + i),
+                pos: program.getLocation("sectionPlanePos" + i),
+                dir: program.getLocation("sectionPlaneDir" + i)
+            });
+        }
+
+        this._aPosition = program.getAttribute("position");
+        this._aOffset = program.getAttribute("offset");
+        this._aNormal = program.getAttribute("normal");
+        this._aColor = program.getAttribute("color");
+        this._aMetallicRoughness = program.getAttribute("metallicRoughness");
+        this._aFlags = program.getAttribute("flags");
+        this._aFlags2 = program.getAttribute("flags2");
+
+        if (this._withSAO) {
+            this._uOcclusionTexture = "uOcclusionTexture";
+            this._uSAOParams = program.getLocation("uSAOParams");
+        }
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            this._uLogDepthBufFC = program.getLocation("logDepthBufFC");
+        }
+    }
+
+    _bindProgram(frameCtx) {
+
+        const maxTextureUnits = WEBGL_INFO.MAX_TEXTURE_UNITS;
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+        const program = this._program;
+        const lightsState = scene._lightsState;
+        const lights = lightsState.lights;
+        const project = scene.camera.project;
+
+        program.bind();
+
+        gl.uniformMatrix4fv(this._uProjMatrix, false, project.matrix)
+
+        if (this._uLightAmbient) {
+            gl.uniform4fv(this._uLightAmbient, scene._lightsState.getAmbientColorAndIntensity());
+        }
+
+        for (let i = 0, len = lights.length; i < len; i++) {
+
+            const light = lights[i];
+
+            if (this._uLightColor[i]) {
+                gl.uniform4f(this._uLightColor[i], light.color[0], light.color[1], light.color[2], light.intensity);
+            }
+            if (this._uLightPos[i]) {
+                gl.uniform3fv(this._uLightPos[i], light.pos);
+                if (this._uLightAttenuation[i]) {
+                    gl.uniform1f(this._uLightAttenuation[i], light.attenuation);
+                }
+            }
+            if (this._uLightDir[i]) {
+                gl.uniform3fv(this._uLightDir[i], light.dir);
+            }
+        }
+
+        if (lightsState.reflectionMaps.length > 0 && lightsState.reflectionMaps[0].texture && this._uReflectionMap) {
+            program.bindTexture(this._uReflectionMap, lightsState.reflectionMaps[0].texture, frameCtx.textureUnit);
+            frameCtx.textureUnit = (frameCtx.textureUnit + 1) % maxTextureUnits;
+            frameCtx.bindTexture++;
+        }
+
+        if (lightsState.lightMaps.length > 0 && lightsState.lightMaps[0].texture && this._uLightMap) {
+            program.bindTexture(this._uLightMap, lightsState.lightMaps[0].texture, frameCtx.textureUnit);
+            frameCtx.textureUnit = (frameCtx.textureUnit + 1) % maxTextureUnits;
+            frameCtx.bindTexture++;
+        }
+
+        if (this._withSAO) {
+            const sao = scene.sao;
+            const saoEnabled = sao.possible;
+            if (saoEnabled) {
+                const viewportWidth = gl.drawingBufferWidth;
+                const viewportHeight = gl.drawingBufferHeight;
+                tempVec4[0] = viewportWidth;
+                tempVec4[1] = viewportHeight;
+                tempVec4[2] = sao.blendCutoff;
+                tempVec4[3] = sao.blendFactor;
+                gl.uniform4fv(this._uSAOParams, tempVec4);
+                this._program.bindTexture(this._uOcclusionTexture, frameCtx.occlusionTexture, frameCtx.textureUnit);
+                frameCtx.textureUnit = (frameCtx.textureUnit + 1) % maxTextureUnits;
+                frameCtx.bindTexture++;
+            }
+        }
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            const logDepthBufFC = 2.0 / (Math.log(project.far + 1.0) / Math.LN2);
+            gl.uniform1f(this._uLogDepthBufFC, logDepthBufFC);
+        }
+
+        if (this._uGammaFactor) {
+            gl.uniform1f(this._uGammaFactor, scene.gammaFactor);
+        }
+    }
+
+    _buildShader() {
+        return {
+            vertex: this._buildVertexShader(),
+            fragment: this._buildFragmentShader()
+        };
+    }
+
+    _buildVertexShader() {
+
+        const scene = this._scene;
+        const sectionPlanesState = scene._sectionPlanesState;
+        const lightsState = scene._lightsState;
+        const clipping = sectionPlanesState.sectionPlanes.length > 0;
+        const clippingCaps = sectionPlanesState.clippingCaps;
+
+        const src = [];
+
+        src.push("// Triangles dataTexture quality draw vertex shader");
+
+        if (scene.logarithmicDepthBufferEnabled && WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+            src.push("#extension GL_EXT_frag_depth : enable");
+        }
+
+        src.push("uniform int renderPass;");
+
+        src.push("attribute vec3 position;");
+        src.push("attribute vec3 normal;");
+        src.push("attribute vec4 color;");
+        src.push("attribute vec2 metallicRoughness;");
+        src.push("attribute vec4 flags;");
+        src.push("attribute vec4 flags2;");
+
+        if (scene.entityOffsetsEnabled) {
+            src.push("attribute vec3 offset;");
+        }
+
+        src.push("uniform mat4 worldMatrix;");
+        src.push("uniform mat4 worldNormalMatrix;");
+
+        src.push("uniform mat4 viewMatrix;");
+        src.push("uniform mat4 projMatrix;");
+        src.push("uniform mat4 viewNormalMatrix;");
+        src.push("uniform mat4 positionsDecodeMatrix;");
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("uniform float logDepthBufFC;");
+            if (WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+                src.push("varying float vFragDepth;");
+            }
+            src.push("bool isPerspectiveMatrix(mat4 m) {");
+            src.push("    return (m[2][3] == - 1.0);");
+            src.push("}");
+            src.push("varying float isPerspective;");
+        }
+
+        src.push("vec3 octDecode(vec2 oct) {");
+        src.push("    vec3 v = vec3(oct.xy, 1.0 - abs(oct.x) - abs(oct.y));");
+        src.push("    if (v.z < 0.0) {");
+        src.push("        v.xy = (1.0 - abs(v.yx)) * vec2(v.x >= 0.0 ? 1.0 : -1.0, v.y >= 0.0 ? 1.0 : -1.0);");
+        src.push("    }");
+        src.push("    return normalize(v);");
+        src.push("}");
+
+        src.push("varying vec4 vViewPosition;");
+        src.push("varying vec3 vViewNormal;");
+        src.push("varying vec4 vColor;");
+        src.push("varying vec2 vMetallicRoughness;");
+
+        if (lightsState.lightMaps.length > 0) {
+            src.push("varying vec3 vWorldNormal;");
+        }
+
+        if (clipping) {
+            src.push("varying vec4 vWorldPosition;");
+            src.push("varying vec4 vFlags2;");
+            if (clippingCaps) {
+                src.push("varying vec4 vClipPosition;");
+            }
+        }
+
+        src.push("void main(void) {");
+
+        // flags.x = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
+        // renderPass = COLOR_OPAQUE
+
+        src.push(`if (int(flags.x) != renderPass) {`);
+        src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
+
+        src.push("} else {");
+
+        src.push("vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
+        if (scene.entityOffsetsEnabled) {
+            src.push("worldPosition.xyz = worldPosition.xyz + offset;");
+        }
+        src.push("vec4 viewPosition  = viewMatrix * worldPosition; ");
+        src.push("vec4 worldNormal =  worldNormalMatrix * vec4(octDecode(normal.xy), 0.0); ");
+        src.push("vec3 viewNormal = normalize((viewNormalMatrix * worldNormal).xyz);");
+
+        src.push("vec4 clipPos = projMatrix * viewPosition;");
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("isPerspective = float (isPerspectiveMatrix(projMatrix));");
+            if (WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+                src.push("vFragDepth = 1.0 + clipPos.w;");
+            } else {
+                src.push("clipPos.z = log2( max( 1e-6, clipPos.w + 1.0 ) ) * logDepthBufFC - 1.0;");
+                src.push("clipPos.z *= clipPos.w;");
+            }
+        }
+
+        if (clipping) {
+            src.push("vWorldPosition = worldPosition;");
+            src.push("vFlags2 = flags2;");
+            if (clippingCaps) {
+                src.push("vClipPosition = clipPos;");
+            }
+        }
+
+        src.push("vViewPosition = viewPosition;");
+        src.push("vViewNormal = viewNormal;");
+        src.push("vColor = color;");
+        src.push("vMetallicRoughness = metallicRoughness;");
+
+        if (lightsState.lightMaps.length > 0) {
+            src.push("vWorldNormal = worldNormal.xyz;");
+        }
+
+        src.push("gl_Position = clipPos;");
+        src.push("}");
+
+        src.push("}");
+        return src;
+    }
+
+    _buildFragmentShader() {
+
+        const scene = this._scene;
+        const gammaOutput = scene.gammaOutput; // If set, then it expects that all textures and colors need to be outputted in premultiplied gamma. Default is false.
+        const sectionPlanesState = scene._sectionPlanesState;
+        const lightsState = scene._lightsState;
+        const clipping = sectionPlanesState.sectionPlanes.length > 0;
+        const clippingCaps = sectionPlanesState.clippingCaps;
+        const src = [];
+
+        src.push("// Triangles dataTexture quality draw fragment shader");
+
+        if (scene.logarithmicDepthBufferEnabled && WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+            src.push("#extension GL_EXT_frag_depth : enable");
+        }
+
+        src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
+        src.push("precision highp float;");
+        src.push("precision highp int;");
+        src.push("#else");
+        src.push("precision mediump float;");
+        src.push("precision mediump int;");
+        src.push("#endif");
+
+        if (scene.logarithmicDepthBufferEnabled && WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+            src.push("varying float isPerspective;");
+            src.push("uniform float logDepthBufFC;");
+            src.push("varying float vFragDepth;");
+        }
+
+        src.push("varying vec4 vViewPosition;");
+        src.push("varying vec3 vViewNormal;");
+        src.push("varying vec4 vColor;");
+        src.push("varying vec2 vMetallicRoughness;");
+
+        if (lightsState.lightMaps.length > 0) {
+            src.push("varying vec3 vWorldNormal;");
+        }
+
+        src.push("uniform mat4 viewMatrix;");
+
+        if (lightsState.reflectionMaps.length > 0) {
+            src.push("uniform samplerCube reflectionMap;");
+        }
+
+        if (lightsState.lightMaps.length > 0) {
+            src.push("uniform samplerCube lightMap;");
+        }
+
+        src.push("uniform vec4 lightAmbient;");
+
+        for (let i = 0, len = lightsState.lights.length; i < len; i++) {
+            const light = lightsState.lights[i];
+            if (light.type === "ambient") {
+                continue;
+            }
+            src.push("uniform vec4 lightColor" + i + ";");
+            if (light.type === "dir") {
+                src.push("uniform vec3 lightDir" + i + ";");
+            }
+            if (light.type === "point") {
+                src.push("uniform vec3 lightPos" + i + ";");
+            }
+            if (light.type === "spot") {
+                src.push("uniform vec3 lightPos" + i + ";");
+                src.push("uniform vec3 lightDir" + i + ";");
+            }
+        }
+
+        if (this._withSAO) {
+            src.push("uniform sampler2D uOcclusionTexture;");
+            src.push("uniform vec4      uSAOParams;");
+
+            src.push("const float       packUpscale = 256. / 255.;");
+            src.push("const float       unpackDownScale = 255. / 256.;");
+            src.push("const vec3        packFactors = vec3( 256. * 256. * 256., 256. * 256.,  256. );");
+            src.push("const vec4        unPackFactors = unpackDownScale / vec4( packFactors, 1. );");
+
+            src.push("float unpackRGBAToDepth( const in vec4 v ) {");
+            src.push("    return dot( v, unPackFactors );");
+            src.push("}");
+        }
+
+        src.push("uniform float gammaFactor;");
+        src.push("vec4 linearToLinear( in vec4 value ) {");
+        src.push("  return value;");
+        src.push("}");
+        src.push("vec4 sRGBToLinear( in vec4 value ) {");
+        src.push("  return vec4( mix( pow( value.rgb * 0.9478672986 + vec3( 0.0521327014 ), vec3( 2.4 ) ), value.rgb * 0.0773993808, vec3( lessThanEqual( value.rgb, vec3( 0.04045 ) ) ) ), value.w );");
+        src.push("}");
+        src.push("vec4 gammaToLinear( in vec4 value) {");
+        src.push("  return vec4( pow( value.xyz, vec3( gammaFactor ) ), value.w );");
+        src.push("}");
+        if (gammaOutput) {
+            src.push("vec4 linearToGamma( in vec4 value, in float gammaFactor ) {");
+            src.push("  return vec4( pow( value.xyz, vec3( 1.0 / gammaFactor ) ), value.w );");
+            src.push("}");
+        }
+
+        if (clipping) {
+            src.push("varying vec4 vWorldPosition;");
+            src.push("varying vec4 vFlags2;");
+            if (clippingCaps) {
+                src.push("varying vec4 vClipPosition;");
+            }
+            for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
+                src.push("uniform bool sectionPlaneActive" + i + ";");
+                src.push("uniform vec3 sectionPlanePos" + i + ";");
+                src.push("uniform vec3 sectionPlaneDir" + i + ";");
+            }
+        }
+
+        // CONSTANT DEFINITIONS
+
+        src.push("#define PI 3.14159265359");
+        src.push("#define RECIPROCAL_PI 0.31830988618");
+        src.push("#define RECIPROCAL_PI2 0.15915494");
+        src.push("#define EPSILON 1e-6");
+
+        src.push("#define saturate(a) clamp( a, 0.0, 1.0 )");
+
+        // UTILITY DEFINITIONS
+
+        src.push("vec3 inverseTransformDirection(in vec3 dir, in mat4 matrix) {");
+        src.push("   return normalize( ( vec4( dir, 0.0 ) * matrix ).xyz );");
+        src.push("}");
+
+        // STRUCTURES
+
+        src.push("struct IncidentLight {");
+        src.push("   vec3 color;");
+        src.push("   vec3 direction;");
+        src.push("};");
+
+        src.push("struct ReflectedLight {");
+        src.push("   vec3 diffuse;");
+        src.push("   vec3 specular;");
+        src.push("};");
+
+        src.push("struct Geometry {");
+        src.push("   vec3 position;");
+        src.push("   vec3 viewNormal;");
+        src.push("   vec3 worldNormal;");
+        src.push("   vec3 viewEyeDir;");
+        src.push("};");
+
+        src.push("struct Material {");
+        src.push("   vec3    diffuseColor;");
+        src.push("   float   specularRoughness;");
+        src.push("   vec3    specularColor;");
+        src.push("   float   shine;"); // Only used for Phong
+        src.push("};");
+
+        // IRRADIANCE EVALUATION
+
+        src.push("float GGXRoughnessToBlinnExponent(const in float ggxRoughness) {");
+        src.push("   float r = ggxRoughness + 0.0001;");
+        src.push("   return (2.0 / (r * r) - 2.0);");
+        src.push("}");
+
+        src.push("float getSpecularMIPLevel(const in float blinnShininessExponent, const in int maxMIPLevel) {");
+        src.push("   float maxMIPLevelScalar = float( maxMIPLevel );");
+        src.push("   float desiredMIPLevel = maxMIPLevelScalar - 0.79248 - 0.5 * log2( ( blinnShininessExponent * blinnShininessExponent ) + 1.0 );");
+        src.push("   return clamp( desiredMIPLevel, 0.0, maxMIPLevelScalar );");
+        src.push("}");
+
+        if (lightsState.reflectionMaps.length > 0) {
+            src.push("vec3 getLightProbeIndirectRadiance(const in vec3 reflectVec, const in float blinnShininessExponent, const in int maxMIPLevel) {");
+            src.push("   float mipLevel = 0.5 * getSpecularMIPLevel(blinnShininessExponent, maxMIPLevel);"); //TODO: a random factor - fix this
+            src.push("   vec3 envMapColor = " + TEXTURE_DECODE_FUNCS[lightsState.reflectionMaps[0].encoding] + "(textureCube(reflectionMap, reflectVec, mipLevel)).rgb;");
+            src.push("  return envMapColor;");
+            src.push("}");
+        }
+
+        // SPECULAR BRDF EVALUATION
+
+        src.push("vec3 F_Schlick(const in vec3 specularColor, const in float dotLH) {");
+        src.push("   float fresnel = exp2( ( -5.55473 * dotLH - 6.98316 ) * dotLH );");
+        src.push("   return ( 1.0 - specularColor ) * fresnel + specularColor;");
+        src.push("}");
+
+        src.push("float G_GGX_Smith(const in float alpha, const in float dotNL, const in float dotNV) {");
+        src.push("   float a2 = ( alpha * alpha );");
+        src.push("   float gl = dotNL + sqrt( a2 + ( 1.0 - a2 ) * ( dotNL * dotNL ) );");
+        src.push("   float gv = dotNV + sqrt( a2 + ( 1.0 - a2 ) * ( dotNV * dotNV ) );");
+        src.push("   return 1.0 / ( gl * gv );");
+        src.push("}");
+
+        src.push("float G_GGX_SmithCorrelated(const in float alpha, const in float dotNL, const in float dotNV) {");
+        src.push("   float a2 = ( alpha * alpha );");
+        src.push("   float gv = dotNL * sqrt( a2 + ( 1.0 - a2 ) * ( dotNV * dotNV ) );");
+        src.push("   float gl = dotNV * sqrt( a2 + ( 1.0 - a2 ) * ( dotNL * dotNL ) );");
+        src.push("   return 0.5 / max( gv + gl, EPSILON );");
+        src.push("}");
+
+        src.push("float D_GGX(const in float alpha, const in float dotNH) {");
+        src.push("   float a2 = ( alpha * alpha );");
+        src.push("   float denom = ( dotNH * dotNH) * ( a2 - 1.0 ) + 1.0;");
+        src.push("   return RECIPROCAL_PI * a2 / ( denom * denom);");
+        src.push("}");
+
+        src.push("vec3 BRDF_Specular_GGX(const in IncidentLight incidentLight, const in Geometry geometry, const in vec3 specularColor, const in float roughness) {");
+        src.push("   float alpha = ( roughness * roughness );");
+        src.push("   vec3 halfDir = normalize( incidentLight.direction + geometry.viewEyeDir );");
+        src.push("   float dotNL = saturate( dot( geometry.viewNormal, incidentLight.direction ) );");
+        src.push("   float dotNV = saturate( dot( geometry.viewNormal, geometry.viewEyeDir ) );");
+        src.push("   float dotNH = saturate( dot( geometry.viewNormal, halfDir ) );");
+        src.push("   float dotLH = saturate( dot( incidentLight.direction, halfDir ) );");
+        src.push("   vec3  F = F_Schlick( specularColor, dotLH );");
+        src.push("   float G = G_GGX_SmithCorrelated( alpha, dotNL, dotNV );");
+        src.push("   float D = D_GGX( alpha, dotNH );");
+        src.push("   return F * (G * D);");
+        src.push("}");
+
+        src.push("vec3 BRDF_Specular_GGX_Environment(const in Geometry geometry, const in vec3 specularColor, const in float roughness) {");
+        src.push("   float dotNV = saturate(dot(geometry.viewNormal, geometry.viewEyeDir));");
+        src.push("   const vec4 c0 = vec4( -1, -0.0275, -0.572,  0.022);");
+        src.push("   const vec4 c1 = vec4(  1,  0.0425,   1.04, -0.04);");
+        src.push("   vec4 r = roughness * c0 + c1;");
+        src.push("   float a004 = min(r.x * r.x, exp2(-9.28 * dotNV)) * r.x + r.y;");
+        src.push("   vec2 AB    = vec2(-1.04, 1.04) * a004 + r.zw;");
+        src.push("   return specularColor * AB.x + AB.y;");
+        src.push("}");
+
+        if (lightsState.lightMaps.length > 0 || lightsState.reflectionMaps.length > 0) {
+
+            src.push("void computePBRLightMapping(const in Geometry geometry, const in Material material, inout ReflectedLight reflectedLight) {");
+
+            if (lightsState.lightMaps.length > 0) {
+                src.push("   vec3 irradiance = " + TEXTURE_DECODE_FUNCS[lightsState.lightMaps[0].encoding] + "(textureCube(lightMap, geometry.worldNormal)).rgb;");
+                src.push("   irradiance *= PI;");
+                src.push("   vec3 diffuseBRDFContrib = (RECIPROCAL_PI * material.diffuseColor);");
+                src.push("   reflectedLight.diffuse +=  irradiance * diffuseBRDFContrib;");
+            }
+
+            if (lightsState.reflectionMaps.length > 0) {
+                src.push("   vec3 reflectVec             = reflect(geometry.viewEyeDir, geometry.viewNormal);");
+                src.push("   reflectVec                  = inverseTransformDirection(reflectVec, viewMatrix);");
+                src.push("   float blinnExpFromRoughness = GGXRoughnessToBlinnExponent(material.specularRoughness);");
+                src.push("   vec3 radiance               = getLightProbeIndirectRadiance(reflectVec, blinnExpFromRoughness, 8);");
+                src.push("   vec3 specularBRDFContrib    = BRDF_Specular_GGX_Environment(geometry, material.specularColor, material.specularRoughness);");
+                src.push("   reflectedLight.specular     += radiance * specularBRDFContrib;");
+            }
+
+            src.push("}");
+        }
+
+        // MAIN LIGHTING COMPUTATION FUNCTION
+
+        src.push("void computePBRLighting(const in IncidentLight incidentLight, const in Geometry geometry, const in Material material, inout ReflectedLight reflectedLight) {");
+        src.push("   float dotNL     = saturate(dot(geometry.viewNormal, incidentLight.direction));");
+        src.push("   vec3 irradiance = dotNL * incidentLight.color * PI;");
+        src.push("   reflectedLight.diffuse  += irradiance * (RECIPROCAL_PI * material.diffuseColor);");
+        src.push("   reflectedLight.specular += irradiance * BRDF_Specular_GGX(incidentLight, geometry, material.specularColor, material.specularRoughness);");
+        src.push("}");
+
+        src.push("void main(void) {");
+
+        if (clipping) {
+            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  if (clippable) {");
+            src.push("  float dist = 0.0;");
+            for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
+                src.push("if (sectionPlaneActive" + i + ") {");
+                src.push("   dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
+                src.push("}");
+            }
+            if (clippingCaps) {
+                src.push("  if (dist > (0.002 * vClipPosition.w)) {");
+                src.push("      discard;");
+                src.push("  }");
+                src.push("  if (dist > 0.0) { ");
+                src.push("      gl_FragColor=vec4(1.0, 0.0, 0.0, 1.0);");
+                if (scene.logarithmicDepthBufferEnabled && WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+                    src.push("  gl_FragDepthEXT = log2( vFragDepth ) * logDepthBufFC * 0.5;");
+                }
+                src.push("  return;");
+                src.push("}");
+            } else {
+                src.push("  if (dist > 0.0) { ");
+                src.push("      discard;")
+                src.push("  }");
+            }
+            src.push("}");
+        }
+
+        src.push("IncidentLight  light;");
+        src.push("Material       material;");
+        src.push("Geometry       geometry;");
+        src.push("ReflectedLight reflectedLight = ReflectedLight(vec3(0.0,0.0,0.0), vec3(0.0,0.0,0.0));");
+
+        src.push("vec3 rgb = (vec3(float(vColor.r) / 255.0, float(vColor.g) / 255.0, float(vColor.b) / 255.0));");
+        src.push("float alpha = float(vColor.a) / 255.0;");
+
+        src.push("vec3  diffuseColor = rgb;");
+        src.push("float specularF0 = 1.0;");
+        src.push("float metallic = float(vMetallicRoughness.r) / 255.0;");
+        src.push("float roughness = float(vMetallicRoughness.g) / 255.0;");
+        src.push("float dielectricSpecular = 0.16 * specularF0 * specularF0;");
+
+        src.push("material.diffuseColor      = diffuseColor * (1.0 - dielectricSpecular) * (1.0 - metallic);");
+        src.push("material.specularRoughness = clamp(roughness, 0.04, 1.0);");
+        src.push("material.specularColor     = mix(vec3(dielectricSpecular), diffuseColor, metallic);");
+
+        src.push("geometry.position      = vViewPosition.xyz;");
+        src.push("geometry.viewNormal    = -normalize(vViewNormal);");
+        src.push("geometry.viewEyeDir    = normalize(vViewPosition.xyz);");
+
+        if (lightsState.lightMaps.length > 0) {
+            src.push("geometry.worldNormal   = normalize(vWorldNormal);");
+        }
+
+        if (lightsState.lightMaps.length > 0 || lightsState.reflectionMaps.length > 0) {
+            src.push("computePBRLightMapping(geometry, material, reflectedLight);");
+        }
+
+        for (let i = 0, len = lightsState.lights.length; i < len; i++) {
+            const light = lightsState.lights[i];
+            if (light.type === "ambient") {
+                continue;
+            }
+            if (light.type === "dir") {
+                if (light.space === "view") {
+                    src.push("light.direction =  normalize(lightDir" + i + ");");
+                } else {
+                    src.push("light.direction =  normalize((viewMatrix * vec4(lightDir" + i + ", 0.0)).xyz);");
+                }
+            } else if (light.type === "point") {
+                if (light.space === "view") {
+                    src.push("light.direction =  normalize(lightPos" + i + " - vViewPosition.xyz);");
+                } else {
+                    src.push("light.direction =  normalize((viewMatrix * vec4(lightPos" + i + ", 0.0)).xyz);");
+                }
+            } else if (light.type === "spot") {
+                if (light.space === "view") {
+                    src.push("light.direction =  normalize(lightDir" + i + ");");
+                } else {
+                    src.push("light.direction =  normalize((viewMatrix * vec4(lightDir" + i + ", 0.0)).xyz);");
+                }
+            } else {
+                continue;
+            }
+
+            src.push("light.color =  lightColor" + i + ".rgb * lightColor" + i + ".a;"); // a is intensity
+
+            src.push("computePBRLighting(light, geometry, material, reflectedLight);");
+        }
+
+        src.push("vec3 outgoingLight = (lightAmbient.rgb * lightAmbient.a * rgb) + (reflectedLight.diffuse) + (reflectedLight.specular);");
+
+        src.push("vec4 fragColor;");
+
+        if (this._withSAO) {
+            // Doing SAO blend in the main solid fill draw shader just so that edge lines can be drawn over the top
+            // Would be more efficient to defer this, then render lines later, using same depth buffer for Z-reject
+            src.push("   float viewportWidth     = uSAOParams[0];");
+            src.push("   float viewportHeight    = uSAOParams[1];");
+            src.push("   float blendCutoff       = uSAOParams[2];");
+            src.push("   float blendFactor       = uSAOParams[3];");
+            src.push("   vec2 uv                 = vec2(gl_FragCoord.x / viewportWidth, gl_FragCoord.y / viewportHeight);");
+            src.push("   float ambient           = smoothstep(blendCutoff, 1.0, unpackRGBAToDepth(texture2D(uOcclusionTexture, uv))) * blendFactor;");
+            src.push("   fragColor               = vec4(outgoingLight.rgb * ambient, alpha);");
+        } else {
+            src.push("   fragColor            = vec4(outgoingLight.rgb, alpha);");
+        }
+
+        if (gammaOutput) {
+            src.push("fragColor = linearToGamma(fragColor, gammaFactor);");
+        }
+
+        src.push("gl_FragColor = fragColor;");
+
+        if (scene.logarithmicDepthBufferEnabled && WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+            src.push("    gl_FragDepthEXT = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;");
+        }
+
+        src.push("}");
+        return src;
+    }
+
+    webglContextRestored() {
+        this._program = null;
+    }
+
+    destroy() {
+        if (this._program) {
+            this._program.destroy();
+        }
+        this._program = null;
+    }
+}
+
+export {TrianglesDataTextureColorQualityRenderer};

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
@@ -401,12 +401,20 @@ class TrianglesDataTextureColorRenderer {
         // get color
         src.push("uvec4 color = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(0, objectIndex), 0);"); // chipmunk
         
+        src.push(`if (color.a == 0u) {`);
+        src.push("   gl_Position = vec4(3.0, 3.0, 3.0, 1.0);"); // Cull vertex
+        src.push("   return;");
+        src.push("};");
+
         // get normal
         src.push("vec3 normal = -normalize(cross(positions[2] - positions[0], positions[1] - positions[0]));");
 
         src.push("vec3 position = positions[gl_VertexID % 3];");
         
         src.push("vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
+
+        src.push("worldPosition.xyz /= worldPosition.w;");
+        src.push("worldPosition.w = 1.0;");
 
         // get XYZ offset
         src.push("vec3 offset = texelFetch (uTexturePerObjectIdOffsets, ivec2(0, objectIndex), 0).rgb;");

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
@@ -417,10 +417,7 @@ class TrianglesDataTextureColorRenderer {
 
         src.push("mat4 entityNormalMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(8, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(9, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(10, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(11, objectIndex), 0));")
 
-        src.push("vec4 worldNormal =  worldNormalMatrix * (vec4(normal, 1) * entityNormalMatrix); ");
-
-        src.push("worldNormalMatrix = entityNormalMatrix * worldNormalMatrix;")
-
+        src.push("vec4 worldNormal = entityNormalMatrix * worldNormalMatrix * vec4(normal, 1); ");
 
         src.push("vec3 viewNormal = normalize((viewNormalMatrix * worldNormal).xyz);");
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
@@ -293,7 +293,7 @@ class TrianglesDataTextureColorRenderer {
 
         // src.push("uniform sampler2D uOcclusionTexture;"); // chipmunk
 
-        src.push("uniform mediump sampler2D uTexturePerObjectIdPositionsDecodeMatrix;"); // chipmunk
+        src.push("uniform highp sampler2D uTexturePerObjectIdPositionsDecodeMatrix;"); // chipmunk
         src.push("uniform lowp usampler2D uTexturePerObjectIdColorsAndFlags;"); // chipmunk
         src.push("uniform highp sampler2D uTexturePerObjectIdOffsets;"); // chipmunk
         src.push("uniform mediump usampler2D uTexturePerVertexIdCoordinates;"); // chipmunk

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
@@ -54,7 +54,8 @@ class TrianglesDataTextureColorRenderer {
             this._uTexturePerVertexIdCoordinates, 
             this._uTexturePerObjectIdColorsAndFlags, 
             this._uTextureCameraMatrices, 
-            this._uTextureModelMatrices, 
+            this._uTextureModelMatrices,
+            this._uTexturePerObjectIdOffsets
         );
 
         gl.uniform1i(this._uRenderPass, renderPass);
@@ -198,6 +199,7 @@ class TrianglesDataTextureColorRenderer {
         this._uTexturePerPolygonIdPortionIds = "uTexturePerPolygonIdPortionIds"; // chipmunk
         this._uTextureCameraMatrices = "uTextureCameraMatrices"; // chipmunk
         this._uTextureModelMatrices = "uTextureModelMatrices"; // chipmunk
+        this._uTexturePerObjectIdOffsets = "uTexturePerObjectIdOffsets"; // chipmunk
     }
 
     _bindProgram(frameCtx) {
@@ -293,6 +295,7 @@ class TrianglesDataTextureColorRenderer {
 
         src.push("uniform mediump sampler2D uTexturePerObjectIdPositionsDecodeMatrix;"); // chipmunk
         src.push("uniform lowp usampler2D uTexturePerObjectIdColorsAndFlags;"); // chipmunk
+        src.push("uniform highp sampler2D uTexturePerObjectIdOffsets;"); // chipmunk
         src.push("uniform mediump usampler2D uTexturePerVertexIdCoordinates;"); // chipmunk
         src.push("uniform highp usampler2D uTexturePerPolygonIdIndices;"); // chipmunk
         src.push("uniform mediump usampler2D uTexturePerPolygonIdPortionIds;"); // chipmunk
@@ -405,9 +408,10 @@ class TrianglesDataTextureColorRenderer {
         
         src.push("vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
 
-        if (scene.entityOffsetsEnabled) {
-            src.push("worldPosition.xyz = worldPosition.xyz + offset;");
-        }
+        // get XYZ offset
+        src.push("vec3 offset = texelFetch (uTexturePerObjectIdOffsets, ivec2(0, objectIndex), 0).rgb;");
+
+        src.push("worldPosition.xyz = worldPosition.xyz + offset;");
 
         src.push("vec4 viewPosition = viewMatrix * worldPosition; ");
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
@@ -1,0 +1,574 @@
+import {Program} from "../../../../../webgl/Program.js";
+import {math} from "../../../../../math/math.js";
+import {createRTCViewMat, getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
+import {WEBGL_INFO} from "../../../../../webglInfo.js";
+
+const tempVec4 = math.vec4();
+const tempVec3a = math.vec3();
+
+/**
+ * @private
+ */
+class TrianglesDataTextureColorRenderer {
+
+    constructor(scene, withSAO) {
+        this._scene = scene;
+        this._withSAO = withSAO;
+        this._hash = this._getHash();
+        this._allocate();
+    }
+
+    getValid() {
+        return this._hash === this._getHash();
+    };
+
+    _getHash() {
+        const scene = this._scene;
+        return [scene._lightsState.getHash(), scene._sectionPlanesState.getHash(), (this._withSAO ? "sao" : "nosao")].join(";");
+    }
+
+    drawLayer(frameCtx, dataTextureLayer, renderPass) {
+        const scene = this._scene;
+        const camera = scene.camera;
+        const model = dataTextureLayer.model;
+        const gl = scene.canvas.gl;
+        const state = dataTextureLayer._state;
+        const textureState = state.textureState;
+        const origin = dataTextureLayer._state.origin;
+
+        if (!this._program) {
+            this._allocate();
+            if (this.errors) {
+                return;
+            }
+        }
+
+        if (frameCtx.lastProgramId !== this._program.id) {
+            frameCtx.lastProgramId = this._program.id;
+            this._bindProgram(frameCtx, state);
+        }
+        
+        textureState.bindCommonTextures (
+            this._program,
+            this._uTexturePerObjectIdPositionsDecodeMatrix, 
+            this._uTexturePerVertexIdCoordinates, 
+            this._uTexturePerObjectIdColorsAndFlags, 
+            this._uTextureCameraMatrices, 
+            this._uTextureModelMatrices, 
+        );
+
+        gl.uniform1i(this._uRenderPass, renderPass);
+
+        const numSectionPlanes = scene._sectionPlanesState.sectionPlanes.length;
+        if (numSectionPlanes > 0) {
+            const sectionPlanes = scene._sectionPlanesState.sectionPlanes;
+            const baseIndex = dataTextureLayer.layerIndex * numSectionPlanes;
+            const renderFlags = model.renderFlags;
+            for (let sectionPlaneIndex = 0; sectionPlaneIndex < numSectionPlanes; sectionPlaneIndex++) {
+                const sectionPlaneUniforms = this._uSectionPlanes[sectionPlaneIndex];
+                if (sectionPlaneUniforms) {
+                    const active = renderFlags.sectionPlanesActivePerLayer[baseIndex + sectionPlaneIndex];
+                    gl.uniform1i(sectionPlaneUniforms.active, active ? 1 : 0);
+                    if (active) {
+                        const sectionPlane = sectionPlanes[sectionPlaneIndex];
+                        if (origin) {
+                            const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a);
+                            gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
+                        } else {
+                            gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);
+                        }
+                        gl.uniform3fv(sectionPlaneUniforms.dir, sectionPlane.dir);
+                    }
+                }
+            }
+        }
+
+        if (state.numIndices8Bits > 0)
+        {
+            textureState.bindTriangleIndicesTextures(
+                this._program,
+                this._uTexturePerPolygonIdPortionIds, 
+                this._uTexturePerPolygonIdIndices, 
+                8 // 8 bits indices
+            );
+
+            gl.drawArrays(gl.TRIANGLES, 0, state.numIndices8Bits);
+        }
+
+        if (state.numIndices16Bits > 0)
+        {
+            textureState.bindTriangleIndicesTextures(
+                this._program,
+                this._uTexturePerPolygonIdPortionIds, 
+                this._uTexturePerPolygonIdIndices, 
+                16 // 16 bits indices
+            );
+
+            gl.drawArrays(gl.TRIANGLES, 0, state.numIndices16Bits);
+        }
+        
+        if (state.numIndices32Bits > 0)
+        {
+            textureState.bindTriangleIndicesTextures(
+                this._program,
+                this._uTexturePerPolygonIdPortionIds, 
+                this._uTexturePerPolygonIdIndices, 
+                32 // 32 bits indices
+            );
+
+            gl.drawArrays(gl.TRIANGLES, 0, state.numIndices32Bits);
+        }
+
+        frameCtx.drawElements++;
+    }
+
+    _allocate() {
+
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+        const lightsState = scene._lightsState;
+
+        this._program = new Program(gl, this._buildShader());
+
+        if (this._program.errors) {
+            this.errors = this._program.errors;
+            return;
+        }
+
+        const program = this._program;
+
+        this._uRenderPass = program.getLocation("renderPass");
+
+        this._uLightAmbient = program.getLocation("lightAmbient");
+        this._uLightColor = [];
+        this._uLightDir = [];
+        this._uLightPos = [];
+        this._uLightAttenuation = [];
+
+        const lights = lightsState.lights;
+        let light;
+
+        for (let i = 0, len = lights.length; i < len; i++) {
+            light = lights[i];
+            switch (light.type) {
+                case "dir":
+                    this._uLightColor[i] = program.getLocation("lightColor" + i);
+                    this._uLightPos[i] = null;
+                    this._uLightDir[i] = program.getLocation("lightDir" + i);
+                    break;
+                case "point":
+                    this._uLightColor[i] = program.getLocation("lightColor" + i);
+                    this._uLightPos[i] = program.getLocation("lightPos" + i);
+                    this._uLightDir[i] = null;
+                    this._uLightAttenuation[i] = program.getLocation("lightAttenuation" + i);
+                    break;
+                case "spot":
+                    this._uLightColor[i] = program.getLocation("lightColor" + i);
+                    this._uLightPos[i] = program.getLocation("lightPos" + i);
+                    this._uLightDir[i] = program.getLocation("lightDir" + i);
+                    this._uLightAttenuation[i] = program.getLocation("lightAttenuation" + i);
+                    break;
+            }
+        }
+
+        this._uSectionPlanes = [];
+
+        for (let i = 0, len = scene._sectionPlanesState.sectionPlanes.length; i < len; i++) {
+            this._uSectionPlanes.push({
+                active: program.getLocation("sectionPlaneActive" + i),
+                pos: program.getLocation("sectionPlanePos" + i),
+                dir: program.getLocation("sectionPlaneDir" + i)
+            });
+        }
+        
+        if (this._withSAO) {
+            this._uOcclusionTexture = "uOcclusionTexture";
+            this._uSAOParams = program.getLocation("uSAOParams");
+        }
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            this._uLogDepthBufFC = program.getLocation("logDepthBufFC");
+        }
+
+        this._uTexturePerObjectIdPositionsDecodeMatrix = "uTexturePerObjectIdPositionsDecodeMatrix"; // chipmunk
+        this._uTexturePerObjectIdColorsAndFlags = "uTexturePerObjectIdColorsAndFlags"; // chipmunk
+        this._uTexturePerVertexIdCoordinates = "uTexturePerVertexIdCoordinates"; // chipmunk
+        this._uTexturePerPolygonIdNormals = "uTexturePerPolygonIdNormals"; // chipmunk
+        this._uTexturePerPolygonIdIndices = "uTexturePerPolygonIdIndices"; // chipmunk
+        this._uTexturePerPolygonIdPortionIds = "uTexturePerPolygonIdPortionIds"; // chipmunk
+        this._uTextureCameraMatrices = "uTextureCameraMatrices"; // chipmunk
+        this._uTextureModelMatrices = "uTextureModelMatrices"; // chipmunk
+    }
+
+    _bindProgram(frameCtx) {
+
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+        const program = this._program;
+        const lights = scene._lightsState.lights;
+        const project = scene.camera.project;
+
+        program.bind();
+
+        if (this._uLightAmbient) {
+            gl.uniform4fv(this._uLightAmbient, scene._lightsState.getAmbientColorAndIntensity());
+        }
+
+        for (let i = 0, len = lights.length; i < len; i++) {
+            const light = lights[i];
+
+            if (this._uLightColor[i]) {
+                gl.uniform4f(this._uLightColor[i], light.color[0], light.color[1], light.color[2], light.intensity);
+            }
+            if (this._uLightPos[i]) {
+                gl.uniform3fv(this._uLightPos[i], light.pos);
+                if (this._uLightAttenuation[i]) {
+                    gl.uniform1f(this._uLightAttenuation[i], light.attenuation);
+                }
+            }
+            if (this._uLightDir[i]) {
+                gl.uniform3fv(this._uLightDir[i], light.dir);
+            }
+        }
+
+        if (this._withSAO) {
+            const sao = scene.sao;
+            const saoEnabled = sao.possible;
+            if (saoEnabled) {
+                const viewportWidth = gl.drawingBufferWidth;
+                const viewportHeight = gl.drawingBufferHeight;
+                tempVec4[0] = viewportWidth;
+                tempVec4[1] = viewportHeight;
+                tempVec4[2] = sao.blendCutoff;
+                tempVec4[3] = sao.blendFactor;
+                gl.uniform4fv(this._uSAOParams, tempVec4);
+                this._program.bindTexture(this._uOcclusionTexture, frameCtx.occlusionTexture, 0);
+            }
+        }
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            const logDepthBufFC = 2.0 / (Math.log(project.far + 1.0) / Math.LN2);
+            gl.uniform1f(this._uLogDepthBufFC, logDepthBufFC);
+        }
+    }
+
+    _buildShader() {
+        return {
+            vertex: this._buildVertexShader(),
+            fragment: this._buildFragmentShader()
+        };
+    }
+
+    _buildVertexShader() {
+        const scene = this._scene;
+        const sectionPlanesState = scene._sectionPlanesState;
+        const lightsState = scene._lightsState;
+        const clipping = sectionPlanesState.sectionPlanes.length > 0;
+        let light;
+        const src = [];
+        src.push("#version 300 es");
+        src.push("// Triangles dataTexture draw vertex shader");
+
+        src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
+        src.push("precision highp float;");
+        src.push("precision highp int;");
+        src.push("precision highp usampler2D;");
+        src.push("precision highp isampler2D;");
+        src.push("precision highp sampler2D;");
+        src.push("#else");
+        src.push("precision mediump float;");
+        src.push("precision mediump int;");
+        src.push("precision mediump usampler2D;");
+        src.push("precision mediump isampler2D;");
+        src.push("precision mediump sampler2D;");
+        src.push("#endif");
+
+        src.push("uniform int renderPass;");
+
+        if (scene.entityOffsetsEnabled) {
+            src.push("in vec3 offset;");
+        }
+
+        // src.push("uniform sampler2D uOcclusionTexture;"); // chipmunk
+
+        src.push("uniform mediump sampler2D uTexturePerObjectIdPositionsDecodeMatrix;"); // chipmunk
+        src.push("uniform lowp usampler2D uTexturePerObjectIdColorsAndFlags;"); // chipmunk
+        src.push("uniform mediump usampler2D uTexturePerVertexIdCoordinates;"); // chipmunk
+        src.push("uniform highp usampler2D uTexturePerPolygonIdIndices;"); // chipmunk
+        src.push("uniform mediump usampler2D uTexturePerPolygonIdPortionIds;"); // chipmunk
+        src.push("uniform highp sampler2D uTextureCameraMatrices;"); // chipmunk
+        src.push("uniform highp sampler2D uTextureModelMatrices;"); // chipmunk
+
+        src.push("vec3 positions[3];")
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("uniform float logDepthBufFC;");
+            src.push("out float vFragDepth;");
+            src.push("bool isPerspectiveMatrix(mat4 m) {");
+            src.push("    return (m[2][3] == - 1.0);");
+            src.push("}");
+            src.push("out float isPerspective;");
+        }
+
+        src.push("uniform vec4 lightAmbient;");
+
+        for (let i = 0, len = lightsState.lights.length; i < len; i++) {
+            light = lightsState.lights[i];
+            if (light.type === "ambient") {
+                continue;
+            }
+            src.push("uniform vec4 lightColor" + i + ";");
+            if (light.type === "dir") {
+                src.push("uniform vec3 lightDir" + i + ";");
+            }
+            if (light.type === "point") {
+                src.push("uniform vec3 lightPos" + i + ";");
+            }
+            if (light.type === "spot") {
+                src.push("uniform vec3 lightPos" + i + ";");
+                src.push("uniform vec3 lightDir" + i + ";");
+            }
+        }
+        
+        if (clipping) {
+            src.push("out vec4 vWorldPosition;");
+            src.push("out int vFlags2;");
+        }
+        
+        src.push("out vec4 vColor;");
+
+        src.push("void main(void) {");
+
+        // camera matrices
+        src.push ("mat4 viewMatrix = mat4 (texelFetch (uTextureCameraMatrices, ivec2(0, 0), 0), texelFetch (uTextureCameraMatrices, ivec2(1, 0), 0), texelFetch (uTextureCameraMatrices, ivec2(2, 0), 0), texelFetch (uTextureCameraMatrices, ivec2(3, 0), 0));");
+        src.push ("mat4 viewNormalMatrix = mat4 (texelFetch (uTextureCameraMatrices, ivec2(0, 1), 0), texelFetch (uTextureCameraMatrices, ivec2(1, 1), 0), texelFetch (uTextureCameraMatrices, ivec2(2, 1), 0), texelFetch (uTextureCameraMatrices, ivec2(3, 1), 0));");
+        src.push ("mat4 projMatrix = mat4 (texelFetch (uTextureCameraMatrices, ivec2(0, 2), 0), texelFetch (uTextureCameraMatrices, ivec2(1, 2), 0), texelFetch (uTextureCameraMatrices, ivec2(2, 2), 0), texelFetch (uTextureCameraMatrices, ivec2(3, 2), 0));");
+
+        // model matrices
+        src.push ("mat4 worldMatrix = mat4 (texelFetch (uTextureModelMatrices, ivec2(0, 0), 0), texelFetch (uTextureModelMatrices, ivec2(1, 0), 0), texelFetch (uTextureModelMatrices, ivec2(2, 0), 0), texelFetch (uTextureModelMatrices, ivec2(3, 0), 0));");
+        src.push ("mat4 worldNormalMatrix = mat4 (texelFetch (uTextureModelMatrices, ivec2(0, 1), 0), texelFetch (uTextureModelMatrices, ivec2(1, 1), 0), texelFetch (uTextureModelMatrices, ivec2(2, 1), 0), texelFetch (uTextureModelMatrices, ivec2(3, 1), 0));");
+        
+        // constants
+        src.push("int polygonIndex = gl_VertexID / 3;")
+
+        // get packed object-id
+        src.push("int h_packed_object_id_index = (polygonIndex >> 3) & 1023;")
+        src.push("int v_packed_object_id_index = (polygonIndex >> 3) >> 10;")
+
+        src.push("int objectIndex = int(texelFetch(uTexturePerPolygonIdPortionIds, ivec2(h_packed_object_id_index, v_packed_object_id_index), 0).r);");
+
+        // get flags & flags2
+        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(2, objectIndex), 0);"); // chipmunk
+        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(3, objectIndex), 0);"); // chipmunk
+        
+        // flags.x = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
+        // renderPass = COLOR_OPAQUE
+
+        src.push(`if (int(flags.x) != renderPass) {`);
+        src.push("   gl_Position = vec4(3.0, 3.0, 3.0, 1.0);"); // Cull vertex
+        src.push("   return;"); // Cull vertex
+        src.push("} else {");
+
+        // get vertex base
+        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(4, objectIndex), 0));");
+
+        src.push("ivec4 packedIndexBaseOffset = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(5, objectIndex), 0));");
+
+        src.push("int indexBaseOffset = (packedIndexBaseOffset.r << 24) + (packedIndexBaseOffset.g << 16) + (packedIndexBaseOffset.b << 8) + packedIndexBaseOffset.a;");
+
+        src.push("int h_index = (polygonIndex - indexBaseOffset) & 1023;")
+        src.push("int v_index = (polygonIndex - indexBaseOffset) >> 10;")
+
+        src.push("ivec3 vertexIndices = ivec3(texelFetch(uTexturePerPolygonIdIndices, ivec2(h_index, v_index), 0));");
+        src.push("ivec3 uniqueVertexIndexes = vertexIndices + (packedVertexBase.r << 24) + (packedVertexBase.g << 16) + (packedVertexBase.b << 8) + packedVertexBase.a;")
+        
+        src.push("ivec3 indexPositionH = uniqueVertexIndexes & 1023;")
+        src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 10;")
+
+        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(0, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(1, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(2, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(3, objectIndex), 0));")
+        src.push("mat4 entityMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(4, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(5, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(6, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(7, objectIndex), 0));")
+
+        src.push("positionsDecodeMatrix = entityMatrix * positionsDecodeMatrix;")
+        
+        // get position
+        src.push("positions[0] = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.r, indexPositionV.r), 0));")
+        src.push("positions[1] = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.g, indexPositionV.g), 0));")
+        src.push("positions[2] = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.b, indexPositionV.b), 0));")
+
+        // get color
+        src.push("uvec4 color = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(0, objectIndex), 0);"); // chipmunk
+        
+        // get normal
+        src.push("vec3 normal = -normalize(cross(positions[2] - positions[0], positions[1] - positions[0]));");
+
+        src.push("vec3 position = positions[gl_VertexID % 3];");
+        
+        src.push("vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
+
+        if (scene.entityOffsetsEnabled) {
+            src.push("worldPosition.xyz = worldPosition.xyz + offset;");
+        }
+
+        src.push("vec4 viewPosition = viewMatrix * worldPosition; ");
+
+        src.push("mat4 entityNormalMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(8, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(9, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(10, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(11, objectIndex), 0));")
+
+        src.push("vec4 worldNormal =  worldNormalMatrix * (vec4(normal, 1) * entityNormalMatrix); ");
+
+        src.push("worldNormalMatrix = entityNormalMatrix * worldNormalMatrix;")
+
+
+        src.push("vec3 viewNormal = normalize((viewNormalMatrix * worldNormal).xyz);");
+
+        src.push("vec3 reflectedColor = vec3(0.0, 0.0, 0.0);");
+        src.push("vec3 viewLightDir = vec3(0.0, 0.0, -1.0);");
+
+        src.push("float lambertian = 1.0;");
+        for (let i = 0, len = lightsState.lights.length; i < len; i++) {
+            light = lightsState.lights[i];
+            if (light.type === "ambient") {
+                continue;
+            }
+            if (light.type === "dir") {
+                if (light.space === "view") {
+                    src.push("viewLightDir = normalize(lightDir" + i + ");");
+                } else {
+                    src.push("viewLightDir = normalize((viewMatrix * vec4(lightDir" + i + ", 0.0)).xyz);");
+                }
+            } else if (light.type === "point") {
+                if (light.space === "view") {
+                    src.push("viewLightDir = -normalize(lightPos" + i + " - viewPosition.xyz);");
+                } else {
+                    src.push("viewLightDir = -normalize((viewMatrix * vec4(lightPos" + i + ", 0.0)).xyz);");
+                }
+            } else if (light.type === "spot") {
+                if (light.space === "view") {
+                    src.push("viewLightDir = normalize(lightDir" + i + ");");
+                } else {
+                    src.push("viewLightDir = normalize((viewMatrix * vec4(lightDir" + i + ", 0.0)).xyz);");
+                }
+            } else {
+                continue;
+            }
+            src.push("lambertian = max(dot(-viewNormal, viewLightDir), 0.0);");
+            src.push("reflectedColor += lambertian * (lightColor" + i + ".rgb * lightColor" + i + ".a);");
+        }
+
+        src.push("vec3 rgb = vec3(color.rgb) / 255.0;");
+        src.push("vColor =  vec4((lightAmbient.rgb * lightAmbient.a * rgb) + (reflectedColor * rgb), float(color.a) / 255.0);");
+
+        src.push("vec4 clipPos = projMatrix * viewPosition;");
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("vFragDepth = 1.0 + clipPos.w;");
+            src.push("isPerspective = float (isPerspectiveMatrix(projMatrix));");
+        }
+        if (clipping) {
+            src.push("vWorldPosition = worldPosition;");
+            src.push("vFlags2 = flags2.r;");
+        }
+        src.push("gl_Position = clipPos;");
+        src.push("}");
+
+        src.push("}");
+
+        return src;
+    }
+
+    _buildFragmentShader() {
+        const scene = this._scene;
+        const sectionPlanesState = scene._sectionPlanesState;
+        const clipping = sectionPlanesState.sectionPlanes.length > 0;
+        const src = [];
+        src.push ('#version 300 es');
+        src.push("// Triangles dataTexture draw fragment shader");
+        src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
+        src.push("precision highp float;");
+        src.push("precision highp int;");
+        src.push("#else");
+        src.push("precision mediump float;");
+        src.push("precision mediump int;");
+        src.push("#endif");
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("in float isPerspective;");
+            src.push("uniform float logDepthBufFC;");
+            src.push("in float vFragDepth;");
+        }
+
+        if (this._withSAO) {
+            src.push("uniform sampler2D uOcclusionTexture;");
+            src.push("uniform vec4      uSAOParams;");
+
+            src.push("const float       packUpscale = 256. / 255.;");
+            src.push("const float       unpackDownScale = 255. / 256.;");
+            src.push("const vec3        packFactors = vec3( 256. * 256. * 256., 256. * 256.,  256. );");
+            src.push("const vec4        unPackFactors = unpackDownScale / vec4( packFactors, 1. );");
+
+            src.push("float unpackRGBToFloat( const in vec4 v ) {");
+            src.push("    return dot( v, unPackFactors );");
+            src.push("}");
+        }
+        if (clipping) {
+            src.push("in vec4 vWorldPosition;");
+            src.push("in int vFlags2;");
+            for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
+                src.push("uniform bool sectionPlaneActive" + i + ";");
+                src.push("uniform vec3 sectionPlanePos" + i + ";");
+                src.push("uniform vec3 sectionPlaneDir" + i + ";");
+            }
+        }
+        src.push("in vec4 vColor;");
+        src.push("out vec4 outColor;");
+        src.push("void main(void) {");
+
+        if (clipping) {
+            src.push("  bool clippable = vFlags2 > 0;");
+            src.push("  if (clippable) {");
+            src.push("  float dist = 0.0;");
+            for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
+                src.push("if (sectionPlaneActive" + i + ") {");
+                src.push("   dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
+                src.push("}");
+            }
+                src.push("  if (dist > 0.0) { ");
+                src.push("      discard;")
+                src.push("  }");
+            src.push("}");
+        }
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            // src.push("    gl_FragDepth = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;");
+            src.push("    gl_FragDepth = log2( vFragDepth ) * logDepthBufFC * 0.5;");
+        }
+
+        if (this._withSAO) {
+            // Doing SAO blend in the main solid fill draw shader just so that edge lines can be drawn over the top
+            // Would be more efficient to defer this, then render lines later, using same depth buffer for Z-reject
+            src.push("   float viewportWidth     = uSAOParams[0];");
+            src.push("   float viewportHeight    = uSAOParams[1];");
+            src.push("   float blendCutoff       = uSAOParams[2];");
+            src.push("   float blendFactor       = uSAOParams[3];");
+            src.push("   vec2 uv                 = vec2(gl_FragCoord.x / viewportWidth, gl_FragCoord.y / viewportHeight);");
+            src.push("   float ambient           = smoothstep(blendCutoff, 1.0, unpackRGBToFloat(texture2D(uOcclusionTexture, uv))) * blendFactor;");
+            src.push("   outColor            = vec4(vColor.rgb * ambient, 1.0);");
+        } else {
+            src.push("   outColor            = vColor;");
+        }
+
+        src.push("}");
+        return src;
+    }
+
+    webglContextRestored() {
+        this._program = null;
+    }
+
+    destroy() {
+        if (this._program) {
+            this._program.destroy();
+        }
+        this._program = null;
+    }
+}
+
+export {TrianglesDataTextureColorRenderer};

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
@@ -1,7 +1,7 @@
-import {Program} from "../../../../../webgl/Program.js";
-import {math} from "../../../../../math/math.js";
-import {createRTCViewMat, getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
-import {WEBGL_INFO} from "../../../../../webglInfo.js";
+import {Program} from "../../../../../../webgl/Program.js";
+import {math} from "../../../../../../math/math.js";
+import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
+import {WEBGL_INFO} from "../../../../../../webglInfo.js";
 
 const tempVec4 = math.vec4();
 const tempVec3a = math.vec3();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
@@ -418,9 +418,9 @@ class TrianglesDataTextureColorRenderer {
         src.push("worldPosition.w = 1.0;");
 
         // get XYZ offset
-        src.push("vec3 offset = texelFetch (uTexturePerObjectIdOffsets, ivec2(0, objectIndex), 0).rgb;");
+        src.push("vec4 offset = vec4(texelFetch (uTexturePerObjectIdOffsets, objectIndexCoords, 0).rgb, 0.0);");
 
-        src.push("worldPosition.xyz = worldPosition.xyz + offset;");
+        src.push("worldPosition.xyz = worldPosition.xyz + offset.xyz;");
 
         src.push("vec4 viewPosition = viewMatrix * worldPosition; ");
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
@@ -355,8 +355,8 @@ class TrianglesDataTextureColorRenderer {
         src.push("int polygonIndex = gl_VertexID / 3;")
 
         // get packed object-id
-        src.push("int h_packed_object_id_index = (polygonIndex >> 3) & 1023;")
-        src.push("int v_packed_object_id_index = (polygonIndex >> 3) >> 10;")
+        src.push("int h_packed_object_id_index = (polygonIndex >> 3) & 4095;")
+        src.push("int v_packed_object_id_index = (polygonIndex >> 3) >> 12;")
 
         src.push("int objectIndex = int(texelFetch(uTexturePerPolygonIdPortionIds, ivec2(h_packed_object_id_index, v_packed_object_id_index), 0).r);");
 
@@ -379,14 +379,14 @@ class TrianglesDataTextureColorRenderer {
 
         src.push("int indexBaseOffset = (packedIndexBaseOffset.r << 24) + (packedIndexBaseOffset.g << 16) + (packedIndexBaseOffset.b << 8) + packedIndexBaseOffset.a;");
 
-        src.push("int h_index = (polygonIndex - indexBaseOffset) & 1023;")
-        src.push("int v_index = (polygonIndex - indexBaseOffset) >> 10;")
+        src.push("int h_index = (polygonIndex - indexBaseOffset) & 4095;")
+        src.push("int v_index = (polygonIndex - indexBaseOffset) >> 12;")
 
         src.push("ivec3 vertexIndices = ivec3(texelFetch(uTexturePerPolygonIdIndices, ivec2(h_index, v_index), 0));");
         src.push("ivec3 uniqueVertexIndexes = vertexIndices + (packedVertexBase.r << 24) + (packedVertexBase.g << 16) + (packedVertexBase.b << 8) + packedVertexBase.a;")
         
-        src.push("ivec3 indexPositionH = uniqueVertexIndexes & 1023;")
-        src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 10;")
+        src.push("ivec3 indexPositionH = uniqueVertexIndexes & 4095;")
+        src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 12;")
 
         src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(0, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(1, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(2, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(3, objectIndex), 0));")
         src.push("mat4 entityMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(4, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(5, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(6, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(7, objectIndex), 0));")

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
@@ -436,7 +436,7 @@ class TrianglesDataTextureColorRenderer {
             src.push("}");
         src.push("}");
 
-        src.push("vec3 viewNormal = -normalize((transpose(inverse(viewMatrix)) * vec4(normal,1)).xyz);");
+        src.push("vec3 viewNormal = -normalize((transpose(inverse(viewMatrix*positionsDecodeMatrix)) * vec4(normal,1)).xyz);");
 
         src.push("vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
@@ -422,26 +422,22 @@ class TrianglesDataTextureColorRenderer {
 
         // get normal
         src.push("vec3 normal = normalize(cross(positions[2] - positions[0], positions[1] - positions[0]));");
-        src.push("vec3 viewNormal = -normalize((transpose(inverse(viewMatrix)) * vec4(normal,1)).xyz);");
+
+        src.push("vec3 position;");
+        src.push("position = positions[gl_VertexID % 3];");
 
         // when the geometry is not solid, if needed, flip the triangle winding
-        src.push("vec3 position;");
-
         src.push("if (solid != 1u) {");
-            src.push("vec3 triangleCenter = (worldMatrix*positionsDecodeMatrix*vec4((positions[0] + positions[1] + positions[2]) / 3.0, 1)).xyz;")
-            src.push("vec3 worldNormal = normalize((transpose(inverse(worldMatrix*positionsDecodeMatrix)) * vec4(normal, 1)).xyz);");
-            src.push("vec3 cameraToTriangleDirection = normalize(triangleCenter - uCameraEyeRtc);")
-            // src.push("vColor = vec4(vec3(1, -1, 0)*dot(cameraToTriangleDirection, worldNormal), 1);")
-            src.push("if (dot(cameraToTriangleDirection, worldNormal) < 0.0) {");
+            src.push("vec3 uCameraEyeRtcInQuantizedSpace = (inverse(worldMatrix * positionsDecodeMatrix) * vec4(uCameraEyeRtc, 1)).xyz;")
+            // src.push("vColor = vec4(vec3(1, -1, 0)*dot(normalize(position.xyz - uCameraEyeRtcInQuantizedSpace), normal), 1);")
+            src.push("if (dot(position.xyz - uCameraEyeRtcInQuantizedSpace, normal) < 0.0) {");
                 src.push("position = positions[2 - (gl_VertexID % 3)];");
-                src.push("viewNormal = -viewNormal;");
-            src.push("} else {");
-                src.push("position = positions[gl_VertexID % 3];");
+                src.push("normal = -normal;");
             src.push("}");
-        src.push("} else {")
-                src.push("position = positions[gl_VertexID % 3];");
         src.push("}");
-        
+
+        src.push("vec3 viewNormal = -normalize((transpose(inverse(viewMatrix)) * vec4(normal,1)).xyz);");
+
         src.push("vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
 
         // get XYZ offset

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
@@ -359,10 +359,11 @@ class TrianglesDataTextureColorRenderer {
         src.push("int v_packed_object_id_index = (polygonIndex >> 3) >> 12;")
 
         src.push("int objectIndex = int(texelFetch(uTexturePerPolygonIdPortionIds, ivec2(h_packed_object_id_index, v_packed_object_id_index), 0).r);");
+        src.push("ivec2 objectIndexCoords = ivec2(objectIndex % 512, objectIndex / 512);");
 
         // get flags & flags2
-        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(2, objectIndex), 0);"); // chipmunk
-        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(3, objectIndex), 0);"); // chipmunk
+        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+2, objectIndexCoords.y), 0);"); // chipmunk
+        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+3, objectIndexCoords.y), 0);"); // chipmunk
         
         // flags.x = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
         // renderPass = COLOR_OPAQUE
@@ -373,9 +374,9 @@ class TrianglesDataTextureColorRenderer {
         src.push("} else {");
 
         // get vertex base
-        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(4, objectIndex), 0));");
+        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+4, objectIndexCoords.y), 0));"); // chipmunk
 
-        src.push("ivec4 packedIndexBaseOffset = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(5, objectIndex), 0));");
+        src.push("ivec4 packedIndexBaseOffset = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+5, objectIndexCoords.y), 0));"); // chipmunk
 
         src.push("int indexBaseOffset = (packedIndexBaseOffset.r << 24) + (packedIndexBaseOffset.g << 16) + (packedIndexBaseOffset.b << 8) + packedIndexBaseOffset.a;");
 
@@ -399,7 +400,7 @@ class TrianglesDataTextureColorRenderer {
         src.push("positions[2] = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.b, indexPositionV.b), 0));")
 
         // get color
-        src.push("uvec4 color = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(0, objectIndex), 0);"); // chipmunk
+        src.push("uvec4 color = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+0, objectIndexCoords.y), 0);"); // chipmunk
         
         src.push(`if (color.a == 0u) {`);
         src.push("   gl_Position = vec4(3.0, 3.0, 3.0, 1.0);"); // Cull vertex

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
@@ -425,9 +425,7 @@ class TrianglesDataTextureColorRenderer {
 
         src.push("mat4 entityNormalMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(8, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(9, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(10, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(11, objectIndex), 0));")
 
-        src.push("vec4 worldNormal = entityNormalMatrix * worldNormalMatrix * vec4(normal, 1); ");
-
-        src.push("vec3 viewNormal = normalize((viewNormalMatrix * worldNormal).xyz);");
+        src.push("vec3 viewNormal = normalize((viewNormalMatrix * vec4(normal,1)).xyz);");
 
         src.push("vec3 reflectedColor = vec3(0.0, 0.0, 0.0);");
         src.push("vec3 viewLightDir = vec3(0.0, 0.0, -1.0);");

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
@@ -389,8 +389,8 @@ class TrianglesDataTextureColorRenderer {
         src.push("ivec3 indexPositionH = uniqueVertexIndexes & 4095;")
         src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 12;")
 
-        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(0, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(1, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(2, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(3, objectIndex), 0));")
-        src.push("mat4 entityMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(4, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(5, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(6, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(7, objectIndex), 0));")
+        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+2, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+3, objectIndexCoords.y), 0));")
+        src.push("mat4 entityMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+4, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+5, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+6, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+7, objectIndexCoords.y), 0));")
 
         src.push("positionsDecodeMatrix = entityMatrix * positionsDecodeMatrix;")
         

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
@@ -330,7 +330,7 @@ class TrianglesDataTextureColorRenderer {
             src.push("out float vFragDepth;");
             src.push("out float isPerspective;");
         }
-        
+
         src.push("bool isPerspectiveMatrix(mat4 m) {");
         src.push("    return (m[2][3] == - 1.0);");
         src.push("}");
@@ -357,7 +357,7 @@ class TrianglesDataTextureColorRenderer {
         
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out int vFlags2;");
+            src.push("flat out uint vFlags2;");
         }
         
         src.push("out vec4 vColor;");
@@ -445,15 +445,15 @@ class TrianglesDataTextureColorRenderer {
                 src.push("vec3 uCameraEyeRtcInQuantizedSpace = (inverse(worldMatrix * positionsDecodeMatrix) * vec4(uCameraEyeRtc, 1)).xyz;")
                 // src.push("vColor = vec4(vec3(1, -1, 0)*dot(normalize(position.xyz - uCameraEyeRtcInQuantizedSpace), normal), 1);")
                 src.push("if (dot(position.xyz - uCameraEyeRtcInQuantizedSpace, normal) < 0.0) {");
-                    src.push("position = positions[2 - (gl_VertexID % 3)];");
-                    src.push("viewNormal = -viewNormal;");
-                src.push("}");
+                        src.push("position = positions[2 - (gl_VertexID % 3)];");
+                        src.push("viewNormal = -viewNormal;");
+                    src.push("}");
             src.push("} else {");
                 // src.push("vColor = vec4(vec3(1, -1, 0)*viewNormal.z, 1);")
                 src.push("if (viewNormal.z < 0.0) {");
-                    src.push("position = positions[2 - (gl_VertexID % 3)];");
-                    src.push("viewNormal = -viewNormal;");
-                src.push("}");
+                        src.push("position = positions[2 - (gl_VertexID % 3)];");
+                        src.push("viewNormal = -viewNormal;");
+                    src.push("}");
             src.push("}");
         src.push("}");
 
@@ -556,7 +556,7 @@ class TrianglesDataTextureColorRenderer {
         }
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in int vFlags2;");
+            src.push("flat in uint vFlags2;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -568,7 +568,7 @@ class TrianglesDataTextureColorRenderer {
         src.push("void main(void) {");
 
         if (clipping) {
-            src.push("  bool clippable = vFlags2 > 0;");
+            src.push("  bool clippable = vFlags2 > 0u;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureDepthRenderer.js
@@ -1,0 +1,303 @@
+import {stats} from "../../../../../stats.js"
+import {Program} from "../../../../../webgl/Program.js";
+import {createRTCViewMat, getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
+import {math} from "../../../../../math/math.js";
+import {WEBGL_INFO} from "../../../../../webglInfo.js";
+
+const tempVec3a = math.vec3();
+
+/**
+ * @private
+ */
+class TrianglesDataTextureDepthRenderer {
+
+    constructor(scene) {
+        this._scene = scene;
+        this._allocate();
+        this._hash = this._getHash();
+    }
+
+    getValid() {
+        return this._hash === this._getHash();
+    };
+
+    _getHash() {
+        return this._scene._sectionPlanesState.getHash();
+    }
+
+    drawLayer(frameCtx, dataTextureLayer, renderPass) {
+
+        const model = dataTextureLayer.model;
+        const scene = model.scene;
+        const camera = scene.camera;
+        const gl = scene.canvas.gl;
+        const state = dataTextureLayer._state;
+        const origin = dataTextureLayer._state.origin;
+
+        if (!this._program) {
+            this._allocate();
+            if (this.errors) {
+                return;
+            }
+        }
+
+        if (frameCtx.lastProgramId !== this._program.id) {
+            frameCtx.lastProgramId = this._program.id;
+            this._bindProgram();
+        }
+
+        gl.uniform1i(this._uRenderPass, renderPass);
+
+        gl.uniformMatrix4fv(this._uWorldMatrix, false, model.worldMatrix);
+        gl.uniformMatrix4fv(this._uViewMatrix, false, (origin) ? createRTCViewMat(camera.viewMatrix, origin) : camera.viewMatrix);
+
+        const numSectionPlanes = scene._sectionPlanesState.sectionPlanes.length;
+        if (numSectionPlanes > 0) {
+            const sectionPlanes = scene._sectionPlanesState.sectionPlanes;
+            const baseIndex = dataTextureLayer.layerIndex * numSectionPlanes;
+            const renderFlags = model.renderFlags;
+            for (let sectionPlaneIndex = 0; sectionPlaneIndex < numSectionPlanes; sectionPlaneIndex++) {
+                const sectionPlaneUniforms = this._uSectionPlanes[sectionPlaneIndex];
+                if (sectionPlaneUniforms) {
+                    const active = renderFlags.sectionPlanesActivePerLayer[baseIndex + sectionPlaneIndex];
+                    gl.uniform1i(sectionPlaneUniforms.active, active ? 1 : 0);
+                    if (active) {
+                        const sectionPlane = sectionPlanes[sectionPlaneIndex];
+                        if (origin) {
+                            const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a);
+                            gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
+                        } else {
+                            gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);
+                        }
+                        gl.uniform3fv(sectionPlaneUniforms.dir, sectionPlane.dir);
+                    }
+                }
+            }
+        }
+
+        gl.uniformMatrix4fv(this._uPositionsDecodeMatrix, false, dataTextureLayer._state.positionsDecodeMatrix);
+
+        this._aPosition.bindArrayBuffer(state.positionsBuf);
+
+        if (this._aOffset) {
+            this._aOffset.bindArrayBuffer(state.offsetsBuf);
+        }
+
+        this._aFlags.bindArrayBuffer(state.flagsBuf);
+
+        if (this._aFlags2) {
+            this._aFlags2.bindArrayBuffer(state.flags2Buf);
+        }
+
+        state.indicesBuf.bind();
+
+        gl.drawElements(gl.TRIANGLES, state.indicesBuf.numItems, state.indicesBuf.itemType, 0);
+    }
+
+    _allocate() {
+
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+
+        this._program = new Program(gl, this._buildShader());
+
+        if (this._program.errors) {
+            this.errors = this._program.errors;
+            return;
+        }
+
+        const program = this._program;
+
+        this._uRenderPass = program.getLocation("renderPass");
+        this._uPositionsDecodeMatrix = program.getLocation("positionsDecodeMatrix");
+        this._uWorldMatrix = program.getLocation("worldMatrix");
+        this._uViewMatrix = program.getLocation("viewMatrix");
+        this._uProjMatrix = program.getLocation("projMatrix");
+        this._uSectionPlanes = [];
+
+        for (let i = 0, len = scene._sectionPlanesState.sectionPlanes.length; i < len; i++) {
+            this._uSectionPlanes.push({
+                active: program.getLocation("sectionPlaneActive" + i),
+                pos: program.getLocation("sectionPlanePos" + i),
+                dir: program.getLocation("sectionPlaneDir" + i)
+            });
+        }
+
+        this._aPosition = program.getAttribute("position");
+        this._aOffset = program.getAttribute("offset");
+        this._aFlags = program.getAttribute("flags");
+        this._aFlags2 = program.getAttribute("flags2");
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            this._uLogDepthBufFC = program.getLocation("logDepthBufFC");
+        }
+    }
+
+    _bindProgram() {
+
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+        const project = scene.camera.project;
+
+        this._program.bind();
+
+        gl.uniformMatrix4fv(this._uProjMatrix, false, project.matrix);
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            const logDepthBufFC = 2.0 / (Math.log(project.far + 1.0) / Math.LN2);
+            gl.uniform1f(this._uLogDepthBufFC, logDepthBufFC);
+        }
+    }
+
+    _buildShader() {
+        return {
+            vertex: this._buildVertexShader(),
+            fragment: this._buildFragmentShader()
+        };
+    }
+
+    _buildVertexShader() {
+        const scene = this._scene;
+        const clipping = scene._sectionPlanesState.sectionPlanes.length > 0;
+        const src = [];
+        src.push("// Triangles dataTexture depth vertex shader");
+        if (scene.logarithmicDepthBufferEnabled && WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+            src.push("#extension GL_EXT_frag_depth : enable");
+        }
+        src.push("uniform int renderPass;");
+        src.push("attribute vec3 position;");
+        if (scene.entityOffsetsEnabled) {
+            src.push("attribute vec3 offset;");
+        }
+        src.push("attribute vec4 flags;");
+        src.push("attribute vec4 flags2;");
+        src.push("uniform mat4 worldMatrix;");
+        src.push("uniform mat4 viewMatrix;");
+        src.push("uniform mat4 projMatrix;");
+        src.push("uniform mat4 positionsDecodeMatrix;");
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("uniform float logDepthBufFC;");
+            if (WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+                src.push("varying float vFragDepth;");
+            }
+            src.push("bool isPerspectiveMatrix(mat4 m) {");
+            src.push("    return (m[2][3] == - 1.0);");
+            src.push("}");
+            src.push("varying float isPerspective;");
+        }
+        if (clipping) {
+            src.push("varying vec4 vWorldPosition;");
+            src.push("varying vec4 vFlags2;");
+        }
+        src.push("varying vec2 vHighPrecisionZW;");
+        src.push("void main(void) {");
+
+        // flags.x = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
+        // renderPass = COLOR_OPAQUE
+
+        src.push(`if (int(flags.x) != renderPass) {`);
+        src.push("      gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
+        src.push("  } else {");
+        src.push("      vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
+        if (scene.entityOffsetsEnabled) {
+            src.push("      worldPosition.xyz = worldPosition.xyz + offset;");
+        }
+        src.push("      vec4 viewPosition  = viewMatrix * worldPosition; ");
+        if (clipping) {
+            src.push("      vWorldPosition = worldPosition;");
+            src.push("      vFlags2 = flags2;");
+        }
+        src.push("vec4 clipPos = projMatrix * viewPosition;");
+        if (scene.logarithmicDepthBufferEnabled) {
+            if (WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+                src.push("vFragDepth = 1.0 + clipPos.w;");
+            } else {
+                src.push("clipPos.z = log2( max( 1e-6, clipPos.w + 1.0 ) ) * logDepthBufFC - 1.0;");
+                src.push("clipPos.z *= clipPos.w;");
+            }
+            src.push("isPerspective = float (isPerspectiveMatrix(projMatrix));");
+        }
+        src.push("gl_Position = clipPos;");
+        src.push("vHighPrecisionZW = gl_Position.zw;");
+        src.push("  }");
+        src.push("}");
+        return src;
+    }
+
+    _buildFragmentShader() {
+        const scene = this._scene;
+        const sectionPlanesState = scene._sectionPlanesState;
+        const clipping = (sectionPlanesState.sectionPlanes.length > 0);
+        const src = [];
+        src.push("// Triangles dataTexture depth fragment shader");
+        if (scene.logarithmicDepthBufferEnabled && WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+            src.push("#extension GL_EXT_frag_depth : enable");
+        }
+        src.push("precision highp float;");
+        src.push("precision highp int;");
+        if (scene.logarithmicDepthBufferEnabled && WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+            src.push("varying float isPerspective;");
+            src.push("uniform float logDepthBufFC;");
+            src.push("varying float vFragDepth;");
+        }
+        if (clipping) {
+            src.push("varying vec4 vWorldPosition;");
+            src.push("varying vec4 vFlags2;");
+            for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
+                src.push("uniform bool sectionPlaneActive" + i + ";");
+                src.push("uniform vec3 sectionPlanePos" + i + ";");
+                src.push("uniform vec3 sectionPlaneDir" + i + ";");
+            }
+        }
+        src.push("const float   packUpScale = 256. / 255.;");
+        src.push("const float   unpackDownscale = 255. / 256.;");
+        src.push("const vec3    packFactors = vec3( 256. * 256. * 256., 256. * 256.,  256. );");
+        src.push("const vec4    unpackFactors = unpackDownscale / vec4( packFactors, 1. );");
+        src.push("const float   shiftRight8 = 1.0 / 256.;");
+
+        src.push("vec4 packDepthToRGBA( const in float v ) {");
+        src.push("    vec4 r = vec4( fract( v * packFactors ), v );");
+        src.push("    r.yzw -= r.xyz * shiftRight8;");
+        src.push("    return r * packUpScale;");
+        src.push("}");
+        src.push("varying vec2 vHighPrecisionZW;");
+        src.push("void main(void) {");
+        if (clipping) {
+            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  if (clippable) {");
+            src.push("      float dist = 0.0;");
+            for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
+                src.push("      if (sectionPlaneActive" + i + ") {");
+                src.push("          dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
+                src.push("      }");
+            }
+            src.push("      if (dist > 0.0) { discard; }");
+            src.push("  }");
+        }
+        if (scene.logarithmicDepthBufferEnabled && WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+            src.push("    gl_FragDepthEXT = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;");
+        }
+        src.push("float fragCoordZ = 0.5 * vHighPrecisionZW[0] / vHighPrecisionZW[1] + 0.5;");
+        if (WEBGL_INFO.SUPPORTED_EXTENSIONS["WEBGL_depth_texture"]) {
+            src.push("    gl_FragColor = vec4(vec3(1.0 - fragCoordZ), 1.0); ");
+        } else {
+            src.push("    gl_FragColor = packDepthToRGBA(fragCoordZ); "); // Must be linear depth
+        }
+        src.push("}");
+        return src;
+    }
+
+    webglContextRestored() {
+        this._program = null;
+    }
+
+    destroy() {
+        if (this._program) {
+            this._program.destroy();
+        }
+        this._program = null;
+        stats.memory.programs--;
+    }
+}
+
+export {TrianglesDataTextureDepthRenderer};

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureDepthRenderer.js
@@ -1,8 +1,8 @@
-import {stats} from "../../../../../stats.js"
-import {Program} from "../../../../../webgl/Program.js";
-import {createRTCViewMat, getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
-import {math} from "../../../../../math/math.js";
-import {WEBGL_INFO} from "../../../../../webglInfo.js";
+import {stats} from "../../../../../../stats.js"
+import {Program} from "../../../../../../webgl/Program.js";
+import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
+import {math} from "../../../../../../math/math.js";
+import {WEBGL_INFO} from "../../../../../../webglInfo.js";
 
 const tempVec3a = math.vec3();
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
@@ -1,0 +1,388 @@
+import {Program} from "../../../../../webgl/Program.js";
+import {createRTCViewMat, getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
+import {math} from "../../../../../math/math.js";
+import {WEBGL_INFO} from "../../../../../webglInfo.js";
+
+const tempVec3a = math.vec3();
+
+/**
+ * @private
+ */
+class TrianglesDataTextureEdgesColorRenderer {
+
+    constructor(scene) {
+        this._scene = scene;
+        this._hash = this._getHash();
+        this._allocate();
+    }
+
+    getValid() {
+        return this._hash === this._getHash();
+    };
+
+    _getHash() {
+        return this._scene._sectionPlanesState.getHash();
+    }
+
+    drawLayer(frameCtx, dataTextureLayer, renderPass) {
+        const model = dataTextureLayer.model;
+        const scene = model.scene;
+        const camera = scene.camera;
+        const gl = scene.canvas.gl;
+        const state = dataTextureLayer._state;
+        const textureState = state.textureState;
+        const origin = dataTextureLayer._state.origin;
+        
+        if (!this._program) {
+            this._allocate(dataTextureLayer);
+            if (this.errors) {
+                return;
+            }
+        }
+
+        if (frameCtx.lastProgramId !== this._program.id) {
+            frameCtx.lastProgramId = this._program.id;
+            this._bindProgram();
+        }
+        
+        textureState.bindCommonTextures (
+            this._program,
+            this._uTexturePerObjectIdPositionsDecodeMatrix, 
+            this._uTexturePerVertexIdCoordinates, 
+            this._uTexturePerObjectIdColorsAndFlags, 
+            this._uTextureCameraMatrices, 
+            this._uTextureModelMatrices, 
+        );
+
+        gl.uniform1i(this._uRenderPass, renderPass);
+
+        const numSectionPlanes = scene._sectionPlanesState.sectionPlanes.length;
+        if (numSectionPlanes > 0) {
+            const sectionPlanes = scene._sectionPlanesState.sectionPlanes;
+            const baseIndex = dataTextureLayer.layerIndex * numSectionPlanes;
+            const renderFlags = model.renderFlags;
+            for (let sectionPlaneIndex = 0; sectionPlaneIndex < numSectionPlanes; sectionPlaneIndex++) {
+                const sectionPlaneUniforms = this._uSectionPlanes[sectionPlaneIndex];
+                if (sectionPlaneUniforms) {
+                    const active = renderFlags.sectionPlanesActivePerLayer[baseIndex + sectionPlaneIndex];
+                    gl.uniform1i(sectionPlaneUniforms.active, active ? 1 : 0);
+                    if (active) {
+                        const sectionPlane = sectionPlanes[sectionPlaneIndex];
+                        if (origin) {
+                            const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a);
+                            gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
+                        } else {
+                            gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);
+                        }
+                        gl.uniform3fv(sectionPlaneUniforms.dir, sectionPlane.dir);
+                    }
+                }
+            }
+        }
+
+        if (state.numEdgeIndices8Bits > 0)
+        {
+            textureState.bindEdgeIndicesTextures(
+                this._program,
+                this._uTexturePerEdgeIdPortionIds, 
+                this._uTexturePerPolygonIdEdgeIndices, 
+                8 // 8 bits edge indices
+            );
+
+            gl.drawArrays(gl.LINES, 0, state.numEdgeIndices8Bits);
+        }
+
+        if (state.numEdgeIndices16Bits > 0)
+        {
+            textureState.bindEdgeIndicesTextures(
+                this._program,
+                this._uTexturePerEdgeIdPortionIds, 
+                this._uTexturePerPolygonIdEdgeIndices, 
+                16 // 16 bits edge indices
+            );
+
+            gl.drawArrays(gl.LINES, 0, state.numEdgeIndices16Bits);
+        }
+
+        if (state.numEdgeIndices32Bits > 0)
+        {
+            textureState.bindEdgeIndicesTextures(
+                this._program,
+                this._uTexturePerEdgeIdPortionIds, 
+                this._uTexturePerPolygonIdEdgeIndices, 
+                32 // 32 bits edge indices
+            );
+
+            gl.drawArrays(gl.LINES, 0, state.numEdgeIndices32Bits);
+        }
+
+        frameCtx.drawElements++;
+    }
+
+    _allocate() {
+
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+
+        this._program = new Program(gl, this._buildShader());
+
+        if (this._program.errors) {
+            this.errors = this._program.errors;
+            return;
+        }
+
+        const program = this._program;
+
+        this._uRenderPass = program.getLocation("renderPass");
+        
+        this._uSectionPlanes = [];
+
+        for (let i = 0, len = scene._sectionPlanesState.sectionPlanes.length; i < len; i++) {
+            this._uSectionPlanes.push({
+                active: program.getLocation("sectionPlaneActive" + i),
+                pos: program.getLocation("sectionPlanePos" + i),
+                dir: program.getLocation("sectionPlaneDir" + i)
+            });
+        }
+
+        //this._aOffset = program.getAttribute("offset");
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            this._uLogDepthBufFC = program.getLocation("logDepthBufFC");
+        }
+
+        this._uTexturePerObjectIdPositionsDecodeMatrix = "uTexturePerObjectIdPositionsDecodeMatrix"; // chipmunk
+        this._uTexturePerObjectIdColorsAndFlags = "uTexturePerObjectIdColorsAndFlags"; // chipmunk
+        this._uTexturePerVertexIdCoordinates = "uTexturePerVertexIdCoordinates"; // chipmunk
+        this._uTexturePerPolygonIdEdgeIndices = "uTexturePerPolygonIdEdgeIndices"; // chipmunk
+        this._uTexturePerEdgeIdPortionIds = "uTexturePerEdgeIdPortionIds"; // chipmunk
+        this._uTextureCameraMatrices = "uTextureCameraMatrices"; // chipmunk
+        this._uTextureModelMatrices = "uTextureModelMatrices"; // chipmunk
+    }
+
+    _bindProgram() {
+
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+        const program = this._program;
+        const project = scene.camera.project;
+
+        program.bind();
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            const logDepthBufFC = 2.0 / (Math.log(project.far + 1.0) / Math.LN2);
+            gl.uniform1f(this._uLogDepthBufFC, logDepthBufFC);
+        }
+    }
+
+    _buildShader() {
+        return {
+            vertex: this._buildVertexShader(),
+            fragment: this._buildFragmentShader()
+        };
+    }
+
+    _buildVertexShader() {
+        const scene = this._scene;
+        const sectionPlanesState = scene._sectionPlanesState;
+        const clipping = sectionPlanesState.sectionPlanes.length > 0;
+        const src = [];
+        src.push("#version 300 es");
+        src.push("// Batched geometry edges drawing vertex shader");
+
+        src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
+        src.push("precision highp float;");
+        src.push("precision highp int;");
+        src.push("precision highp usampler2D;");
+        src.push("precision highp isampler2D;");
+        src.push("precision highp sampler2D;");
+        src.push("#else");
+        src.push("precision mediump float;");
+        src.push("precision mediump int;");
+        src.push("precision mediump usampler2D;");
+        src.push("precision mediump isampler2D;");
+        src.push("precision mediump sampler2D;");
+        src.push("#endif");
+
+        src.push("uniform int renderPass;");
+
+        if (scene.entityOffsetsEnabled) {
+            src.push("in vec3 offset;");
+        }
+
+        src.push("uniform mediump sampler2D uTexturePerObjectIdPositionsDecodeMatrix;"); // chipmunk
+        src.push("uniform lowp usampler2D uTexturePerObjectIdColorsAndFlags;"); // chipmunk
+        src.push("uniform mediump usampler2D uTexturePerVertexIdCoordinates;"); // chipmunk
+        src.push("uniform highp usampler2D uTexturePerPolygonIdEdgeIndices;"); // chipmunk
+        src.push("uniform mediump usampler2D uTexturePerEdgeIdPortionIds;"); // chipmunk
+        src.push("uniform highp sampler2D uTextureCameraMatrices;"); // chipmunk
+        src.push("uniform highp sampler2D uTextureModelMatrices;"); // chipmunk
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("uniform float logDepthBufFC;");
+            src.push("out float vFragDepth;");
+            src.push("bool isPerspectiveMatrix(mat4 m) {");
+            src.push("    return (m[2][3] == - 1.0);");
+            src.push("}");
+            src.push("out float isPerspective;");
+        }
+
+        if (clipping) {
+            src.push("out vec4 vWorldPosition;");
+            src.push("out int vFlags2;");
+        }
+        src.push("out vec4 vColor;");
+
+        src.push("void main(void) {");
+
+        // camera matrices
+        src.push ("mat4 viewMatrix = mat4 (texelFetch (uTextureCameraMatrices, ivec2(0, 0), 0), texelFetch (uTextureCameraMatrices, ivec2(1, 0), 0), texelFetch (uTextureCameraMatrices, ivec2(2, 0), 0), texelFetch (uTextureCameraMatrices, ivec2(3, 0), 0));");
+        src.push ("mat4 projMatrix = mat4 (texelFetch (uTextureCameraMatrices, ivec2(0, 2), 0), texelFetch (uTextureCameraMatrices, ivec2(1, 2), 0), texelFetch (uTextureCameraMatrices, ivec2(2, 2), 0), texelFetch (uTextureCameraMatrices, ivec2(3, 2), 0));");
+
+        // model matrices
+        src.push ("mat4 worldMatrix = mat4 (texelFetch (uTextureModelMatrices, ivec2(0, 0), 0), texelFetch (uTextureModelMatrices, ivec2(1, 0), 0), texelFetch (uTextureModelMatrices, ivec2(2, 0), 0), texelFetch (uTextureModelMatrices, ivec2(3, 0), 0));");
+        
+        // constants
+        src.push("int edgeIndex = gl_VertexID / 2;")
+
+        // get packed object-id
+        src.push("int h_packed_object_id_index = (edgeIndex >> 3) & 1023;")
+        src.push("int v_packed_object_id_index = (edgeIndex >> 3) >> 10;")
+
+        src.push("int objectIndex = int(texelFetch(uTexturePerEdgeIdPortionIds, ivec2(h_packed_object_id_index, v_packed_object_id_index), 0).r);");
+
+        // get flags & flags2
+        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(2, objectIndex), 0);"); // chipmunk
+        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(3, objectIndex), 0);"); // chipmunk
+        
+        // flags.z = NOT_RENDERED | EDGES_COLOR_OPAQUE | EDGES_COLOR_TRANSPARENT | EDGES_HIGHLIGHTED | EDGES_XRAYED | EDGES_SELECTED
+        // renderPass = EDGES_COLOR_OPAQUE | EDGES_COLOR_TRANSPARENT
+        
+        src.push(`if (int(flags.z) != renderPass) {`);
+        src.push("   gl_Position = vec4(3.0, 3.0, 3.0, 1.0);"); // Cull vertex
+        src.push("   return;"); // Cull vertex
+        src.push("} else {");
+
+        // get vertex base
+        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(4, objectIndex), 0));");
+
+        src.push("ivec4 packedEdgeIndexBaseOffset = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(6, objectIndex), 0));");
+
+        src.push("int edgeIndexBaseOffset = (packedEdgeIndexBaseOffset.r << 24) + (packedEdgeIndexBaseOffset.g << 16) + (packedEdgeIndexBaseOffset.b << 8) + packedEdgeIndexBaseOffset.a;");
+
+        src.push("int h_index = (edgeIndex - edgeIndexBaseOffset) & 1023;")
+        src.push("int v_index = (edgeIndex - edgeIndexBaseOffset) >> 10;")
+
+        src.push("ivec3 vertexIndices = ivec3(texelFetch(uTexturePerPolygonIdEdgeIndices, ivec2(h_index, v_index), 0));");
+        src.push("ivec3 uniqueVertexIndexes = vertexIndices + (packedVertexBase.r << 24) + (packedVertexBase.g << 16) + (packedVertexBase.b << 8) + packedVertexBase.a;")
+        
+        src.push("int indexPositionH = uniqueVertexIndexes[gl_VertexID % 2] & 1023;")
+        src.push("int indexPositionV = uniqueVertexIndexes[gl_VertexID % 2] >> 10;")
+
+        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(0, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(1, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(2, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(3, objectIndex), 0));")
+        src.push("mat4 entityMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(4, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(5, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(6, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(7, objectIndex), 0));")
+
+        src.push("positionsDecodeMatrix = entityMatrix * positionsDecodeMatrix;")
+
+        // get flags & flags2
+        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(2, objectIndex), 0);"); // chipmunk
+        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(3, objectIndex), 0);"); // chipmunk
+        
+        // get position
+        src.push("vec3 position = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH, indexPositionV), 0));")
+
+        // get color
+        src.push("uvec4 color = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(0, objectIndex), 0);"); // chipmunk
+
+        src.push("      vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
+        if (scene.entityOffsetsEnabled) {
+            src.push("      worldPosition.xyz = worldPosition.xyz + offset;");
+        }
+        src.push("      vec4 viewPosition  = viewMatrix * worldPosition; ");
+
+        if (clipping) {
+            src.push("  vWorldPosition = worldPosition;");
+            src.push("  vFlags2 = flags2;");
+        }
+
+        src.push("vec4 clipPos = projMatrix * viewPosition;");
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("vFragDepth = 1.0 + clipPos.w;");
+            src.push("isPerspective = float (isPerspectiveMatrix(projMatrix));");
+        }
+        src.push("gl_Position = clipPos;");
+        src.push("vec4 rgb = vec4(color.rgba);");
+        //src.push("vColor = vec4(float(color.r-100.0) / 255.0, float(color.g-100.0) / 255.0, float(color.b-100.0) / 255.0, float(color.a) / 255.0);");
+        src.push("vColor = vec4(float(rgb.r*0.5) / 255.0, float(rgb.g*0.5) / 255.0, float(rgb.b*0.5) / 255.0, float(rgb.a) / 255.0);");
+        src.push("}");
+        src.push("}");
+        return src;
+    }
+
+    _buildFragmentShader() {
+        const scene = this._scene;
+        const sectionPlanesState = scene._sectionPlanesState;
+        const clipping = sectionPlanesState.sectionPlanes.length > 0;
+        const src = [];
+        src.push ('#version 300 es');
+        src.push("// Batched geometry edges drawing fragment shader");
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("#extension GL_EXT_frag_depth : enable");
+        }
+        src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
+        src.push("precision highp float;");
+        src.push("precision highp int;");
+        src.push("#else");
+        src.push("precision mediump float;");
+        src.push("precision mediump int;");
+        src.push("#endif");
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("in float isPerspective;");
+            src.push("uniform float logDepthBufFC;");
+            src.push("in float vFragDepth;");
+        }
+        if (clipping) {
+            src.push("in vec4 vWorldPosition;");
+            src.push("in int vFlags2;");
+            for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
+                src.push("uniform bool sectionPlaneActive" + i + ";");
+                src.push("uniform vec3 sectionPlanePos" + i + ";");
+                src.push("uniform vec3 sectionPlaneDir" + i + ";");
+            }
+        }
+        src.push("in vec4 vColor;");
+        src.push("out vec4 outColor;");
+        src.push("void main(void) {");
+        if (clipping) {
+            src.push("  bool clippable = vFlags2 > 0;");
+            src.push("  if (clippable) {");
+            src.push("  float dist = 0.0;");
+            for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
+                src.push("if (sectionPlaneActive" + i + ") {");
+                src.push("   dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
+                src.push("}");
+            }
+            src.push("  if (dist > 0.0) { discard; }");
+            src.push("}");
+        }
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("    gl_FragDepth = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;");
+        }
+        src.push("   outColor            = vColor;");
+        src.push("}");
+        return src;
+    }
+
+    webglContextRestored() {
+        this._program = null;
+    }
+
+    destroy() {
+        if (this._program) {
+            this._program.destroy();
+        }
+        this._program = null;
+    }
+}
+
+export {TrianglesDataTextureEdgesColorRenderer};

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
@@ -51,7 +51,8 @@ class TrianglesDataTextureEdgesColorRenderer {
             this._uTexturePerVertexIdCoordinates, 
             this._uTexturePerObjectIdColorsAndFlags, 
             this._uTextureCameraMatrices, 
-            this._uTextureModelMatrices, 
+            this._uTextureModelMatrices,
+            this._uTexturePerObjectIdOffsets
         );
 
         gl.uniform1i(this._uRenderPass, renderPass);
@@ -158,6 +159,7 @@ class TrianglesDataTextureEdgesColorRenderer {
         this._uTexturePerEdgeIdPortionIds = "uTexturePerEdgeIdPortionIds"; // chipmunk
         this._uTextureCameraMatrices = "uTextureCameraMatrices"; // chipmunk
         this._uTextureModelMatrices = "uTextureModelMatrices"; // chipmunk
+        this._uTexturePerObjectIdOffsets = "uTexturePerObjectIdOffsets"; // chipmunk
     }
 
     _bindProgram() {
@@ -212,11 +214,13 @@ class TrianglesDataTextureEdgesColorRenderer {
 
         src.push("uniform mediump sampler2D uTexturePerObjectIdPositionsDecodeMatrix;"); // chipmunk
         src.push("uniform lowp usampler2D uTexturePerObjectIdColorsAndFlags;"); // chipmunk
+        src.push("uniform highp sampler2D uTexturePerObjectIdOffsets;"); // chipmunk
         src.push("uniform mediump usampler2D uTexturePerVertexIdCoordinates;"); // chipmunk
         src.push("uniform highp usampler2D uTexturePerPolygonIdEdgeIndices;"); // chipmunk
         src.push("uniform mediump usampler2D uTexturePerEdgeIdPortionIds;"); // chipmunk
         src.push("uniform highp sampler2D uTextureCameraMatrices;"); // chipmunk
         src.push("uniform highp sampler2D uTextureModelMatrices;"); // chipmunk
+
 
         if (scene.logarithmicDepthBufferEnabled) {
             src.push("uniform float logDepthBufFC;");
@@ -295,9 +299,12 @@ class TrianglesDataTextureEdgesColorRenderer {
         src.push("uvec4 color = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(0, objectIndex), 0);"); // chipmunk
 
         src.push("      vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
-        if (scene.entityOffsetsEnabled) {
-            src.push("      worldPosition.xyz = worldPosition.xyz + offset;");
-        }
+
+        // get XYZ offset
+        src.push("vec3 offset = texelFetch (uTexturePerObjectIdOffsets, ivec2(0, objectIndex), 0).rgb;");
+
+        src.push("worldPosition.xyz = worldPosition.xyz + offset;");
+
         src.push("      vec4 viewPosition  = viewMatrix * worldPosition; ");
 
         if (clipping) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
@@ -1,7 +1,6 @@
-import {Program} from "../../../../../webgl/Program.js";
-import {createRTCViewMat, getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
-import {math} from "../../../../../math/math.js";
-import {WEBGL_INFO} from "../../../../../webglInfo.js";
+import {Program} from "../../../../../../webgl/Program.js";
+import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
+import {math} from "../../../../../../math/math.js";
 
 const tempVec3a = math.vec3();
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
@@ -212,7 +212,7 @@ class TrianglesDataTextureEdgesColorRenderer {
             src.push("in vec3 offset;");
         }
 
-        src.push("uniform mediump sampler2D uTexturePerObjectIdPositionsDecodeMatrix;"); // chipmunk
+        src.push("uniform highp sampler2D uTexturePerObjectIdPositionsDecodeMatrix;"); // chipmunk
         src.push("uniform lowp usampler2D uTexturePerObjectIdColorsAndFlags;"); // chipmunk
         src.push("uniform highp sampler2D uTexturePerObjectIdOffsets;"); // chipmunk
         src.push("uniform mediump usampler2D uTexturePerVertexIdCoordinates;"); // chipmunk

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
@@ -298,6 +298,11 @@ class TrianglesDataTextureEdgesColorRenderer {
         // get color
         src.push("uvec4 color = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(0, objectIndex), 0);"); // chipmunk
 
+        src.push(`if (color.a == 0u) {`);
+        src.push("   gl_Position = vec4(3.0, 3.0, 3.0, 1.0);"); // Cull vertex
+        src.push("   return;");
+        src.push("};");
+
         src.push("      vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
 
         // get XYZ offset

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
@@ -256,8 +256,8 @@ class TrianglesDataTextureEdgesColorRenderer {
         src.push("ivec2 objectIndexCoords = ivec2(objectIndex % 512, objectIndex / 512);");
 
         // get flags & flags2
-        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+2, objectIndexCoords.y), 0);"); // chipmunk
-        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+3, objectIndexCoords.y), 0);"); // chipmunk
+        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+2, objectIndexCoords.y), 0);"); // chipmunk
+        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+3, objectIndexCoords.y), 0);"); // chipmunk
         
         // flags.z = NOT_RENDERED | EDGES_COLOR_OPAQUE | EDGES_COLOR_TRANSPARENT | EDGES_HIGHLIGHTED | EDGES_XRAYED | EDGES_SELECTED
         // renderPass = EDGES_COLOR_OPAQUE | EDGES_COLOR_TRANSPARENT
@@ -268,9 +268,9 @@ class TrianglesDataTextureEdgesColorRenderer {
         src.push("} else {");
 
         // get vertex base
-        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+4, objectIndexCoords.y), 0));"); // chipmunk
+        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+4, objectIndexCoords.y), 0));"); // chipmunk
 
-        src.push("ivec4 packedEdgeIndexBaseOffset = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+6, objectIndexCoords.y), 0));");
+        src.push("ivec4 packedEdgeIndexBaseOffset = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+6, objectIndexCoords.y), 0));");
 
         src.push("int edgeIndexBaseOffset = (packedEdgeIndexBaseOffset.r << 24) + (packedEdgeIndexBaseOffset.g << 16) + (packedEdgeIndexBaseOffset.b << 8) + packedEdgeIndexBaseOffset.a;");
 
@@ -289,14 +289,14 @@ class TrianglesDataTextureEdgesColorRenderer {
         src.push("positionsDecodeMatrix = entityMatrix * positionsDecodeMatrix;")
 
         // get flags & flags2
-        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+2, objectIndexCoords.y), 0);"); // chipmunk
-        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+3, objectIndexCoords.y), 0);"); // chipmunk
+        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+2, objectIndexCoords.y), 0);"); // chipmunk
+        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+3, objectIndexCoords.y), 0);"); // chipmunk
         
         // get position
         src.push("vec3 position = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH, indexPositionV), 0));")
 
         // get color
-        src.push("uvec4 color = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+0, objectIndexCoords.y), 0);"); // chipmunk
+        src.push("uvec4 color = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+0, objectIndexCoords.y), 0);"); // chipmunk
 
         src.push(`if (color.a == 0u) {`);
         src.push("   gl_Position = vec4(3.0, 3.0, 3.0, 1.0);"); // Cull vertex

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
@@ -306,9 +306,9 @@ class TrianglesDataTextureEdgesColorRenderer {
         src.push("      vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
 
         // get XYZ offset
-        src.push("vec3 offset = texelFetch (uTexturePerObjectIdOffsets, ivec2(0, objectIndex), 0).rgb;");
+        src.push("vec4 offset = vec4(texelFetch (uTexturePerObjectIdOffsets, objectIndexCoords, 0).rgb, 0.0);");
 
-        src.push("worldPosition.xyz = worldPosition.xyz + offset;");
+        src.push("worldPosition.xyz = worldPosition.xyz + offset.xyz;");
 
         src.push("      vec4 viewPosition  = viewMatrix * worldPosition; ");
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
@@ -239,7 +239,7 @@ class TrianglesDataTextureEdgesColorRenderer {
 
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out int vFlags2;");
+            src.push("flat out uint vFlags2;");
         }
         src.push("out vec4 vColor;");
 
@@ -321,7 +321,7 @@ class TrianglesDataTextureEdgesColorRenderer {
 
         if (clipping) {
             src.push("  vWorldPosition = worldPosition;");
-            src.push("  vFlags2 = flags2;");
+            src.push("  vFlags2 = flags2.r;");
         }
 
         src.push("vec4 clipPos = projMatrix * viewPosition;");
@@ -362,7 +362,7 @@ class TrianglesDataTextureEdgesColorRenderer {
         }
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in int vFlags2;");
+            src.push("flat in uint vFlags2;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -373,7 +373,7 @@ class TrianglesDataTextureEdgesColorRenderer {
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
-            src.push("  bool clippable = vFlags2 > 0;");
+            src.push("  bool clippable = vFlags2 > 0u;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
@@ -249,8 +249,8 @@ class TrianglesDataTextureEdgesColorRenderer {
         src.push("int edgeIndex = gl_VertexID / 2;")
 
         // get packed object-id
-        src.push("int h_packed_object_id_index = (edgeIndex >> 3) & 1023;")
-        src.push("int v_packed_object_id_index = (edgeIndex >> 3) >> 10;")
+        src.push("int h_packed_object_id_index = (edgeIndex >> 3) & 4095;")
+        src.push("int v_packed_object_id_index = (edgeIndex >> 3) >> 12;")
 
         src.push("int objectIndex = int(texelFetch(uTexturePerEdgeIdPortionIds, ivec2(h_packed_object_id_index, v_packed_object_id_index), 0).r);");
 
@@ -273,14 +273,14 @@ class TrianglesDataTextureEdgesColorRenderer {
 
         src.push("int edgeIndexBaseOffset = (packedEdgeIndexBaseOffset.r << 24) + (packedEdgeIndexBaseOffset.g << 16) + (packedEdgeIndexBaseOffset.b << 8) + packedEdgeIndexBaseOffset.a;");
 
-        src.push("int h_index = (edgeIndex - edgeIndexBaseOffset) & 1023;")
-        src.push("int v_index = (edgeIndex - edgeIndexBaseOffset) >> 10;")
+        src.push("int h_index = (edgeIndex - edgeIndexBaseOffset) & 4095;")
+        src.push("int v_index = (edgeIndex - edgeIndexBaseOffset) >> 12;")
 
         src.push("ivec3 vertexIndices = ivec3(texelFetch(uTexturePerPolygonIdEdgeIndices, ivec2(h_index, v_index), 0));");
         src.push("ivec3 uniqueVertexIndexes = vertexIndices + (packedVertexBase.r << 24) + (packedVertexBase.g << 16) + (packedVertexBase.b << 8) + packedVertexBase.a;")
         
-        src.push("int indexPositionH = uniqueVertexIndexes[gl_VertexID % 2] & 1023;")
-        src.push("int indexPositionV = uniqueVertexIndexes[gl_VertexID % 2] >> 10;")
+        src.push("int indexPositionH = uniqueVertexIndexes[gl_VertexID % 2] & 4095;")
+        src.push("int indexPositionV = uniqueVertexIndexes[gl_VertexID % 2] >> 12;")
 
         src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(0, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(1, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(2, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(3, objectIndex), 0));")
         src.push("mat4 entityMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(4, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(5, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(6, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(7, objectIndex), 0));")

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
@@ -283,8 +283,8 @@ class TrianglesDataTextureEdgesColorRenderer {
         src.push("int indexPositionH = uniqueVertexIndexes[gl_VertexID % 2] & 4095;")
         src.push("int indexPositionV = uniqueVertexIndexes[gl_VertexID % 2] >> 12;")
 
-        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(0, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(1, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(2, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(3, objectIndex), 0));")
-        src.push("mat4 entityMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(4, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(5, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(6, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(7, objectIndex), 0));")
+        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+2, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+3, objectIndexCoords.y), 0));")
+        src.push("mat4 entityMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+4, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+5, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+6, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+7, objectIndexCoords.y), 0));")
 
         src.push("positionsDecodeMatrix = entityMatrix * positionsDecodeMatrix;")
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
@@ -253,10 +253,11 @@ class TrianglesDataTextureEdgesColorRenderer {
         src.push("int v_packed_object_id_index = (edgeIndex >> 3) >> 12;")
 
         src.push("int objectIndex = int(texelFetch(uTexturePerEdgeIdPortionIds, ivec2(h_packed_object_id_index, v_packed_object_id_index), 0).r);");
+        src.push("ivec2 objectIndexCoords = ivec2(objectIndex % 512, objectIndex / 512);");
 
         // get flags & flags2
-        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(2, objectIndex), 0);"); // chipmunk
-        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(3, objectIndex), 0);"); // chipmunk
+        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+2, objectIndexCoords.y), 0);"); // chipmunk
+        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+3, objectIndexCoords.y), 0);"); // chipmunk
         
         // flags.z = NOT_RENDERED | EDGES_COLOR_OPAQUE | EDGES_COLOR_TRANSPARENT | EDGES_HIGHLIGHTED | EDGES_XRAYED | EDGES_SELECTED
         // renderPass = EDGES_COLOR_OPAQUE | EDGES_COLOR_TRANSPARENT
@@ -267,9 +268,9 @@ class TrianglesDataTextureEdgesColorRenderer {
         src.push("} else {");
 
         // get vertex base
-        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(4, objectIndex), 0));");
+        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+4, objectIndexCoords.y), 0));"); // chipmunk
 
-        src.push("ivec4 packedEdgeIndexBaseOffset = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(6, objectIndex), 0));");
+        src.push("ivec4 packedEdgeIndexBaseOffset = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+6, objectIndexCoords.y), 0));");
 
         src.push("int edgeIndexBaseOffset = (packedEdgeIndexBaseOffset.r << 24) + (packedEdgeIndexBaseOffset.g << 16) + (packedEdgeIndexBaseOffset.b << 8) + packedEdgeIndexBaseOffset.a;");
 
@@ -288,14 +289,14 @@ class TrianglesDataTextureEdgesColorRenderer {
         src.push("positionsDecodeMatrix = entityMatrix * positionsDecodeMatrix;")
 
         // get flags & flags2
-        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(2, objectIndex), 0);"); // chipmunk
-        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(3, objectIndex), 0);"); // chipmunk
+        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+2, objectIndexCoords.y), 0);"); // chipmunk
+        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+3, objectIndexCoords.y), 0);"); // chipmunk
         
         // get position
         src.push("vec3 position = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH, indexPositionV), 0));")
 
         // get color
-        src.push("uvec4 color = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(0, objectIndex), 0);"); // chipmunk
+        src.push("uvec4 color = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+0, objectIndexCoords.y), 0);"); // chipmunk
 
         src.push(`if (color.a == 0u) {`);
         src.push("   gl_Position = vec4(3.0, 3.0, 3.0, 1.0);"); // Cull vertex

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
@@ -54,6 +54,13 @@ class TrianglesDataTextureEdgesColorRenderer {
             this._uTexturePerObjectIdOffsets
         );
 
+        if (frameCtx.pickViewMatrix) {
+            textureState.bindPickCameraTexture (
+                this._program,
+                this._uTextureCameraMatrices
+            );
+        }
+
         gl.uniform1i(this._uRenderPass, renderPass);
 
         const numSectionPlanes = scene._sectionPlanesState.sectionPlanes.length;

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesRenderer.js
@@ -1,7 +1,7 @@
-import {Program} from "../../../../../webgl/Program.js";
-import {createRTCViewMat, getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
-import {math} from "../../../../../math/math.js";
-import {WEBGL_INFO} from "../../../../../webglInfo.js";
+import {Program} from "../../../../../../webgl/Program.js";
+import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
+import {math} from "../../../../../../math/math.js";
+import {WEBGL_INFO} from "../../../../../../webglInfo.js";
 import {RENDER_PASSES} from "../../../RENDER_PASSES.js";
 
 const tempVec3a = math.vec3();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesRenderer.js
@@ -1,0 +1,313 @@
+import {Program} from "../../../../../webgl/Program.js";
+import {createRTCViewMat, getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
+import {math} from "../../../../../math/math.js";
+import {WEBGL_INFO} from "../../../../../webglInfo.js";
+import {RENDER_PASSES} from "../../../RENDER_PASSES.js";
+
+const tempVec3a = math.vec3();
+const defaultColor = new Float32Array([0,0,0,1]);
+
+/**
+ * @private
+ */
+class TrianglesDataTextureEdgesRenderer {
+
+    constructor(scene) {
+        this._scene = scene;
+        this._hash = this._getHash();
+        this._allocate();
+    }
+
+    getValid() {
+        return this._hash === this._getHash();
+    };
+
+    _getHash() {
+        return this._scene._sectionPlanesState.getHash();
+    }
+
+    drawLayer(frameCtx, dataTextureLayer, renderPass) {
+        const model = dataTextureLayer.model;
+        const scene = model.scene;
+        const camera = scene.camera;
+        const gl = scene.canvas.gl;
+        const state = dataTextureLayer._state;
+        const origin = dataTextureLayer._state.origin;
+
+        if (!this._program) {
+            this._allocate(dataTextureLayer);
+            if (this.errors) {
+                return;
+            }
+        }
+
+        if (frameCtx.lastProgramId !== this._program.id) {
+            frameCtx.lastProgramId = this._program.id;
+            this._bindProgram();
+        }
+
+        gl.uniform1i(this._uRenderPass, renderPass);
+
+        if (renderPass === RENDER_PASSES.EDGES_XRAYED) {
+            const material = scene.xrayMaterial._state;
+            const edgeColor = material.edgeColor;
+            const edgeAlpha = material.edgeAlpha;
+            gl.uniform4f(this._uColor, edgeColor[0], edgeColor[1], edgeColor[2], edgeAlpha);
+
+        } else if (renderPass === RENDER_PASSES.EDGES_HIGHLIGHTED) {
+            const material = scene.highlightMaterial._state;
+            const edgeColor = material.edgeColor;
+            const edgeAlpha = material.edgeAlpha;
+            gl.uniform4f(this._uColor, edgeColor[0], edgeColor[1], edgeColor[2], edgeAlpha);
+
+        } else if (renderPass === RENDER_PASSES.EDGES_SELECTED) {
+            const material = scene.selectedMaterial._state;
+            const edgeColor = material.edgeColor;
+            const edgeAlpha = material.edgeAlpha;
+            gl.uniform4f(this._uColor, edgeColor[0], edgeColor[1], edgeColor[2], edgeAlpha);
+
+        } else {
+            gl.uniform4fv(this._uColor, defaultColor);
+        }
+
+        gl.uniformMatrix4fv(this._uViewMatrix, false, (origin) ? createRTCViewMat(camera.viewMatrix, origin) : camera.viewMatrix);
+        gl.uniformMatrix4fv(this._uWorldMatrix, false, model.worldMatrix);
+
+        const numSectionPlanes = scene._sectionPlanesState.sectionPlanes.length;
+        if (numSectionPlanes > 0) {
+            const sectionPlanes = scene._sectionPlanesState.sectionPlanes;
+            const baseIndex = dataTextureLayer.layerIndex * numSectionPlanes;
+            const renderFlags = model.renderFlags;
+            for (let sectionPlaneIndex = 0; sectionPlaneIndex < numSectionPlanes; sectionPlaneIndex++) {
+                const sectionPlaneUniforms = this._uSectionPlanes[sectionPlaneIndex];
+                if (sectionPlaneUniforms) {
+                    const active = renderFlags.sectionPlanesActivePerLayer[baseIndex + sectionPlaneIndex];
+                    gl.uniform1i(sectionPlaneUniforms.active, active ? 1 : 0);
+                    if (active) {
+                        const sectionPlane = sectionPlanes[sectionPlaneIndex];
+                        if (origin) {
+                            const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a);
+                            gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
+                        } else {
+                            gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);
+                        }
+                        gl.uniform3fv(sectionPlaneUniforms.dir, sectionPlane.dir);
+                    }
+                }
+            }
+        }
+
+        gl.uniformMatrix4fv(this._uPositionsDecodeMatrix, false, dataTextureLayer._state.positionsDecodeMatrix);
+
+        this._aPosition.bindArrayBuffer(state.positionsBuf);
+        if (this._aOffset) {
+            this._aOffset.bindArrayBuffer(state.offsetsBuf);
+        }
+        if (this._aFlags) {
+            this._aFlags.bindArrayBuffer(state.flagsBuf);
+        }
+        if (this._aFlags2) {
+            this._aFlags2.bindArrayBuffer(state.flags2Buf);
+        }
+        state.edgeIndicesBuf.bind();
+
+        gl.drawElements(gl.LINES, state.edgeIndicesBuf.numItems, state.edgeIndicesBuf.itemType, 0);
+    }
+
+    _allocate() {
+
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+
+        this._program = new Program(gl, this._buildShader());
+
+        if (this._program.errors) {
+            this.errors = this._program.errors;
+            return;
+        }
+
+        const program = this._program;
+
+        this._uRenderPass = program.getLocation("renderPass");
+        this._uColor = program.getLocation("color");
+        this._uPositionsDecodeMatrix = program.getLocation("positionsDecodeMatrix");
+        this._uViewMatrix = program.getLocation("viewMatrix");
+        this._uWorldMatrix = program.getLocation("worldMatrix");
+        this._uProjMatrix = program.getLocation("projMatrix");
+        this._uSectionPlanes = [];
+
+        for (let i = 0, len = scene._sectionPlanesState.sectionPlanes.length; i < len; i++) {
+            this._uSectionPlanes.push({
+                active: program.getLocation("sectionPlaneActive" + i),
+                pos: program.getLocation("sectionPlanePos" + i),
+                dir: program.getLocation("sectionPlaneDir" + i)
+            });
+        }
+
+        this._aPosition = program.getAttribute("position");
+        this._aOffset = program.getAttribute("offset");
+        this._aFlags = program.getAttribute("flags");
+        this._aFlags2 = program.getAttribute("flags2");
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            this._uLogDepthBufFC = program.getLocation("logDepthBufFC");
+        }
+    }
+
+    _bindProgram() {
+
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+        const program = this._program;
+        const project = scene.camera.project;
+
+        program.bind();
+
+        gl.uniformMatrix4fv(this._uProjMatrix, false, project.matrix);
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            const logDepthBufFC = 2.0 / (Math.log(project.far + 1.0) / Math.LN2);
+            gl.uniform1f(this._uLogDepthBufFC, logDepthBufFC);
+        }
+    }
+
+    _buildShader() {
+        return {
+            vertex: this._buildVertexShader(),
+            fragment: this._buildFragmentShader()
+        };
+    }
+
+    _buildVertexShader() {
+        const scene = this._scene;
+        const sectionPlanesState = scene._sectionPlanesState;
+        const clipping = sectionPlanesState.sectionPlanes.length > 0;
+        const src = [];
+
+        src.push("// Batched geometry edges drawing vertex shader");
+
+        src.push("uniform int renderPass;");
+        src.push("uniform vec4 color;");
+
+        src.push("attribute vec3 position;");
+        if (scene.entityOffsetsEnabled) {
+            src.push("attribute vec3 offset;");
+        }
+        src.push("attribute vec4 flags;");
+        src.push("attribute vec4 flags2;");
+
+        src.push("uniform mat4 worldMatrix;");
+        src.push("uniform mat4 viewMatrix;");
+        src.push("uniform mat4 projMatrix;");
+        src.push("uniform mat4 positionsDecodeMatrix;");
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("uniform float logDepthBufFC;");
+            src.push("out float vFragDepth;");
+            src.push("bool isPerspectiveMatrix(mat4 m) {");
+            src.push("    return (m[2][3] == - 1.0);");
+            src.push("}");
+            src.push("varying float isPerspective;");
+        }
+
+        if (clipping) {
+            src.push("varying vec4 vWorldPosition;");
+            src.push("varying vec4 vFlags2;");
+        }
+
+        src.push("varying vec4 vColor;");
+        src.push("void main(void) {");
+
+        // flags.z = NOT_RENDERED | EDGES_COLOR_OPAQUE | EDGES_COLOR_TRANSPARENT | EDGES_HIGHLIGHTED | EDGES_XRAYED | EDGES_SELECTED
+        // renderPass = EDGES_COLOR_OPAQUE | EDGES_COLOR_TRANSPARENT | EDGES_HIGHLIGHTED | EDGES_XRAYED | EDGES_SELECTED
+
+        src.push(`if (int(flags.z) != renderPass) {`);
+        src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
+
+        src.push("} else {");
+
+        src.push("      vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
+        if (scene.entityOffsetsEnabled) {
+            src.push("      worldPosition.xyz = worldPosition.xyz + offset;");
+        }
+        src.push("      vec4 viewPosition  = viewMatrix * worldPosition; ");
+
+        if (clipping) {
+            src.push("  vWorldPosition = worldPosition;");
+            src.push("  vFlags2 = flags2;");
+        }
+
+        src.push("vec4 clipPos = projMatrix * viewPosition;");
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("vFragDepth = 1.0 + clipPos.w;");
+            src.push("isPerspective = float (isPerspectiveMatrix(projMatrix));");
+        }
+        src.push("gl_Position = clipPos;");
+        src.push("vColor = vec4(color.r, color.g, color.b, color.a);");
+        src.push("}");
+        src.push("}");
+        return src;
+    }
+
+    _buildFragmentShader() {
+        const scene = this._scene;
+        const sectionPlanesState = scene._sectionPlanesState;
+        const clipping = sectionPlanesState.sectionPlanes.length > 0;
+        const src = [];
+        src.push("// Batched geometry edges drawing fragment shader");
+        src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
+        src.push("precision highp float;");
+        src.push("precision highp int;");
+        src.push("#else");
+        src.push("precision mediump float;");
+        src.push("precision mediump int;");
+        src.push("#endif");
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("in float isPerspective;");
+            src.push("uniform float logDepthBufFC;");
+            src.push("in float vFragDepth;");
+        }
+        if (clipping) {
+            src.push("varying vec4 vWorldPosition;");
+            src.push("varying vec4 vFlags2;");
+            for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
+                src.push("uniform bool sectionPlaneActive" + i + ";");
+                src.push("uniform vec3 sectionPlanePos" + i + ";");
+                src.push("uniform vec3 sectionPlaneDir" + i + ";");
+            }
+        }
+        src.push("varying vec4 vColor;");
+        src.push("void main(void) {");
+        if (clipping) {
+            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  if (clippable) {");
+            src.push("  float dist = 0.0;");
+            for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
+                src.push("if (sectionPlaneActive" + i + ") {");
+                src.push("   dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
+                src.push("}");
+            }
+            src.push("  if (dist > 0.0) { discard; }");
+            src.push("}");
+        }
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("    gl_FragDepth = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;");
+        }
+        src.push("gl_FragColor = vColor;");
+        src.push("}");
+        return src;
+    }
+
+    webglContextRestored() {
+        this._program = null;
+    }
+
+    destroy() {
+        if (this._program) {
+            this._program.destroy();
+        }
+        this._program = null;
+    }
+}
+
+export {TrianglesDataTextureEdgesRenderer};

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesRenderer.js
@@ -32,8 +32,9 @@ class TrianglesDataTextureEdgesRenderer {
         const camera = scene.camera;
         const gl = scene.canvas.gl;
         const state = dataTextureLayer._state;
+        const textureState = state.textureState;
         const origin = dataTextureLayer._state.origin;
-
+        
         if (!this._program) {
             this._allocate(dataTextureLayer);
             if (this.errors) {
@@ -44,6 +45,23 @@ class TrianglesDataTextureEdgesRenderer {
         if (frameCtx.lastProgramId !== this._program.id) {
             frameCtx.lastProgramId = this._program.id;
             this._bindProgram();
+        }
+
+        textureState.bindCommonTextures (
+            this._program,
+            this._uTexturePerObjectIdPositionsDecodeMatrix, 
+            this._uTexturePerVertexIdCoordinates, 
+            this._uTexturePerObjectIdColorsAndFlags, 
+            this._uTextureCameraMatrices, 
+            this._uTextureModelMatrices,
+            this._uTexturePerObjectIdOffsets
+        );
+
+        if (frameCtx.pickViewMatrix) {
+            textureState.bindPickCameraTexture (
+                this._program,
+                this._uTextureCameraMatrices
+            );
         }
 
         gl.uniform1i(this._uRenderPass, renderPass);
@@ -97,21 +115,43 @@ class TrianglesDataTextureEdgesRenderer {
             }
         }
 
-        gl.uniformMatrix4fv(this._uPositionsDecodeMatrix, false, dataTextureLayer._state.positionsDecodeMatrix);
+        if (state.numEdgeIndices8Bits > 0)
+        {
+            textureState.bindEdgeIndicesTextures(
+                this._program,
+                this._uTexturePerEdgeIdPortionIds, 
+                this._uTexturePerPolygonIdEdgeIndices, 
+                8 // 8 bits edge indices
+            );
 
-        this._aPosition.bindArrayBuffer(state.positionsBuf);
-        if (this._aOffset) {
-            this._aOffset.bindArrayBuffer(state.offsetsBuf);
+            gl.drawArrays(gl.LINES, 0, state.numEdgeIndices8Bits);
         }
-        if (this._aFlags) {
-            this._aFlags.bindArrayBuffer(state.flagsBuf);
-        }
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf);
-        }
-        state.edgeIndicesBuf.bind();
 
-        gl.drawElements(gl.LINES, state.edgeIndicesBuf.numItems, state.edgeIndicesBuf.itemType, 0);
+        if (state.numEdgeIndices16Bits > 0)
+        {
+            textureState.bindEdgeIndicesTextures(
+                this._program,
+                this._uTexturePerEdgeIdPortionIds, 
+                this._uTexturePerPolygonIdEdgeIndices, 
+                16 // 16 bits edge indices
+            );
+
+            gl.drawArrays(gl.LINES, 0, state.numEdgeIndices16Bits);
+        }
+
+        if (state.numEdgeIndices32Bits > 0)
+        {
+            textureState.bindEdgeIndicesTextures(
+                this._program,
+                this._uTexturePerEdgeIdPortionIds, 
+                this._uTexturePerPolygonIdEdgeIndices, 
+                32 // 32 bits edge indices
+            );
+
+            gl.drawArrays(gl.LINES, 0, state.numEdgeIndices32Bits);
+        }
+
+        frameCtx.drawElements++;
     }
 
     _allocate() {
@@ -130,10 +170,6 @@ class TrianglesDataTextureEdgesRenderer {
 
         this._uRenderPass = program.getLocation("renderPass");
         this._uColor = program.getLocation("color");
-        this._uPositionsDecodeMatrix = program.getLocation("positionsDecodeMatrix");
-        this._uViewMatrix = program.getLocation("viewMatrix");
-        this._uWorldMatrix = program.getLocation("worldMatrix");
-        this._uProjMatrix = program.getLocation("projMatrix");
         this._uSectionPlanes = [];
 
         for (let i = 0, len = scene._sectionPlanesState.sectionPlanes.length; i < len; i++) {
@@ -144,14 +180,20 @@ class TrianglesDataTextureEdgesRenderer {
             });
         }
 
-        this._aPosition = program.getAttribute("position");
-        this._aOffset = program.getAttribute("offset");
-        this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
+        //this._aOffset = program.getAttribute("offset");
 
         if (scene.logarithmicDepthBufferEnabled) {
             this._uLogDepthBufFC = program.getLocation("logDepthBufFC");
         }
+
+        this._uTexturePerObjectIdPositionsDecodeMatrix = "uTexturePerObjectIdPositionsDecodeMatrix"; // chipmunk
+        this._uTexturePerObjectIdColorsAndFlags = "uTexturePerObjectIdColorsAndFlags"; // chipmunk
+        this._uTexturePerVertexIdCoordinates = "uTexturePerVertexIdCoordinates"; // chipmunk
+        this._uTexturePerPolygonIdEdgeIndices = "uTexturePerPolygonIdEdgeIndices"; // chipmunk
+        this._uTexturePerEdgeIdPortionIds = "uTexturePerEdgeIdPortionIds"; // chipmunk
+        this._uTextureCameraMatrices = "uTextureCameraMatrices"; // chipmunk
+        this._uTextureModelMatrices = "uTextureModelMatrices"; // chipmunk
+        this._uTexturePerObjectIdOffsets = "uTexturePerObjectIdOffsets"; // chipmunk
     }
 
     _bindProgram() {
@@ -162,8 +204,6 @@ class TrianglesDataTextureEdgesRenderer {
         const project = scene.camera.project;
 
         program.bind();
-
-        gl.uniformMatrix4fv(this._uProjMatrix, false, project.matrix);
 
         if (scene.logarithmicDepthBufferEnabled) {
             const logDepthBufFC = 2.0 / (Math.log(project.far + 1.0) / Math.LN2);
@@ -183,23 +223,39 @@ class TrianglesDataTextureEdgesRenderer {
         const sectionPlanesState = scene._sectionPlanesState;
         const clipping = sectionPlanesState.sectionPlanes.length > 0;
         const src = [];
-
+        src.push("#version 300 es");
         src.push("// Batched geometry edges drawing vertex shader");
 
+        src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
+        src.push("precision highp float;");
+        src.push("precision highp int;");
+        src.push("precision highp usampler2D;");
+        src.push("precision highp isampler2D;");
+        src.push("precision highp sampler2D;");
+        src.push("#else");
+        src.push("precision mediump float;");
+        src.push("precision mediump int;");
+        src.push("precision mediump usampler2D;");
+        src.push("precision mediump isampler2D;");
+        src.push("precision mediump sampler2D;");
+        src.push("#endif");
+
         src.push("uniform int renderPass;");
-        src.push("uniform vec4 color;");
 
-        src.push("attribute vec3 position;");
         if (scene.entityOffsetsEnabled) {
-            src.push("attribute vec3 offset;");
+            src.push("in vec3 offset;");
         }
-        src.push("attribute vec4 flags;");
-        src.push("attribute vec4 flags2;");
 
-        src.push("uniform mat4 worldMatrix;");
-        src.push("uniform mat4 viewMatrix;");
-        src.push("uniform mat4 projMatrix;");
-        src.push("uniform mat4 positionsDecodeMatrix;");
+        src.push("uniform highp sampler2D uTexturePerObjectIdPositionsDecodeMatrix;"); // chipmunk
+        src.push("uniform lowp usampler2D uTexturePerObjectIdColorsAndFlags;"); // chipmunk
+        src.push("uniform highp sampler2D uTexturePerObjectIdOffsets;"); // chipmunk
+        src.push("uniform mediump usampler2D uTexturePerVertexIdCoordinates;"); // chipmunk
+        src.push("uniform highp usampler2D uTexturePerPolygonIdEdgeIndices;"); // chipmunk
+        src.push("uniform mediump usampler2D uTexturePerEdgeIdPortionIds;"); // chipmunk
+        src.push("uniform highp sampler2D uTextureCameraMatrices;"); // chipmunk
+        src.push("uniform highp sampler2D uTextureModelMatrices;"); // chipmunk
+
+        src.push("uniform vec4 color;");
 
         if (scene.logarithmicDepthBufferEnabled) {
             src.push("uniform float logDepthBufFC;");
@@ -207,34 +263,86 @@ class TrianglesDataTextureEdgesRenderer {
             src.push("bool isPerspectiveMatrix(mat4 m) {");
             src.push("    return (m[2][3] == - 1.0);");
             src.push("}");
-            src.push("varying float isPerspective;");
+            src.push("out float isPerspective;");
         }
 
         if (clipping) {
-            src.push("varying vec4 vWorldPosition;");
-            src.push("varying vec4 vFlags2;");
+            src.push("out vec4 vWorldPosition;");
+            src.push("flat out uint vFlags2;");
         }
+        src.push("out vec4 vColor;");
 
-        src.push("varying vec4 vColor;");
         src.push("void main(void) {");
 
+        // camera matrices
+        src.push ("mat4 viewMatrix = mat4 (texelFetch (uTextureCameraMatrices, ivec2(0, 0), 0), texelFetch (uTextureCameraMatrices, ivec2(1, 0), 0), texelFetch (uTextureCameraMatrices, ivec2(2, 0), 0), texelFetch (uTextureCameraMatrices, ivec2(3, 0), 0));");
+        src.push ("mat4 projMatrix = mat4 (texelFetch (uTextureCameraMatrices, ivec2(0, 2), 0), texelFetch (uTextureCameraMatrices, ivec2(1, 2), 0), texelFetch (uTextureCameraMatrices, ivec2(2, 2), 0), texelFetch (uTextureCameraMatrices, ivec2(3, 2), 0));");
+
+        // model matrices
+        src.push ("mat4 worldMatrix = mat4 (texelFetch (uTextureModelMatrices, ivec2(0, 0), 0), texelFetch (uTextureModelMatrices, ivec2(1, 0), 0), texelFetch (uTextureModelMatrices, ivec2(2, 0), 0), texelFetch (uTextureModelMatrices, ivec2(3, 0), 0));");
+        
+        // constants
+        src.push("int edgeIndex = gl_VertexID / 2;")
+
+        // get packed object-id
+        src.push("int h_packed_object_id_index = (edgeIndex >> 3) & 4095;")
+        src.push("int v_packed_object_id_index = (edgeIndex >> 3) >> 12;")
+
+        src.push("int objectIndex = int(texelFetch(uTexturePerEdgeIdPortionIds, ivec2(h_packed_object_id_index, v_packed_object_id_index), 0).r);");
+        src.push("ivec2 objectIndexCoords = ivec2(objectIndex % 512, objectIndex / 512);");
+
+        // get flags & flags2
+        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+2, objectIndexCoords.y), 0);"); // chipmunk
+        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+3, objectIndexCoords.y), 0);"); // chipmunk
+        
         // flags.z = NOT_RENDERED | EDGES_COLOR_OPAQUE | EDGES_COLOR_TRANSPARENT | EDGES_HIGHLIGHTED | EDGES_XRAYED | EDGES_SELECTED
         // renderPass = EDGES_COLOR_OPAQUE | EDGES_COLOR_TRANSPARENT | EDGES_HIGHLIGHTED | EDGES_XRAYED | EDGES_SELECTED
 
         src.push(`if (int(flags.z) != renderPass) {`);
-        src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
-
+        src.push("   gl_Position = vec4(3.0, 3.0, 3.0, 1.0);"); // Cull vertex
+        src.push("   return;"); // Cull vertex
         src.push("} else {");
 
+        // get vertex base
+        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+4, objectIndexCoords.y), 0));"); // chipmunk
+
+        src.push("ivec4 packedEdgeIndexBaseOffset = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+6, objectIndexCoords.y), 0));");
+
+        src.push("int edgeIndexBaseOffset = (packedEdgeIndexBaseOffset.r << 24) + (packedEdgeIndexBaseOffset.g << 16) + (packedEdgeIndexBaseOffset.b << 8) + packedEdgeIndexBaseOffset.a;");
+
+        src.push("int h_index = (edgeIndex - edgeIndexBaseOffset) & 4095;")
+        src.push("int v_index = (edgeIndex - edgeIndexBaseOffset) >> 12;")
+
+        src.push("ivec3 vertexIndices = ivec3(texelFetch(uTexturePerPolygonIdEdgeIndices, ivec2(h_index, v_index), 0));");
+        src.push("ivec3 uniqueVertexIndexes = vertexIndices + (packedVertexBase.r << 24) + (packedVertexBase.g << 16) + (packedVertexBase.b << 8) + packedVertexBase.a;")
+        
+        src.push("int indexPositionH = uniqueVertexIndexes[gl_VertexID % 2] & 4095;")
+        src.push("int indexPositionV = uniqueVertexIndexes[gl_VertexID % 2] >> 12;")
+
+        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+2, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+3, objectIndexCoords.y), 0));")
+        src.push("mat4 entityMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+4, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+5, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+6, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+7, objectIndexCoords.y), 0));")
+
+        src.push("positionsDecodeMatrix = entityMatrix * positionsDecodeMatrix;")
+
+        // get flags & flags2
+        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+2, objectIndexCoords.y), 0);"); // chipmunk
+        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+3, objectIndexCoords.y), 0);"); // chipmunk
+        
+        // get position
+        src.push("vec3 position = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH, indexPositionV), 0));")
+
         src.push("      vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
-        if (scene.entityOffsetsEnabled) {
-            src.push("      worldPosition.xyz = worldPosition.xyz + offset;");
-        }
+
+        // get XYZ offset
+        src.push("vec4 offset = vec4(texelFetch (uTexturePerObjectIdOffsets, objectIndexCoords, 0).rgb, 0.0);");
+
+        src.push("worldPosition.xyz = worldPosition.xyz + offset.xyz;");
+
         src.push("      vec4 viewPosition  = viewMatrix * worldPosition; ");
 
         if (clipping) {
             src.push("  vWorldPosition = worldPosition;");
-            src.push("  vFlags2 = flags2;");
+            src.push("  vFlags2 = flags2.r;");
         }
 
         src.push("vec4 clipPos = projMatrix * viewPosition;");
@@ -254,7 +362,11 @@ class TrianglesDataTextureEdgesRenderer {
         const sectionPlanesState = scene._sectionPlanesState;
         const clipping = sectionPlanesState.sectionPlanes.length > 0;
         const src = [];
+        src.push ('#version 300 es');
         src.push("// Batched geometry edges drawing fragment shader");
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("#extension GL_EXT_frag_depth : enable");
+        }
         src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
         src.push("precision highp float;");
         src.push("precision highp int;");
@@ -268,18 +380,19 @@ class TrianglesDataTextureEdgesRenderer {
             src.push("in float vFragDepth;");
         }
         if (clipping) {
-            src.push("varying vec4 vWorldPosition;");
-            src.push("varying vec4 vFlags2;");
+            src.push("in vec4 vWorldPosition;");
+            src.push("flat in uint vFlags2;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
                 src.push("uniform vec3 sectionPlaneDir" + i + ";");
             }
         }
-        src.push("varying vec4 vColor;");
+        src.push("in vec4 vColor;");
+        src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = vFlags2 > 0u;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
@@ -293,7 +406,7 @@ class TrianglesDataTextureEdgesRenderer {
         if (scene.logarithmicDepthBufferEnabled) {
             src.push("    gl_FragDepth = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;");
         }
-        src.push("gl_FragColor = vColor;");
+        src.push("   outColor            = vColor;");
         src.push("}");
         return src;
     }

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureNormalsRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureNormalsRenderer.js
@@ -1,0 +1,317 @@
+import {Program} from "../../../../../webgl/Program.js";
+import {createRTCViewMat, getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
+import {math} from "../../../../../math/math.js";
+import {WEBGL_INFO} from "../../../../../webglInfo.js";
+
+const tempVec3a = math.vec3();
+
+/**
+ * @private
+ */
+class TrianglesDataTextureNormalsRenderer {
+
+    constructor(scene) {
+        this._scene = scene;
+        this._hash = this._getHash();
+        this._allocate();
+    }
+
+    getValid() {
+        return this._hash === this._getHash();
+    };
+
+    _getHash() {
+        return this._scene._sectionPlanesState.getHash();
+    }
+
+    drawLayer(frameCtx, dataTextureLayer, renderPass) {
+
+        const model = dataTextureLayer.model;
+        const scene = model.scene;
+        const camera = scene.camera;
+        const gl = scene.canvas.gl;
+        const state = dataTextureLayer._state;
+        const origin = dataTextureLayer._state.origin;
+
+        if (!this._program) {
+            this._allocate(dataTextureLayer);
+            if (this.errors) {
+                return;
+            }
+        }
+
+        if (frameCtx.lastProgramId !== this._program.id) {
+            frameCtx.lastProgramId = this._program.id;
+            this._bindProgram(dataTextureLayer);
+        }
+
+        gl.uniform1i(this._uRenderPass, renderPass);
+
+        gl.uniformMatrix4fv(this._uViewMatrix, false, (origin) ? createRTCViewMat(camera.viewMatrix, origin) : camera.viewMatrix);
+        gl.uniformMatrix4fv(this._uViewNormalMatrix, false, camera.viewNormalMatrix);
+
+        gl.uniformMatrix4fv(this._uWorldMatrix, false, model.worldMatrix);
+        gl.uniformMatrix4fv(this._uWorldNormalMatrix, false, model.worldNormalMatrix);
+
+        const numSectionPlanes = scene._sectionPlanesState.sectionPlanes.length;
+        if (numSectionPlanes > 0) {
+            const sectionPlanes = scene._sectionPlanesState.sectionPlanes;
+            const baseIndex = dataTextureLayer.layerIndex * numSectionPlanes;
+            const renderFlags = model.renderFlags;
+            for (let sectionPlaneIndex = 0; sectionPlaneIndex < numSectionPlanes; sectionPlaneIndex++) {
+                const sectionPlaneUniforms = this._uSectionPlanes[sectionPlaneIndex];
+                if (sectionPlaneUniforms) {
+                    const active = renderFlags.sectionPlanesActivePerLayer[baseIndex + sectionPlaneIndex];
+                    gl.uniform1i(sectionPlaneUniforms.active, active ? 1 : 0);
+                    if (active) {
+                        const sectionPlane = sectionPlanes[sectionPlaneIndex];
+                        if (origin) {
+                            const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a);
+                            gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
+                        } else {
+                            gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);
+                        }
+                        gl.uniform3fv(sectionPlaneUniforms.dir, sectionPlane.dir);
+                    }
+                }
+            }
+        }
+
+        gl.uniformMatrix4fv(this._uPositionsDecodeMatrix, false, dataTextureLayer._state.positionsDecodeMatrix);
+
+        this._aPosition.bindArrayBuffer(state.positionsBuf);
+        this._aOffset.bindArrayBuffer(state.offsetsBuf);
+        this._aNormal.bindArrayBuffer(state.normalsBuf);
+        this._aColor.bindArrayBuffer(state.colorsBuf);// Needed for masking out transparent entities using alpha channel
+        this._aFlags.bindArrayBuffer(state.flagsBuf);
+        if (this._aFlags2) {
+            this._aFlags2.bindArrayBuffer(state.flags2Buf);
+        }
+        state.indicesBuf.bind();
+
+        gl.drawElements(gl.TRIANGLES, state.indicesBuf.numItems, state.indicesBuf.itemType, 0);
+    }
+
+    _allocate() {
+
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+
+        this._program = new Program(gl, this._buildShader());
+
+        if (this._program.errors) {
+            this.errors = this._program.errors;
+            return;
+        }
+
+        const program = this._program;
+
+        this._uRenderPass = program.getLocation("renderPass");
+        this._uPositionsDecodeMatrix = program.getLocation("positionsDecodeMatrix");
+        this._uWorldMatrix = program.getLocation("worldMatrix");
+        this._uWorldNormalMatrix = program.getLocation("worldNormalMatrix");
+        this._uViewMatrix = program.getLocation("viewMatrix");
+        this._uViewNormalMatrix = program.getLocation("viewNormalMatrix");
+        this._uProjMatrix = program.getLocation("projMatrix");
+        this._uSectionPlanes = [];
+
+        for (let i = 0, len = scene._sectionPlanesState.sectionPlanes.length; i < len; i++) {
+            this._uSectionPlanes.push({
+                active: program.getLocation("sectionPlaneActive" + i),
+                pos: program.getLocation("sectionPlanePos" + i),
+                dir: program.getLocation("sectionPlaneDir" + i)
+            });
+        }
+
+        this._aPosition = program.getAttribute("position");
+        this._aOffset = program.getAttribute("offset");
+        this._aNormal = program.getAttribute("normal");
+        this._aColor = program.getAttribute("color");
+        this._aFlags = program.getAttribute("flags");
+
+        if (this._aFlags2) { // Won't be in shader when not clipping
+            this._aFlags2 = program.getAttribute("flags2");
+        }
+
+        if ( scene.logarithmicDepthBufferEnabled) {
+            this._uLogDepthBufFC = program.getLocation("logDepthBufFC");
+        }
+    }
+
+    _bindProgram() {
+
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+        const project = scene.camera.project;
+
+        this._program.bind();
+
+        gl.uniformMatrix4fv(this._uProjMatrix, false, project.matrix);
+
+        if ( scene.logarithmicDepthBufferEnabled) {
+            const logDepthBufFC = 2.0 / (Math.log(project.far + 1.0) / Math.LN2);
+            gl.uniform1f(this._uLogDepthBufFC, logDepthBufFC);
+        }
+    }
+
+    _buildShader() {
+        return {
+            vertex: this._buildVertexShader(),
+            fragment: this._buildFragmentShader()
+        };
+    }
+
+    _buildVertexShader() {
+        const scene = this._scene;
+        const clipping = scene._sectionPlanesState.sectionPlanes.length > 0;
+        const src = [];
+        src.push("// Batched geometry normals vertex shader");
+        if (scene.logarithmicDepthBufferEnabled && WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+            src.push("#extension GL_EXT_frag_depth : enable");
+        }
+        src.push("uniform int renderPass;");
+        src.push("attribute vec3 position;");
+        if (scene.entityOffsetsEnabled) {
+            src.push("attribute vec3 offset;");
+        }
+        src.push("attribute vec3 normal;");
+        src.push("attribute vec4 color;");
+        src.push("attribute vec4 flags;");
+        src.push("attribute vec4 flags2;");
+        src.push("uniform mat4 worldMatrix;");
+        src.push("uniform mat4 worldNormalMatrix;");
+        src.push("uniform mat4 viewMatrix;");
+        src.push("uniform mat4 projMatrix;");
+        src.push("uniform mat4 viewNormalMatrix;");
+        src.push("uniform mat4 positionsDecodeMatrix;");
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("uniform float logDepthBufFC;");
+            if (WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+                src.push("varying float vFragDepth;");
+            }
+            src.push("bool isPerspectiveMatrix(mat4 m) {");
+            src.push("    return (m[2][3] == - 1.0);");
+            src.push("}");
+            src.push("varying float isPerspective;");
+        }
+        src.push("vec3 octDecode(vec2 oct) {");
+        src.push("    vec3 v = vec3(oct.xy, 1.0 - abs(oct.x) - abs(oct.y));");
+        src.push("    if (v.z < 0.0) {");
+        src.push("        v.xy = (1.0 - abs(v.yx)) * vec2(v.x >= 0.0 ? 1.0 : -1.0, v.y >= 0.0 ? 1.0 : -1.0);");
+        src.push("    }");
+        src.push("    return normalize(v);");
+        src.push("}");
+        if (clipping) {
+            src.push("varying vec4 vWorldPosition;");
+            src.push("varying vec4 vFlags2;");
+        }
+        src.push("varying vec3 vViewNormal;");
+        src.push("void main(void) {");
+
+        // flags.x = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
+        // renderPass = COLOR_OPAQUE
+
+        src.push(`if (int(flags.x) != renderPass) {`);
+        src.push("      gl_Position = vec4(0.0, 0.0, 0.0, 0.0);");
+
+        src.push("  } else {");
+        src.push("      vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
+        if (scene.entityOffsetsEnabled) {
+            src.push("      worldPosition.xyz = worldPosition.xyz + offset;");
+        }
+        src.push("      vec4 viewPosition   = viewMatrix * worldPosition; ");
+        src.push("      vec4 worldNormal    = worldNormalMatrix * vec4(octDecode(normal.xy), 0.0); ");
+        src.push("      vec3 viewNormal     = normalize((viewNormalMatrix * worldNormal).xyz);");
+        if (clipping) {
+            src.push("      vWorldPosition  = worldPosition;");
+            src.push("      vFlags2         = flags2;");
+        }
+        src.push("      vViewNormal = viewNormal;");
+        src.push("vec4 clipPos = projMatrix * viewPosition;");
+        if (scene.logarithmicDepthBufferEnabled) {
+            if (WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+                src.push("vFragDepth = 1.0 + clipPos.w;");
+            } else {
+                src.push("clipPos.z = log2( max( 1e-6, clipPos.w + 1.0 ) ) * logDepthBufFC - 1.0;");
+                src.push("clipPos.z *= clipPos.w;");
+            }
+            src.push("isPerspective = float (isPerspectiveMatrix(projMatrix));");
+        }
+        src.push("gl_Position = clipPos;");
+        src.push("  }");
+        src.push("}");
+        return src;
+    }
+
+    _buildFragmentShader() {
+        const scene = this._scene;
+        const sectionPlanesState = scene._sectionPlanesState;
+        const clipping = (sectionPlanesState.sectionPlanes.length > 0);
+        const src = [];
+        src.push("// Batched geometry normals fragment shader");
+
+        if (scene.logarithmicDepthBufferEnabled && WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+            src.push("#extension GL_EXT_frag_depth : enable");
+        }
+
+        src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
+        src.push("precision highp float;");
+        src.push("precision highp int;");
+        src.push("#else");
+        src.push("precision mediump float;");
+        src.push("precision mediump int;");
+        src.push("#endif");
+
+        if (scene.logarithmicDepthBufferEnabled && WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+            src.push("varying float isPerspective;");
+            src.push("uniform float logDepthBufFC;");
+            src.push("varying float vFragDepth;");
+        }
+
+        if (clipping) {
+            src.push("varying vec4 vWorldPosition;");
+            src.push("varying vec4 vFlags2;");
+            for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
+                src.push("uniform bool sectionPlaneActive" + i + ";");
+                src.push("uniform vec3 sectionPlanePos" + i + ";");
+                src.push("uniform vec3 sectionPlaneDir" + i + ";");
+            }
+        }
+        src.push("varying vec3 vViewNormal;");
+        src.push("vec3 packNormalToRGB( const in vec3 normal ) {");
+        src.push("    return normalize( normal ) * 0.5 + 0.5;");
+        src.push("}");
+        src.push("void main(void) {");
+        if (clipping) {
+            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  if (clippable) {");
+            src.push("      float dist = 0.0;");
+            for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
+                src.push("      if (sectionPlaneActive" + i + ") {");
+                src.push("          dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
+                src.push("      }");
+            }
+            src.push("      if (dist > 0.0) { discard; }");
+            src.push("  }");
+        }
+        if (scene.logarithmicDepthBufferEnabled && WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+            src.push("    gl_FragDepthEXT = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;");
+        }
+        src.push("    gl_FragColor = vec4(packNormalToRGB(vViewNormal), 1.0); ");
+        src.push("}");
+        return src;
+    }
+
+    webglContextRestored() {
+        this._program = null;
+    }
+
+    destroy() {
+        if (this._program) {
+            this._program.destroy();
+        }
+        this._program = null;
+    }
+}
+
+export {TrianglesDataTextureNormalsRenderer};

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureNormalsRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureNormalsRenderer.js
@@ -1,7 +1,7 @@
-import {Program} from "../../../../../webgl/Program.js";
-import {createRTCViewMat, getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
-import {math} from "../../../../../math/math.js";
-import {WEBGL_INFO} from "../../../../../webglInfo.js";
+import {Program} from "../../../../../../webgl/Program.js";
+import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
+import {math} from "../../../../../../math/math.js";
+import {WEBGL_INFO} from "../../../../../../webglInfo.js";
 
 const tempVec3a = math.vec3();
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureOcclusionRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureOcclusionRenderer.js
@@ -1,7 +1,7 @@
-import {Program} from "../../../../../webgl/Program.js";
-import {createRTCViewMat, getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
-import {math} from "../../../../../math/math.js";
-import {WEBGL_INFO} from "../../../../../webglInfo.js";
+import {Program} from "../../../../../../webgl/Program.js";
+import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
+import {math} from "../../../../../../math/math.js";
+import {WEBGL_INFO} from "../../../../../../webglInfo.js";
 
 const tempVec3a = math.vec3();
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureOcclusionRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureOcclusionRenderer.js
@@ -1,0 +1,297 @@
+import {Program} from "../../../../../webgl/Program.js";
+import {createRTCViewMat, getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
+import {math} from "../../../../../math/math.js";
+import {WEBGL_INFO} from "../../../../../webglInfo.js";
+
+const tempVec3a = math.vec3();
+
+/**
+ * @private
+ */
+class TrianglesDataTextureOcclusionRenderer {
+
+    constructor(scene) {
+        this._scene = scene;
+        this._hash = this._getHash();
+        this._allocate();
+    }
+
+    getValid() {
+        return this._hash === this._getHash();
+    };
+
+    _getHash() {
+        return this._scene._sectionPlanesState.getHash();
+    }
+
+    drawLayer(frameCtx, dataTextureLayer, renderPass) {
+
+        const model = dataTextureLayer.model;
+        const scene = model.scene;
+        const gl = scene.canvas.gl;
+        const state = dataTextureLayer._state;
+        const camera = scene.camera;
+        const origin = dataTextureLayer._state.origin;
+
+        if (!this._program) {
+            this._allocate(dataTextureLayer);
+            if (this.errors) {
+                return;
+            }
+        }
+
+        if (frameCtx.lastProgramId !== this._program.id) {
+            frameCtx.lastProgramId = this._program.id;
+            this._bindProgram();
+        }
+
+        gl.uniform1i(this._uRenderPass, renderPass);
+
+        gl.uniformMatrix4fv(this._uViewMatrix, false, (origin) ? createRTCViewMat(camera.viewMatrix, origin) : camera.viewMatrix);
+        gl.uniformMatrix4fv(this._uWorldMatrix, false, model.worldMatrix);
+
+        const numSectionPlanes = scene._sectionPlanesState.sectionPlanes.length;
+        if (numSectionPlanes > 0) {
+            const sectionPlanes = scene._sectionPlanesState.sectionPlanes;
+            const baseIndex = dataTextureLayer.layerIndex * numSectionPlanes;
+            const renderFlags = model.renderFlags;
+            for (let sectionPlaneIndex = 0; sectionPlaneIndex < numSectionPlanes; sectionPlaneIndex++) {
+                const sectionPlaneUniforms = this._uSectionPlanes[sectionPlaneIndex];
+                if (sectionPlaneUniforms) {
+                    const active = renderFlags.sectionPlanesActivePerLayer[baseIndex + sectionPlaneIndex];
+                    gl.uniform1i(sectionPlaneUniforms.active, active ? 1 : 0);
+                    if (active) {
+                        const sectionPlane = sectionPlanes[sectionPlaneIndex];
+                        if (origin) {
+                            const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a);
+                            gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
+                        } else {
+                            gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);
+                        }
+                        gl.uniform3fv(sectionPlaneUniforms.dir, sectionPlane.dir);
+                    }
+                }
+            }
+        }
+
+        gl.uniformMatrix4fv(this._uPositionsDecodeMatrix, false, dataTextureLayer._state.positionsDecodeMatrix);
+
+        this._aPosition.bindArrayBuffer(state.positionsBuf);
+
+        if (this._aOffset) {
+            this._aOffset.bindArrayBuffer(state.offsetsBuf);
+        }
+
+        if (this._aColor) {
+            this._aColor.bindArrayBuffer(state.colorsBuf);
+        }
+
+        this._aFlags.bindArrayBuffer(state.flagsBuf);
+
+        if (this._aFlags2) { // Won't be in shader when not clipping
+            this._aFlags2.bindArrayBuffer(state.flags2Buf);
+        }
+
+        state.indicesBuf.bind();
+
+        gl.drawElements(gl.TRIANGLES, state.indicesBuf.numItems, state.indicesBuf.itemType, 0);
+    }
+
+    _allocate() {
+
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+
+        this._program = new Program(gl, this._buildShader());
+
+        if (this._program.errors) {
+            this.errors = this._program.errors;
+            return;
+        }
+
+        const program = this._program;
+
+        this._uRenderPass = program.getLocation("renderPass");
+        this._uPositionsDecodeMatrix = program.getLocation("positionsDecodeMatrix");
+        this._uWorldMatrix = program.getLocation("worldMatrix");
+        this._uViewMatrix = program.getLocation("viewMatrix");
+        this._uProjMatrix = program.getLocation("projMatrix");
+        this._uSectionPlanes = [];
+
+        for (let i = 0, len = scene._sectionPlanesState.sectionPlanes.length; i < len; i++) {
+            this._uSectionPlanes.push({
+                active: program.getLocation("sectionPlaneActive" + i),
+                pos: program.getLocation("sectionPlanePos" + i),
+                dir: program.getLocation("sectionPlaneDir" + i)
+            });
+        }
+
+        this._aPosition = program.getAttribute("position");
+        this._aOffset = program.getAttribute("offset");
+        this._aColor = program.getAttribute("color");
+        this._aFlags = program.getAttribute("flags");
+        this._aFlags2 = program.getAttribute("flags2");
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            this._uLogDepthBufFC = program.getLocation("logDepthBufFC");
+        }
+    }
+
+    _bindProgram() {
+
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+        const project = scene.camera.project;
+
+        this._program.bind();
+
+        gl.uniformMatrix4fv(this._uProjMatrix, false, project.matrix);
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            const logDepthBufFC = 2.0 / (Math.log(project.far + 1.0) / Math.LN2);
+            gl.uniform1f(this._uLogDepthBufFC, logDepthBufFC);
+        }
+    }
+
+    _buildShader() {
+        return {
+            vertex: this._buildVertexShader(),
+            fragment: this._buildFragmentShader()
+        };
+    }
+
+    _buildVertexShader() {
+        const scene = this._scene;
+        const clipping = scene._sectionPlanesState.sectionPlanes.length > 0;
+        const src = [];
+        src.push("// Triangles dataTexture occlusion vertex shader");
+        if (scene.logarithmicDepthBufferEnabled && WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+            src.push("#extension GL_EXT_frag_depth : enable");
+        }
+        src.push("uniform int renderPass;");
+        src.push("attribute vec3 position;");
+        if (scene.entityOffsetsEnabled) {
+            src.push("attribute vec3 offset;");
+        }
+        src.push("attribute vec4 color;");
+        src.push("attribute vec4 flags;");
+        src.push("attribute vec4 flags2;");
+
+        src.push("uniform mat4 worldMatrix;");
+        src.push("uniform mat4 viewMatrix;");
+        src.push("uniform mat4 projMatrix;");
+        src.push("uniform mat4 positionsDecodeMatrix;")
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("uniform float logDepthBufFC;");
+            if (WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+                src.push("varying float vFragDepth;");
+            }
+            src.push("bool isPerspectiveMatrix(mat4 m) {");
+            src.push("    return (m[2][3] == - 1.0);");
+            src.push("}");
+            src.push("varying float isPerspective;");
+        }
+        if (clipping) {
+            src.push("varying vec4 vWorldPosition;");
+            src.push("varying vec4 vFlags2;");
+        }
+        src.push("void main(void) {");
+
+        // flags.x = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
+        // renderPass = COLOR_OPAQUE
+        // Only opaque objects can be occluders
+
+        src.push(`if (int(flags.x) != renderPass) {`);
+        src.push("      gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
+
+        src.push("  } else {");
+        src.push("      vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
+        if (scene.entityOffsetsEnabled) {
+            src.push("      worldPosition.xyz = worldPosition.xyz + offset;");
+        }
+
+        src.push("      vec4 viewPosition  = viewMatrix * worldPosition; ");
+        if (clipping) {
+            src.push("      vWorldPosition = worldPosition;");
+            src.push("      vFlags2 = flags2;");
+        }
+        src.push("vec4 clipPos = projMatrix * viewPosition;");
+        if (scene.logarithmicDepthBufferEnabled) {
+            if (WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+                src.push("vFragDepth = 1.0 + clipPos.w;");
+            } else {
+                src.push("clipPos.z = log2( max( 1e-6, clipPos.w + 1.0 ) ) * logDepthBufFC - 1.0;");
+                src.push("clipPos.z *= clipPos.w;");
+            }
+            src.push("isPerspective = float (isPerspectiveMatrix(projMatrix));");
+        }
+        src.push("gl_Position = clipPos;");
+        src.push("  }");
+        src.push("}");
+        return src;
+    }
+
+    _buildFragmentShader() {
+        const scene = this._scene;
+        const sectionPlanesState = scene._sectionPlanesState;
+        const clipping = sectionPlanesState.sectionPlanes.length > 0;
+        const src = [];
+        src.push("// Triangles dataTexture occlusion fragment shader");
+        if (scene.logarithmicDepthBufferEnabled && WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+            src.push("#extension GL_EXT_frag_depth : enable");
+        }
+        src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
+        src.push("precision highp float;");
+        src.push("precision highp int;");
+        src.push("#else");
+        src.push("precision mediump float;");
+        src.push("precision mediump int;");
+        src.push("#endif");
+        if (scene.logarithmicDepthBufferEnabled && WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+            src.push("varying float isPerspective;");
+            src.push("uniform float logDepthBufFC;");
+            src.push("varying float vFragDepth;");
+        }
+        if (clipping) {
+            src.push("varying vec4 vWorldPosition;");
+            src.push("varying vec4 vFlags2;");
+            for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
+                src.push("uniform bool sectionPlaneActive" + i + ";");
+                src.push("uniform vec3 sectionPlanePos" + i + ";");
+                src.push("uniform vec3 sectionPlaneDir" + i + ";");
+            }
+        }
+        src.push("void main(void) {");
+        if (clipping) {
+            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  if (clippable) {");
+            src.push("      float dist = 0.0;");
+            for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
+                src.push("      if (sectionPlaneActive" + i + ") {");
+                src.push("          dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
+                src.push("      }");
+            }
+            src.push("      if (dist > 0.0) { discard; }");
+            src.push("  }");
+        }
+        if (scene.logarithmicDepthBufferEnabled && WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+            src.push("    gl_FragDepthEXT = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;");
+        }
+        src.push("   gl_FragColor = vec4(0.0, 0.0, 1.0, 1.0); "); // Occluders are blue
+        src.push("}");
+        return src;
+    }
+
+    webglContextRestored() {
+        this._program = null;
+    }
+
+    destroy() {
+        if (this._program) {
+            this._program.destroy();
+        }
+        this._program = null;
+    }
+}
+
+export {TrianglesDataTextureOcclusionRenderer};

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureOcclusionRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureOcclusionRenderer.js
@@ -25,7 +25,7 @@ class TrianglesDataTextureOcclusionRenderer {
     }
 
     drawLayer(frameCtx, dataTextureLayer, renderPass) {
-
+        return; // TODO
         const model = dataTextureLayer.model;
         const scene = model.scene;
         const gl = scene.canvas.gl;

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
@@ -1,7 +1,6 @@
-import {Program} from "../../../../../webgl/Program.js";
-import {createRTCViewMat, getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
-import {math} from "../../../../../math/math.js";
-import {WEBGL_INFO} from "../../../../../webglInfo.js";
+import {Program} from "../../../../../../webgl/Program.js";
+import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
+import {math} from "../../../../../../math/math.js";
 
 const tempVec3a = math.vec3();
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
@@ -214,7 +214,7 @@ class TrianglesDataTexturePickDepthRenderer {
 
         src.push("uniform bool pickInvisible;");
 
-        src.push("uniform mediump sampler2D uTexturePerObjectIdPositionsDecodeMatrix;"); // chipmunk
+        src.push("uniform highp sampler2D uTexturePerObjectIdPositionsDecodeMatrix;"); // chipmunk
         src.push("uniform lowp usampler2D uTexturePerObjectIdColorsAndFlags;"); // chipmunk
         src.push("uniform highp sampler2D uTexturePerObjectIdOffsets;"); // chipmunk
         src.push("uniform mediump usampler2D uTexturePerVertexIdCoordinates;"); // chipmunk

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
@@ -299,6 +299,14 @@ class TrianglesDataTexturePickDepthRenderer {
 
         src.push("vec3 position = positions[gl_VertexID % 3];");
         
+        // get color
+        src.push("uvec4 color = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(0, objectIndex), 0);"); // chipmunk
+
+        src.push(`if (color.a == 0u) {`);
+        src.push("   gl_Position = vec4(3.0, 3.0, 3.0, 1.0);"); // Cull vertex
+        src.push("   return;");
+        src.push("};");
+        
         src.push("vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
 
         // get XYZ offset

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
@@ -48,7 +48,8 @@ class TrianglesDataTexturePickDepthRenderer {
             this._uTexturePerVertexIdCoordinates, 
             this._uTexturePerObjectIdColorsAndFlags, 
             this._uTextureCameraMatrices, 
-            this._uTextureModelMatrices, 
+            this._uTextureModelMatrices,
+            this._uTexturePerObjectIdOffsets
         );
 
         gl.uniform1i(this._uRenderPass, renderPass);
@@ -169,6 +170,7 @@ class TrianglesDataTexturePickDepthRenderer {
         this._uTexturePerPolygonIdPortionIds = "uTexturePerPolygonIdPortionIds"; // chipmunk
         this._uTextureCameraMatrices = "uTextureCameraMatrices"; // chipmunk
         this._uTextureModelMatrices = "uTextureModelMatrices"; // chipmunk
+        this._uTexturePerObjectIdOffsets = "uTexturePerObjectIdOffsets"; // chipmunk
     }
 
     _bindProgram() {
@@ -214,6 +216,7 @@ class TrianglesDataTexturePickDepthRenderer {
 
         src.push("uniform mediump sampler2D uTexturePerObjectIdPositionsDecodeMatrix;"); // chipmunk
         src.push("uniform lowp usampler2D uTexturePerObjectIdColorsAndFlags;"); // chipmunk
+        src.push("uniform highp sampler2D uTexturePerObjectIdOffsets;"); // chipmunk
         src.push("uniform mediump usampler2D uTexturePerVertexIdCoordinates;"); // chipmunk
         src.push("uniform highp usampler2D uTexturePerPolygonIdIndices;"); // chipmunk
         src.push("uniform mediump usampler2D uTexturePerPolygonIdPortionIds;"); // chipmunk
@@ -298,9 +301,11 @@ class TrianglesDataTexturePickDepthRenderer {
         
         src.push("vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
 
-        if (scene.entityOffsetsEnabled) {
-            src.push("worldPosition.xyz = worldPosition.xyz + offset;");
-        }
+        // get XYZ offset
+        src.push("vec3 offset = texelFetch (uTexturePerObjectIdOffsets, ivec2(0, objectIndex), 0).rgb;");
+
+        src.push("worldPosition.xyz = worldPosition.xyz + offset;");
+
 
         src.push("vec4 viewPosition = viewMatrix * worldPosition; ");
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
@@ -1,0 +1,402 @@
+import {Program} from "../../../../../webgl/Program.js";
+import {createRTCViewMat, getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
+import {math} from "../../../../../math/math.js";
+import {WEBGL_INFO} from "../../../../../webglInfo.js";
+
+const tempVec3a = math.vec3();
+
+/**
+ * @private
+ */
+class TrianglesDataTexturePickDepthRenderer {
+
+    constructor(scene) {
+        this._scene = scene;
+        this._hash = this._getHash();
+        this._allocate();
+    }
+
+    getValid() {
+        return this._hash === this._getHash();
+    };
+
+    _getHash() {
+        return this._scene._sectionPlanesState.getHash();
+    }
+
+    drawLayer(frameCtx, dataTextureLayer, renderPass) {
+        const model = dataTextureLayer.model;
+        const scene = model.scene;
+        const camera = scene.camera;
+        const gl = scene.canvas.gl;
+        const state = dataTextureLayer._state;
+        const textureState = state.textureState;
+        const origin = dataTextureLayer._state.origin;
+
+        if (!this._program) {
+            this._allocate();
+        }
+
+        if (frameCtx.lastProgramId !== this._program.id) {
+            frameCtx.lastProgramId = this._program.id;
+            this._bindProgram();
+        }
+        
+        textureState.bindCommonTextures (
+            this._program,
+            this._uTexturePerObjectIdPositionsDecodeMatrix, 
+            this._uTexturePerVertexIdCoordinates, 
+            this._uTexturePerObjectIdColorsAndFlags, 
+            this._uTextureCameraMatrices, 
+            this._uTextureModelMatrices, 
+        );
+
+        gl.uniform1i(this._uRenderPass, renderPass);
+
+        gl.uniform1i(this._uPickInvisible, frameCtx.pickInvisible);
+
+        gl.uniform1f(this._uPickZNear, frameCtx.pickZNear);
+        gl.uniform1f(this._uPickZFar, frameCtx.pickZFar);
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            const logDepthBufFC = 2.0 / (Math.log(frameCtx.pickZFar + 1.0) / Math.LN2); // TODO: Far from pick project matrix?
+            gl.uniform1f(this._uLogDepthBufFC, logDepthBufFC);
+        }
+
+        const numSectionPlanes = scene._sectionPlanesState.sectionPlanes.length;
+        if (numSectionPlanes > 0) {
+            const sectionPlanes = scene._sectionPlanesState.sectionPlanes;
+            const baseIndex = dataTextureLayer.layerIndex * numSectionPlanes;
+            const renderFlags = model.renderFlags;
+            for (let sectionPlaneIndex = 0; sectionPlaneIndex < numSectionPlanes; sectionPlaneIndex++) {
+                const sectionPlaneUniforms = this._uSectionPlanes[sectionPlaneIndex];
+                if (sectionPlaneUniforms) {
+                    const active = renderFlags.sectionPlanesActivePerLayer[baseIndex + sectionPlaneIndex];
+                    gl.uniform1i(sectionPlaneUniforms.active, active ? 1 : 0);
+                    if (active) {
+                        const sectionPlane = sectionPlanes[sectionPlaneIndex];
+                        if (origin) {
+                            const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a);
+                            gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
+                        } else {
+                            gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);
+                        }
+                        gl.uniform3fv(sectionPlaneUniforms.dir, sectionPlane.dir);
+                    }
+                }
+            }
+        }
+
+        if (state.numIndices8Bits > 0)
+        {
+            textureState.bindTriangleIndicesTextures(
+                this._program,
+                this._uTexturePerPolygonIdPortionIds, 
+                this._uTexturePerPolygonIdIndices, 
+                8 // 8 bits indices
+            );
+
+            gl.drawArrays(gl.TRIANGLES, 0, state.numIndices8Bits);
+        }
+
+        if (state.numIndices16Bits > 0)
+        {
+            textureState.bindTriangleIndicesTextures(
+                this._program,
+                this._uTexturePerPolygonIdPortionIds, 
+                this._uTexturePerPolygonIdIndices, 
+                16 // 16 bits indices
+            );
+
+            gl.drawArrays(gl.TRIANGLES, 0, state.numIndices16Bits);
+        }
+        
+        if (state.numIndices32Bits > 0)
+        {
+            textureState.bindTriangleIndicesTextures(
+                this._program,
+                this._uTexturePerPolygonIdPortionIds, 
+                this._uTexturePerPolygonIdIndices, 
+                32 // 32 bits indices
+            );
+
+            gl.drawArrays(gl.TRIANGLES, 0, state.numIndices32Bits);
+        }
+
+        frameCtx.drawElements++;
+    }
+
+    _allocate() {
+
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+
+        this._program = new Program(gl, this._buildShader());
+
+        if (this._program.errors) {
+            this.errors = this._program.errors;
+            return;
+        }
+
+        const program = this._program;
+
+        this._uRenderPass = program.getLocation("renderPass");
+        this._uPickInvisible = program.getLocation("pickInvisible");
+
+        this._uSectionPlanes = [];
+
+        for (let i = 0, len = scene._sectionPlanesState.sectionPlanes.length; i < len; i++) {
+            this._uSectionPlanes.push({
+                active: program.getLocation("sectionPlaneActive" + i),
+                pos: program.getLocation("sectionPlanePos" + i),
+                dir: program.getLocation("sectionPlaneDir" + i)
+            });
+        }
+
+        this._aPackedVertexId = program.getAttribute("packedVertexId");
+        this._uPickZNear = program.getLocation("pickZNear");
+        this._uPickZFar = program.getLocation("pickZFar");
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            this._uLogDepthBufFC = program.getLocation("logDepthBufFC");
+        }
+
+        this._uTexturePerObjectIdPositionsDecodeMatrix = "uTexturePerObjectIdPositionsDecodeMatrix"; // chipmunk
+        this._uTexturePerObjectIdColorsAndFlags = "uTexturePerObjectIdColorsAndFlags"; // chipmunk
+        this._uTexturePerVertexIdCoordinates = "uTexturePerVertexIdCoordinates"; // chipmunk
+        this._uTexturePerPolygonIdNormals = "uTexturePerPolygonIdNormals"; // chipmunk
+        this._uTexturePerPolygonIdIndices = "uTexturePerPolygonIdIndices"; // chipmunk
+        this._uTexturePerPolygonIdPortionIds = "uTexturePerPolygonIdPortionIds"; // chipmunk
+        this._uTextureCameraMatrices = "uTextureCameraMatrices"; // chipmunk
+        this._uTextureModelMatrices = "uTextureModelMatrices"; // chipmunk
+    }
+
+    _bindProgram() {
+        this._program.bind();
+    }
+
+    _buildShader() {
+        return {
+            vertex: this._buildVertexShader(),
+            fragment: this._buildFragmentShader()
+        };
+    }
+
+    _buildVertexShader() {
+
+        const scene = this._scene;
+        const clipping = scene._sectionPlanesState.sectionPlanes.length > 0;
+        const src = [];
+        src.push("#version 300 es");
+        src.push("// Triangles dataTexture pick depth vertex shader");
+
+        src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
+        src.push("precision highp float;");
+        src.push("precision highp int;");
+        src.push("precision highp usampler2D;");
+        src.push("precision highp isampler2D;");
+        src.push("precision highp sampler2D;");
+        src.push("#else");
+        src.push("precision mediump float;");
+        src.push("precision mediump int;");
+        src.push("precision mediump usampler2D;");
+        src.push("precision mediump isampler2D;");
+        src.push("precision mediump sampler2D;");
+        src.push("#endif");
+
+        src.push("uniform int renderPass;");
+
+        if (scene.entityOffsetsEnabled) {
+            src.push("in vec3 offset;");
+        }
+
+        src.push("uniform bool pickInvisible;");
+
+        src.push("uniform mediump sampler2D uTexturePerObjectIdPositionsDecodeMatrix;"); // chipmunk
+        src.push("uniform lowp usampler2D uTexturePerObjectIdColorsAndFlags;"); // chipmunk
+        src.push("uniform mediump usampler2D uTexturePerVertexIdCoordinates;"); // chipmunk
+        src.push("uniform highp usampler2D uTexturePerPolygonIdIndices;"); // chipmunk
+        src.push("uniform mediump usampler2D uTexturePerPolygonIdPortionIds;"); // chipmunk
+        src.push("uniform highp sampler2D uTextureCameraMatrices;"); // chipmunk
+        src.push("uniform highp sampler2D uTextureModelMatrices;"); // chipmunk
+
+        src.push("vec3 positions[3];")
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("uniform float logDepthBufFC;");
+            src.push("out float vFragDepth;");
+            src.push("bool isPerspectiveMatrix(mat4 m) {");
+            src.push("    return (m[2][3] == - 1.0);");
+            src.push("}");
+            src.push("out float isPerspective;");
+        }
+
+        if (clipping) {
+            src.push("out vec4 vWorldPosition;");
+            src.push("out int vFlags2;");
+        }
+        src.push("out vec4 vViewPosition;");
+        src.push("void main(void) {");
+
+        // camera matrices
+        src.push ("mat4 viewMatrix = mat4 (texelFetch (uTextureCameraMatrices, ivec2(0, 0), 0), texelFetch (uTextureCameraMatrices, ivec2(1, 0), 0), texelFetch (uTextureCameraMatrices, ivec2(2, 0), 0), texelFetch (uTextureCameraMatrices, ivec2(3, 0), 0));");
+        src.push ("mat4 viewNormalMatrix = mat4 (texelFetch (uTextureCameraMatrices, ivec2(0, 1), 0), texelFetch (uTextureCameraMatrices, ivec2(1, 1), 0), texelFetch (uTextureCameraMatrices, ivec2(2, 1), 0), texelFetch (uTextureCameraMatrices, ivec2(3, 1), 0));");
+        src.push ("mat4 projMatrix = mat4 (texelFetch (uTextureCameraMatrices, ivec2(0, 2), 0), texelFetch (uTextureCameraMatrices, ivec2(1, 2), 0), texelFetch (uTextureCameraMatrices, ivec2(2, 2), 0), texelFetch (uTextureCameraMatrices, ivec2(3, 2), 0));");
+
+        // model matrices
+        src.push ("mat4 worldMatrix = mat4 (texelFetch (uTextureModelMatrices, ivec2(0, 0), 0), texelFetch (uTextureModelMatrices, ivec2(1, 0), 0), texelFetch (uTextureModelMatrices, ivec2(2, 0), 0), texelFetch (uTextureModelMatrices, ivec2(3, 0), 0));");
+        src.push ("mat4 worldNormalMatrix = mat4 (texelFetch (uTextureModelMatrices, ivec2(0, 1), 0), texelFetch (uTextureModelMatrices, ivec2(1, 1), 0), texelFetch (uTextureModelMatrices, ivec2(2, 1), 0), texelFetch (uTextureModelMatrices, ivec2(3, 1), 0));");
+        
+        // constants
+        src.push("int polygonIndex = gl_VertexID / 3;")
+
+        // get packed object-id
+        src.push("int h_packed_object_id_index = (polygonIndex >> 3) & 1023;")
+        src.push("int v_packed_object_id_index = (polygonIndex >> 3) >> 10;")
+
+        src.push("int objectIndex = int(texelFetch(uTexturePerPolygonIdPortionIds, ivec2(h_packed_object_id_index, v_packed_object_id_index), 0).r);");
+
+        // get flags & flags2
+        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(2, objectIndex), 0);"); // chipmunk
+        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(3, objectIndex), 0);"); // chipmunk
+        
+        // flags.w = NOT_RENDERED | PICK
+        // renderPass = PICK
+
+        src.push(`if (int(flags.w) != renderPass) {`);
+        src.push("   gl_Position = vec4(3.0, 3.0, 3.0, 1.0);"); // Cull vertex
+        src.push("   return;"); // Cull vertex
+        src.push("} else {");
+
+        // get vertex base
+        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(4, objectIndex), 0));");
+
+        src.push("ivec4 packedIndexBaseOffset = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(5, objectIndex), 0));");
+
+        src.push("int indexBaseOffset = (packedIndexBaseOffset.r << 24) + (packedIndexBaseOffset.g << 16) + (packedIndexBaseOffset.b << 8) + packedIndexBaseOffset.a;");
+
+        src.push("int h_index = (polygonIndex - indexBaseOffset) & 1023;")
+        src.push("int v_index = (polygonIndex - indexBaseOffset) >> 10;")
+
+        src.push("ivec3 vertexIndices = ivec3(texelFetch(uTexturePerPolygonIdIndices, ivec2(h_index, v_index), 0));");
+        src.push("ivec3 uniqueVertexIndexes = vertexIndices + (packedVertexBase.r << 24) + (packedVertexBase.g << 16) + (packedVertexBase.b << 8) + packedVertexBase.a;")
+        
+        src.push("ivec3 indexPositionH = uniqueVertexIndexes & 1023;")
+        src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 10;")
+
+        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(0, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(1, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(2, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(3, objectIndex), 0));")
+        src.push("mat4 entityMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(4, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(5, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(6, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(7, objectIndex), 0));")
+
+        src.push("positionsDecodeMatrix = entityMatrix * positionsDecodeMatrix;")
+        
+        // get position
+        src.push("positions[0] = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.r, indexPositionV.r), 0));")
+        src.push("positions[1] = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.g, indexPositionV.g), 0));")
+        src.push("positions[2] = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.b, indexPositionV.b), 0));")
+
+        src.push("vec3 position = positions[gl_VertexID % 3];");
+        
+        src.push("vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
+
+        if (scene.entityOffsetsEnabled) {
+            src.push("worldPosition.xyz = worldPosition.xyz + offset;");
+        }
+
+        src.push("vec4 viewPosition = viewMatrix * worldPosition; ");
+
+        if (clipping) {
+            src.push("      vWorldPosition = worldPosition;");
+            src.push("      vFlags2 = flags2;");
+        }
+        src.push("vViewPosition = viewPosition;");
+        src.push("vec4 clipPos = projMatrix * viewPosition;");
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("vFragDepth = 1.0 + clipPos.w;");
+            src.push("isPerspective = float (isPerspectiveMatrix(projMatrix));");
+        }
+        src.push("gl_Position = clipPos;");
+        src.push("  }");
+        src.push("}");
+        return src;
+    }
+
+    _buildFragmentShader() {
+
+        const scene = this._scene;
+        const sectionPlanesState = scene._sectionPlanesState;
+        const clipping = sectionPlanesState.sectionPlanes.length > 0;
+        const src = [];
+        src.push ('#version 300 es');
+        src.push("// Triangles dataTexture pick depth fragment shader");
+
+        src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
+        src.push("precision highp float;");
+        src.push("precision highp int;");
+        src.push("#else");
+        src.push("precision mediump float;");
+        src.push("precision mediump int;");
+        src.push("#endif");
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("in float isPerspective;");
+            src.push("uniform float logDepthBufFC;");
+            src.push("in float vFragDepth;");
+        }
+
+        src.push("uniform float pickZNear;");
+        src.push("uniform float pickZFar;");
+
+        if (clipping) {
+            src.push("in vec4 vWorldPosition;");
+            src.push("in int vFlags2;");
+            for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
+                src.push("uniform bool sectionPlaneActive" + i + ";");
+                src.push("uniform vec3 sectionPlanePos" + i + ";");
+                src.push("uniform vec3 sectionPlaneDir" + i + ";");
+            }
+        }
+        src.push("in vec4 vViewPosition;");
+        src.push("vec4 packDepth(const in float depth) {");
+        src.push("  const vec4 bitShift = vec4(256.0*256.0*256.0, 256.0*256.0, 256.0, 1.0);");
+        src.push("  const vec4 bitMask  = vec4(0.0, 1.0/256.0, 1.0/256.0, 1.0/256.0);");
+        src.push("  vec4 res = fract(depth * bitShift);");
+        src.push("  res -= res.xxyz * bitMask;");
+        src.push("  return res;");
+        src.push("}");
+        
+        src.push("out vec4 outPackedDepth;");        
+        src.push("void main(void) {");
+        if (clipping) {
+            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  if (clippable) {");
+            src.push("      float dist = 0.0;");
+            for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
+                src.push("      if (sectionPlaneActive" + i + ") {");
+                src.push("          dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
+                src.push("      }");
+            }
+            src.push("      if (dist > 0.0) { discard; }");
+            src.push("  }");
+        }
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("    gl_FragDepth = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;");
+        }
+        src.push("    float zNormalizedDepth = abs((pickZNear + vViewPosition.z) / (pickZFar - pickZNear));");
+        src.push("    outPackedDepth = packDepth(zNormalizedDepth); ");  // Must be linear depth
+        src.push("}");
+        return src;
+    }
+
+    webglContextRestored() {
+        this._program = null;
+    }
+
+    destroy() {
+        if (this._program) {
+            this._program.destroy();
+        }
+        this._program = null;
+    }
+}
+
+export {TrianglesDataTexturePickDepthRenderer};

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
@@ -257,10 +257,11 @@ class TrianglesDataTexturePickDepthRenderer {
         src.push("int v_packed_object_id_index = (polygonIndex >> 3) >> 12;")
 
         src.push("int objectIndex = int(texelFetch(uTexturePerPolygonIdPortionIds, ivec2(h_packed_object_id_index, v_packed_object_id_index), 0).r);");
+        src.push("ivec2 objectIndexCoords = ivec2(objectIndex % 512, objectIndex / 512);");
 
         // get flags & flags2
-        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(2, objectIndex), 0);"); // chipmunk
-        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(3, objectIndex), 0);"); // chipmunk
+        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+2, objectIndexCoords.y), 0);"); // chipmunk
+        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+3, objectIndexCoords.y), 0);"); // chipmunk
         
         // flags.w = NOT_RENDERED | PICK
         // renderPass = PICK
@@ -271,9 +272,9 @@ class TrianglesDataTexturePickDepthRenderer {
         src.push("} else {");
 
         // get vertex base
-        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(4, objectIndex), 0));");
+        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+4, objectIndexCoords.y), 0));"); // chipmunk
 
-        src.push("ivec4 packedIndexBaseOffset = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(5, objectIndex), 0));");
+        src.push("ivec4 packedIndexBaseOffset = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+5, objectIndexCoords.y), 0));"); // chipmunk
 
         src.push("int indexBaseOffset = (packedIndexBaseOffset.r << 24) + (packedIndexBaseOffset.g << 16) + (packedIndexBaseOffset.b << 8) + packedIndexBaseOffset.a;");
 
@@ -299,7 +300,7 @@ class TrianglesDataTexturePickDepthRenderer {
         src.push("vec3 position = positions[gl_VertexID % 3];");
         
         // get color
-        src.push("uvec4 color = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(0, objectIndex), 0);"); // chipmunk
+        src.push("uvec4 color = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+0, objectIndexCoords.y), 0);"); // chipmunk
 
         src.push(`if (color.a == 0u) {`);
         src.push("   gl_Position = vec4(3.0, 3.0, 3.0, 1.0);"); // Cull vertex

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
@@ -53,6 +53,14 @@ class TrianglesDataTexturePickDepthRenderer {
 
         gl.uniform1i(this._uRenderPass, renderPass);
 
+        const originCameraEye = [
+            camera.eye[0] - origin[0],
+            camera.eye[1] - origin[1],
+            camera.eye[2] - origin[2],
+        ];
+
+        gl.uniform3fv(this._uCameraEyeRtc, originCameraEye);
+
         gl.uniform1i(this._uPickInvisible, frameCtx.pickInvisible);
 
         gl.uniform1f(this._uPickZNear, frameCtx.pickZNear);
@@ -170,6 +178,7 @@ class TrianglesDataTexturePickDepthRenderer {
         this._uTextureCameraMatrices = "uTextureCameraMatrices"; // chipmunk
         this._uTextureModelMatrices = "uTextureModelMatrices"; // chipmunk
         this._uTexturePerObjectIdOffsets = "uTexturePerObjectIdOffsets"; // chipmunk
+        this._uCameraEyeRtc = program.getLocation("uCameraEyeRtc"); // chipmunk
     }
 
     _bindProgram() {
@@ -221,6 +230,7 @@ class TrianglesDataTexturePickDepthRenderer {
         src.push("uniform mediump usampler2D uTexturePerPolygonIdPortionIds;"); // chipmunk
         src.push("uniform highp sampler2D uTextureCameraMatrices;"); // chipmunk
         src.push("uniform highp sampler2D uTextureModelMatrices;"); // chipmunk
+        src.push("uniform vec3 uCameraEyeRtc;"); // chipmunk
 
         src.push("vec3 positions[3];")
 
@@ -260,8 +270,8 @@ class TrianglesDataTexturePickDepthRenderer {
         src.push("ivec2 objectIndexCoords = ivec2(objectIndex % 512, objectIndex / 512);");
 
         // get flags & flags2
-        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+2, objectIndexCoords.y), 0);"); // chipmunk
-        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+3, objectIndexCoords.y), 0);"); // chipmunk
+        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+2, objectIndexCoords.y), 0);"); // chipmunk
+        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+3, objectIndexCoords.y), 0);"); // chipmunk
         
         // flags.w = NOT_RENDERED | PICK
         // renderPass = PICK
@@ -272,9 +282,9 @@ class TrianglesDataTexturePickDepthRenderer {
         src.push("} else {");
 
         // get vertex base
-        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+4, objectIndexCoords.y), 0));"); // chipmunk
+        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+4, objectIndexCoords.y), 0));"); // chipmunk
 
-        src.push("ivec4 packedIndexBaseOffset = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+5, objectIndexCoords.y), 0));"); // chipmunk
+        src.push("ivec4 packedIndexBaseOffset = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+5, objectIndexCoords.y), 0));"); // chipmunk
 
         src.push("int indexBaseOffset = (packedIndexBaseOffset.r << 24) + (packedIndexBaseOffset.g << 16) + (packedIndexBaseOffset.b << 8) + packedIndexBaseOffset.a;");
 
@@ -292,20 +302,39 @@ class TrianglesDataTexturePickDepthRenderer {
 
         src.push("positionsDecodeMatrix = entityMatrix * positionsDecodeMatrix;")
         
+        src.push("uint solid = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+7, objectIndexCoords.y), 0).r;"); // chipmunk
+
         // get position
         src.push("positions[0] = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.r, indexPositionV.r), 0));")
         src.push("positions[1] = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.g, indexPositionV.g), 0));")
         src.push("positions[2] = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.b, indexPositionV.b), 0));")
-
-        src.push("vec3 position = positions[gl_VertexID % 3];");
         
         // get color
-        src.push("uvec4 color = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+0, objectIndexCoords.y), 0);"); // chipmunk
+        src.push("uvec4 color = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+0, objectIndexCoords.y), 0);"); // chipmunk
 
         src.push(`if (color.a == 0u) {`);
         src.push("   gl_Position = vec4(3.0, 3.0, 3.0, 1.0);"); // Cull vertex
         src.push("   return;");
         src.push("};");
+
+        // get normal
+
+        // when the geometry is not solid, if needed, flip the triangle winding
+        src.push("vec3 position;");
+
+        src.push("if (solid != 1u) {");
+            src.push("vec3 normal = normalize(cross(positions[2] - positions[0], positions[1] - positions[0]));");
+            src.push("vec3 triangleCenter = (worldMatrix*positionsDecodeMatrix*vec4((positions[0] + positions[1] + positions[2]) / 3.0, 1)).xyz;")
+            src.push("vec3 worldNormal = normalize((transpose(inverse(worldMatrix*positionsDecodeMatrix)) * vec4(normal, 1)).xyz);");
+            src.push("vec3 cameraToTriangleDirection = normalize(triangleCenter - uCameraEyeRtc);")
+            src.push("if (dot(cameraToTriangleDirection, worldNormal) < 0.0) {");
+                src.push("position = positions[2 - (gl_VertexID % 3)];");
+            src.push("} else {");
+                src.push("position = positions[gl_VertexID % 3];");
+            src.push("}");
+        src.push("} else {")
+                src.push("position = positions[gl_VertexID % 3];");
+        src.push("}");
         
         src.push("vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
 
@@ -313,7 +342,6 @@ class TrianglesDataTexturePickDepthRenderer {
         src.push("vec4 offset = vec4(texelFetch (uTexturePerObjectIdOffsets, objectIndexCoords, 0).rgb, 0.0);");
 
         src.push("worldPosition.xyz = worldPosition.xyz + offset.xyz;");
-
 
         src.push("vec4 viewPosition = viewMatrix * worldPosition; ");
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
@@ -253,8 +253,8 @@ class TrianglesDataTexturePickDepthRenderer {
         src.push("int polygonIndex = gl_VertexID / 3;")
 
         // get packed object-id
-        src.push("int h_packed_object_id_index = (polygonIndex >> 3) & 1023;")
-        src.push("int v_packed_object_id_index = (polygonIndex >> 3) >> 10;")
+        src.push("int h_packed_object_id_index = (polygonIndex >> 3) & 4095;")
+        src.push("int v_packed_object_id_index = (polygonIndex >> 3) >> 12;")
 
         src.push("int objectIndex = int(texelFetch(uTexturePerPolygonIdPortionIds, ivec2(h_packed_object_id_index, v_packed_object_id_index), 0).r);");
 
@@ -277,14 +277,14 @@ class TrianglesDataTexturePickDepthRenderer {
 
         src.push("int indexBaseOffset = (packedIndexBaseOffset.r << 24) + (packedIndexBaseOffset.g << 16) + (packedIndexBaseOffset.b << 8) + packedIndexBaseOffset.a;");
 
-        src.push("int h_index = (polygonIndex - indexBaseOffset) & 1023;")
-        src.push("int v_index = (polygonIndex - indexBaseOffset) >> 10;")
+        src.push("int h_index = (polygonIndex - indexBaseOffset) & 4095;")
+        src.push("int v_index = (polygonIndex - indexBaseOffset) >> 12;")
 
         src.push("ivec3 vertexIndices = ivec3(texelFetch(uTexturePerPolygonIdIndices, ivec2(h_index, v_index), 0));");
         src.push("ivec3 uniqueVertexIndexes = vertexIndices + (packedVertexBase.r << 24) + (packedVertexBase.g << 16) + (packedVertexBase.b << 8) + packedVertexBase.a;")
         
-        src.push("ivec3 indexPositionH = uniqueVertexIndexes & 1023;")
-        src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 10;")
+        src.push("ivec3 indexPositionH = uniqueVertexIndexes & 4095;")
+        src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 12;")
 
         src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(0, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(1, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(2, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(3, objectIndex), 0));")
         src.push("mat4 entityMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(4, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(5, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(6, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(7, objectIndex), 0));")

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
@@ -256,7 +256,7 @@ class TrianglesDataTexturePickDepthRenderer {
 
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out int vFlags2;");
+            src.push("flat out uint vFlags2;");
         }
         src.push("out vec4 vViewPosition;");
         src.push("void main(void) {");
@@ -360,7 +360,7 @@ class TrianglesDataTexturePickDepthRenderer {
 
         if (clipping) {
             src.push("      vWorldPosition = worldPosition;");
-            src.push("      vFlags2 = flags2;");
+            src.push("      vFlags2 = flags2.r;");
         }
         src.push("vViewPosition = viewPosition;");
         src.push("vec4 clipPos = projMatrix * viewPosition;");
@@ -402,7 +402,7 @@ class TrianglesDataTexturePickDepthRenderer {
 
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in int vFlags2;");
+            src.push("flat in uint vFlags2;");
             for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -421,7 +421,7 @@ class TrianglesDataTexturePickDepthRenderer {
         src.push("out vec4 outPackedDepth;");        
         src.push("void main(void) {");
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = vFlags2 > 0u;");
             src.push("  if (clippable) {");
             src.push("      float dist = 0.0;");
             for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
@@ -310,9 +310,9 @@ class TrianglesDataTexturePickDepthRenderer {
         src.push("vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
 
         // get XYZ offset
-        src.push("vec3 offset = texelFetch (uTexturePerObjectIdOffsets, ivec2(0, objectIndex), 0).rgb;");
+        src.push("vec4 offset = vec4(texelFetch (uTexturePerObjectIdOffsets, objectIndexCoords, 0).rgb, 0.0);");
 
-        src.push("worldPosition.xyz = worldPosition.xyz + offset;");
+        src.push("worldPosition.xyz = worldPosition.xyz + offset.xyz;");
 
 
         src.push("vec4 viewPosition = viewMatrix * worldPosition; ");

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
@@ -287,8 +287,8 @@ class TrianglesDataTexturePickDepthRenderer {
         src.push("ivec3 indexPositionH = uniqueVertexIndexes & 4095;")
         src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 12;")
 
-        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(0, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(1, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(2, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(3, objectIndex), 0));")
-        src.push("mat4 entityMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(4, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(5, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(6, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(7, objectIndex), 0));")
+        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+2, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+3, objectIndexCoords.y), 0));")
+        src.push("mat4 entityMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+4, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+5, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+6, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+7, objectIndexCoords.y), 0));")
 
         src.push("positionsDecodeMatrix = entityMatrix * positionsDecodeMatrix;")
         

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
@@ -318,24 +318,20 @@ class TrianglesDataTexturePickDepthRenderer {
         src.push("};");
 
         // get normal
+        src.push("vec3 normal = normalize(cross(positions[2] - positions[0], positions[1] - positions[0]));");
+
+        src.push("vec3 position;");
+        src.push("position = positions[gl_VertexID % 3];");
 
         // when the geometry is not solid, if needed, flip the triangle winding
-        src.push("vec3 position;");
-
         src.push("if (solid != 1u) {");
-            src.push("vec3 normal = normalize(cross(positions[2] - positions[0], positions[1] - positions[0]));");
-            src.push("vec3 triangleCenter = (worldMatrix*positionsDecodeMatrix*vec4((positions[0] + positions[1] + positions[2]) / 3.0, 1)).xyz;")
-            src.push("vec3 worldNormal = normalize((transpose(inverse(worldMatrix*positionsDecodeMatrix)) * vec4(normal, 1)).xyz);");
-            src.push("vec3 cameraToTriangleDirection = normalize(triangleCenter - uCameraEyeRtc);")
-            src.push("if (dot(cameraToTriangleDirection, worldNormal) < 0.0) {");
+            src.push("vec3 uCameraEyeRtcInQuantizedSpace = (inverse(worldMatrix * positionsDecodeMatrix) * vec4(uCameraEyeRtc, 1)).xyz;")
+
+            src.push("if (dot(position.xyz - uCameraEyeRtcInQuantizedSpace, normal) < 0.0) {");
                 src.push("position = positions[2 - (gl_VertexID % 3)];");
-            src.push("} else {");
-                src.push("position = positions[gl_VertexID % 3];");
             src.push("}");
-        src.push("} else {")
-                src.push("position = positions[gl_VertexID % 3];");
         src.push("}");
-        
+
         src.push("vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
 
         // get XYZ offset

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
@@ -48,7 +48,8 @@ class TrianglesDataTexturePickMeshRenderer {
             this._uTexturePerVertexIdCoordinates, 
             this._uTexturePerObjectIdColorsAndFlags, 
             this._uTextureCameraMatrices, 
-            this._uTextureModelMatrices, 
+            this._uTextureModelMatrices,
+            this._uTexturePerObjectIdOffsets
         );
 
         gl.uniform1i(this._uRenderPass, renderPass);
@@ -165,6 +166,7 @@ class TrianglesDataTexturePickMeshRenderer {
         this._uTexturePerPolygonIdPortionIds = "uTexturePerPolygonIdPortionIds"; // chipmunk
         this._uTextureCameraMatrices = "uTextureCameraMatrices"; // chipmunk
         this._uTextureModelMatrices = "uTextureModelMatrices"; // chipmunk
+        this._uTexturePerObjectIdOffsets = "uTexturePerObjectIdOffsets"; // chipmunk
     }
 
     _bindProgram(frameCtx) {
@@ -216,6 +218,7 @@ class TrianglesDataTexturePickMeshRenderer {
 
         src.push("uniform mediump sampler2D uTexturePerObjectIdPositionsDecodeMatrix;"); // chipmunk
         src.push("uniform lowp usampler2D uTexturePerObjectIdColorsAndFlags;"); // chipmunk
+        src.push("uniform highp sampler2D uTexturePerObjectIdOffsets;"); // chipmunk
         src.push("uniform mediump usampler2D uTexturePerVertexIdCoordinates;"); // chipmunk
         src.push("uniform highp usampler2D uTexturePerPolygonIdIndices;"); // chipmunk
         src.push("uniform mediump usampler2D uTexturePerPolygonIdPortionIds;"); // chipmunk
@@ -305,9 +308,10 @@ class TrianglesDataTexturePickMeshRenderer {
         
         src.push("vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
 
-        if (scene.entityOffsetsEnabled) {
-            src.push("worldPosition.xyz = worldPosition.xyz + offset;");
-        }
+        // get XYZ offset
+        src.push("vec3 offset = texelFetch (uTexturePerObjectIdOffsets, ivec2(0, objectIndex), 0).rgb;");
+
+        src.push("worldPosition.xyz = worldPosition.xyz + offset;");
 
         src.push("vec4 viewPosition = viewMatrix * worldPosition; ");
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
@@ -1,7 +1,6 @@
-import {Program} from "../../../../../webgl/Program.js";
-import {createRTCViewMat, getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
-import {math} from "../../../../../math/math.js";
-import {WEBGL_INFO} from "../../../../../webglInfo.js";
+import {Program} from "../../../../../../webgl/Program.js";
+import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
+import {math} from "../../../../../../math/math.js";
 
 const tempVec3a = math.vec3();
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
@@ -216,7 +216,7 @@ class TrianglesDataTexturePickMeshRenderer {
         src.push("uniform bool pickInvisible;");
         // src.push("uniform sampler2D uOcclusionTexture;"); // chipmunk
 
-        src.push("uniform mediump sampler2D uTexturePerObjectIdPositionsDecodeMatrix;"); // chipmunk
+        src.push("uniform highp sampler2D uTexturePerObjectIdPositionsDecodeMatrix;"); // chipmunk
         src.push("uniform lowp usampler2D uTexturePerObjectIdColorsAndFlags;"); // chipmunk
         src.push("uniform highp sampler2D uTexturePerObjectIdOffsets;"); // chipmunk
         src.push("uniform mediump usampler2D uTexturePerVertexIdCoordinates;"); // chipmunk

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
@@ -301,6 +301,14 @@ class TrianglesDataTexturePickMeshRenderer {
         src.push("positions[1] = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.g, indexPositionV.g), 0));")
         src.push("positions[2] = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.b, indexPositionV.b), 0));")
 
+        // get color
+        src.push("uvec4 color = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(0, objectIndex), 0);"); // chipmunk
+
+        src.push(`if (color.a == 0u) {`);
+        src.push("   gl_Position = vec4(3.0, 3.0, 3.0, 1.0);"); // Cull vertex
+        src.push("   return;");
+        src.push("};");
+
         // get pick-color
         src.push("vPickColor = vec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(1, objectIndex), 0)) / 255.0;");
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
@@ -1,0 +1,393 @@
+import {Program} from "../../../../../webgl/Program.js";
+import {createRTCViewMat, getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
+import {math} from "../../../../../math/math.js";
+import {WEBGL_INFO} from "../../../../../webglInfo.js";
+
+const tempVec3a = math.vec3();
+
+/**
+ * @private
+ */
+class TrianglesDataTexturePickMeshRenderer {
+
+    constructor(scene) {
+        this._scene = scene;
+        this._hash = this._getHash();
+        this._allocate();
+    }
+
+    getValid() {
+        return this._hash === this._getHash();
+    };
+
+    _getHash() {
+        return this._scene._sectionPlanesState.getHash();
+    }
+
+    drawLayer(frameCtx, dataTextureLayer, renderPass) {
+        const model = dataTextureLayer.model;
+        const scene = model.scene;
+        const camera = scene.camera;
+        const gl = scene.canvas.gl;
+        const state = dataTextureLayer._state;
+        const textureState = state.textureState;
+        const origin = dataTextureLayer._state.origin;
+
+        if (!this._program) {
+            this._allocate(dataTextureLayer);
+        }
+
+        if (frameCtx.lastProgramId !== this._program.id) {
+            frameCtx.lastProgramId = this._program.id;
+            this._bindProgram(frameCtx);
+        }
+        
+        textureState.bindCommonTextures (
+            this._program,
+            this._uTexturePerObjectIdPositionsDecodeMatrix, 
+            this._uTexturePerVertexIdCoordinates, 
+            this._uTexturePerObjectIdColorsAndFlags, 
+            this._uTextureCameraMatrices, 
+            this._uTextureModelMatrices, 
+        );
+
+        gl.uniform1i(this._uRenderPass, renderPass);
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            const logDepthBufFC = 2.0 / (Math.log(camera.project.far + 1.0) / Math.LN2); // TODO: Far from pick project matrix?
+            gl.uniform1f(this._uLogDepthBufFC, logDepthBufFC);
+        }
+
+        const numSectionPlanes = scene._sectionPlanesState.sectionPlanes.length;
+        if (numSectionPlanes > 0) {
+            const sectionPlanes = scene._sectionPlanesState.sectionPlanes;
+            const baseIndex = dataTextureLayer.layerIndex * numSectionPlanes;
+            const renderFlags = model.renderFlags;
+            for (let sectionPlaneIndex = 0; sectionPlaneIndex < numSectionPlanes; sectionPlaneIndex++) {
+                const sectionPlaneUniforms = this._uSectionPlanes[sectionPlaneIndex];
+                if (sectionPlaneUniforms) {
+                    const active = renderFlags.sectionPlanesActivePerLayer[baseIndex + sectionPlaneIndex];
+                    gl.uniform1i(sectionPlaneUniforms.active, active ? 1 : 0);
+                    if (active) {
+                        const sectionPlane = sectionPlanes[sectionPlaneIndex];
+                        if (origin) {
+                            const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a);
+                            gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
+                        } else {
+                            gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);
+                        }
+                        gl.uniform3fv(sectionPlaneUniforms.dir, sectionPlane.dir);
+                    }
+                }
+            }
+        }
+
+        if (state.numIndices8Bits > 0)
+        {
+            textureState.bindTriangleIndicesTextures(
+                this._program,
+                this._uTexturePerPolygonIdPortionIds, 
+                this._uTexturePerPolygonIdIndices, 
+                8 // 8 bits indices
+            );
+
+            gl.drawArrays(gl.TRIANGLES, 0, state.numIndices8Bits);
+        }
+
+        if (state.numIndices16Bits > 0)
+        {
+            textureState.bindTriangleIndicesTextures(
+                this._program,
+                this._uTexturePerPolygonIdPortionIds, 
+                this._uTexturePerPolygonIdIndices, 
+                16 // 16 bits indices
+            );
+
+            gl.drawArrays(gl.TRIANGLES, 0, state.numIndices16Bits);
+        }
+        
+        if (state.numIndices32Bits > 0)
+        {
+            textureState.bindTriangleIndicesTextures(
+                this._program,
+                this._uTexturePerPolygonIdPortionIds, 
+                this._uTexturePerPolygonIdIndices, 
+                32 // 32 bits indices
+            );
+
+            gl.drawArrays(gl.TRIANGLES, 0, state.numIndices32Bits);
+        }
+
+        frameCtx.drawElements++;
+    }
+
+    _allocate() {
+
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+
+        this._program = new Program(gl, this._buildShader());
+
+        if (this._program.errors) {
+            this.errors = this._program.errors;
+            return;
+        }
+
+        const program = this._program;
+
+        this._uRenderPass = program.getLocation("renderPass");
+        this._uPickInvisible = program.getLocation("pickInvisible");
+
+        this._uSectionPlanes = [];
+
+        for (let i = 0, len = scene._sectionPlanesState.sectionPlanes.length; i < len; i++) {
+            this._uSectionPlanes.push({
+                active: program.getLocation("sectionPlaneActive" + i),
+                pos: program.getLocation("sectionPlanePos" + i),
+                dir: program.getLocation("sectionPlaneDir" + i)
+            });
+        }
+        
+        if (this._withSAO) {
+            this._uOcclusionTexture = "uOcclusionTexture";
+            this._uSAOParams = program.getLocation("uSAOParams");
+        }
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            this._uLogDepthBufFC = program.getLocation("logDepthBufFC");
+        }
+
+        this._uTexturePerObjectIdPositionsDecodeMatrix = "uTexturePerObjectIdPositionsDecodeMatrix"; // chipmunk
+        this._uTexturePerObjectIdColorsAndFlags = "uTexturePerObjectIdColorsAndFlags"; // chipmunk
+        this._uTexturePerVertexIdCoordinates = "uTexturePerVertexIdCoordinates"; // chipmunk
+        this._uTexturePerPolygonIdNormals = "uTexturePerPolygonIdNormals"; // chipmunk
+        this._uTexturePerPolygonIdIndices = "uTexturePerPolygonIdIndices"; // chipmunk
+        this._uTexturePerPolygonIdPortionIds = "uTexturePerPolygonIdPortionIds"; // chipmunk
+        this._uTextureCameraMatrices = "uTextureCameraMatrices"; // chipmunk
+        this._uTextureModelMatrices = "uTextureModelMatrices"; // chipmunk
+    }
+
+    _bindProgram(frameCtx) {
+
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+
+        this._program.bind();
+
+        gl.uniform1i(this._uPickInvisible, frameCtx.pickInvisible);
+    }
+
+    _buildShader() {
+        return {
+            vertex: this._buildVertexShader(),
+            fragment: this._buildFragmentShader()
+        };
+    }
+
+    _buildVertexShader() {
+        const scene = this._scene;
+        const clipping = scene._sectionPlanesState.sectionPlanes.length > 0;
+        const src = [];
+        src.push("#version 300 es");
+        src.push("// Batched geometry picking vertex shader");
+
+        src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
+        src.push("precision highp float;");
+        src.push("precision highp int;");
+        src.push("precision highp usampler2D;");
+        src.push("precision highp isampler2D;");
+        src.push("precision highp sampler2D;");
+        src.push("#else");
+        src.push("precision mediump float;");
+        src.push("precision mediump int;");
+        src.push("precision mediump usampler2D;");
+        src.push("precision mediump isampler2D;");
+        src.push("precision mediump sampler2D;");
+        src.push("#endif");
+
+        src.push("uniform int renderPass;");
+
+        if (scene.entityOffsetsEnabled) {
+            src.push("in vec3 offset;");
+        }
+
+        src.push("uniform bool pickInvisible;");
+        // src.push("uniform sampler2D uOcclusionTexture;"); // chipmunk
+
+        src.push("uniform mediump sampler2D uTexturePerObjectIdPositionsDecodeMatrix;"); // chipmunk
+        src.push("uniform lowp usampler2D uTexturePerObjectIdColorsAndFlags;"); // chipmunk
+        src.push("uniform mediump usampler2D uTexturePerVertexIdCoordinates;"); // chipmunk
+        src.push("uniform highp usampler2D uTexturePerPolygonIdIndices;"); // chipmunk
+        src.push("uniform mediump usampler2D uTexturePerPolygonIdPortionIds;"); // chipmunk
+        src.push("uniform highp sampler2D uTextureCameraMatrices;"); // chipmunk
+        src.push("uniform highp sampler2D uTextureModelMatrices;"); // chipmunk
+
+        src.push("vec3 positions[3];")
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("uniform float logDepthBufFC;");
+            src.push("out float vFragDepth;");
+            src.push("bool isPerspectiveMatrix(mat4 m) {");
+            src.push("    return (m[2][3] == - 1.0);");
+            src.push("}");
+            src.push("out float isPerspective;");
+        }
+
+        if (clipping) {
+            src.push("out vec4 vWorldPosition;");
+            src.push("out int vFlags2;");
+        }
+
+        src.push("out vec4 vPickColor;");
+
+        src.push("void main(void) {");
+
+        // camera matrices
+        src.push ("mat4 viewMatrix = mat4 (texelFetch (uTextureCameraMatrices, ivec2(0, 0), 0), texelFetch (uTextureCameraMatrices, ivec2(1, 0), 0), texelFetch (uTextureCameraMatrices, ivec2(2, 0), 0), texelFetch (uTextureCameraMatrices, ivec2(3, 0), 0));");
+        src.push ("mat4 viewNormalMatrix = mat4 (texelFetch (uTextureCameraMatrices, ivec2(0, 1), 0), texelFetch (uTextureCameraMatrices, ivec2(1, 1), 0), texelFetch (uTextureCameraMatrices, ivec2(2, 1), 0), texelFetch (uTextureCameraMatrices, ivec2(3, 1), 0));");
+        src.push ("mat4 projMatrix = mat4 (texelFetch (uTextureCameraMatrices, ivec2(0, 2), 0), texelFetch (uTextureCameraMatrices, ivec2(1, 2), 0), texelFetch (uTextureCameraMatrices, ivec2(2, 2), 0), texelFetch (uTextureCameraMatrices, ivec2(3, 2), 0));");
+
+        // model matrices
+        src.push ("mat4 worldMatrix = mat4 (texelFetch (uTextureModelMatrices, ivec2(0, 0), 0), texelFetch (uTextureModelMatrices, ivec2(1, 0), 0), texelFetch (uTextureModelMatrices, ivec2(2, 0), 0), texelFetch (uTextureModelMatrices, ivec2(3, 0), 0));");
+        src.push ("mat4 worldNormalMatrix = mat4 (texelFetch (uTextureModelMatrices, ivec2(0, 1), 0), texelFetch (uTextureModelMatrices, ivec2(1, 1), 0), texelFetch (uTextureModelMatrices, ivec2(2, 1), 0), texelFetch (uTextureModelMatrices, ivec2(3, 1), 0));");
+
+        // constants
+        src.push("int polygonIndex = gl_VertexID / 3;")
+
+        // get packed object-id
+        src.push("int h_packed_object_id_index = (polygonIndex >> 3) & 1023;")
+        src.push("int v_packed_object_id_index = (polygonIndex >> 3) >> 10;")
+
+        src.push("int objectIndex = int(texelFetch(uTexturePerPolygonIdPortionIds, ivec2(h_packed_object_id_index, v_packed_object_id_index), 0).r);");
+
+        // get flags & flags2
+        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(2, objectIndex), 0);"); // chipmunk
+        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(3, objectIndex), 0);"); // chipmunk
+        
+        // flags.w = NOT_RENDERED | PICK
+        // renderPass = PICK
+
+        src.push(`if (int(flags.w) != renderPass) {`);
+        src.push("   gl_Position = vec4(3.0, 3.0, 3.0, 1.0);"); // Cull vertex
+        src.push("   return;"); // Cull vertex
+        src.push("} else {");
+
+        // get vertex base
+        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(4, objectIndex), 0));");
+
+        src.push("ivec4 packedIndexBaseOffset = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(5, objectIndex), 0));");
+
+        src.push("int indexBaseOffset = (packedIndexBaseOffset.r << 24) + (packedIndexBaseOffset.g << 16) + (packedIndexBaseOffset.b << 8) + packedIndexBaseOffset.a;");
+
+        src.push("int h_index = (polygonIndex - indexBaseOffset) & 1023;")
+        src.push("int v_index = (polygonIndex - indexBaseOffset) >> 10;")
+
+        src.push("ivec3 vertexIndices = ivec3(texelFetch(uTexturePerPolygonIdIndices, ivec2(h_index, v_index), 0));");
+        src.push("ivec3 uniqueVertexIndexes = vertexIndices + (packedVertexBase.r << 24) + (packedVertexBase.g << 16) + (packedVertexBase.b << 8) + packedVertexBase.a;")
+        
+        src.push("ivec3 indexPositionH = uniqueVertexIndexes & 1023;")
+        src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 10;")
+
+        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(0, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(1, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(2, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(3, objectIndex), 0));")
+        src.push("mat4 entityMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(4, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(5, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(6, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(7, objectIndex), 0));")
+
+        src.push("positionsDecodeMatrix = entityMatrix * positionsDecodeMatrix;")
+        
+        // get position
+        src.push("positions[0] = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.r, indexPositionV.r), 0));")
+        src.push("positions[1] = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.g, indexPositionV.g), 0));")
+        src.push("positions[2] = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.b, indexPositionV.b), 0));")
+
+        // get pick-color
+        src.push("vPickColor = vec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(1, objectIndex), 0)) / 255.0;");
+
+        src.push("vec3 position = positions[gl_VertexID % 3];");
+        
+        src.push("vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
+
+        if (scene.entityOffsetsEnabled) {
+            src.push("worldPosition.xyz = worldPosition.xyz + offset;");
+        }
+
+        src.push("vec4 viewPosition = viewMatrix * worldPosition; ");
+
+        if (clipping) {
+            src.push("      vWorldPosition = worldPosition;");
+            src.push("      vFlags2 = flags2;");
+        }
+        src.push("vec4 clipPos = projMatrix * viewPosition;");
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("vFragDepth = 1.0 + clipPos.w;");
+            src.push("isPerspective = float (isPerspectiveMatrix(projMatrix));");
+        }
+        src.push("gl_Position = clipPos;");
+        src.push("  }");
+        src.push("}");
+        return src;
+    }
+
+    _buildFragmentShader() {
+        const scene = this._scene;
+        const sectionPlanesState = scene._sectionPlanesState;
+        const clipping = sectionPlanesState.sectionPlanes.length > 0;
+        const src = [];
+        src.push ('#version 300 es');
+        src.push("// Batched geometry picking fragment shader");
+        src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
+        src.push("precision highp float;");
+        src.push("precision highp int;");
+        src.push("#else");
+        src.push("precision mediump float;");
+        src.push("precision mediump int;");
+        src.push("#endif");
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("in float isPerspective;");
+            src.push("uniform float logDepthBufFC;");
+            src.push("in float vFragDepth;");
+        }
+        if (clipping) {
+            src.push("in vec4 vWorldPosition;");
+            src.push("in int vFlags2;");
+            for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
+                src.push("uniform bool sectionPlaneActive" + i + ";");
+                src.push("uniform vec3 sectionPlanePos" + i + ";");
+                src.push("uniform vec3 sectionPlaneDir" + i + ";");
+            }
+        }
+        src.push("in vec4 vPickColor;");
+        src.push("out vec4 outPickColor;");
+        src.push("void main(void) {");
+        if (clipping) {
+            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  if (clippable) {");
+            src.push("      float dist = 0.0;");
+            for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
+                src.push("      if (sectionPlaneActive" + i + ") {");
+                src.push("          dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
+                src.push("      }");
+            }
+            src.push("      if (dist > 0.0) { discard; }");
+            src.push("  }");
+        }
+        if (scene.logarithmicDepthBufferEnabled) {
+            // src.push("    gl_FragDepth = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;");
+            src.push("    gl_FragDepth = log2( vFragDepth ) * logDepthBufFC * 0.5;");
+        }
+        src.push("   outPickColor = vPickColor; ");
+        src.push("}");
+        return src;
+    }
+
+    webglContextRestored() {
+        this._program = null;
+    }
+
+    destroy() {
+        if (this._program) {
+            this._program.destroy();
+        }
+        this._program = null;
+    }
+}
+
+export {TrianglesDataTexturePickMeshRenderer};

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
@@ -51,15 +51,25 @@ class TrianglesDataTexturePickMeshRenderer {
             this._uTexturePerObjectIdOffsets
         );
 
-        gl.uniform1i(this._uRenderPass, renderPass);
+        let cameraEye = camera.eye;
+
+        if (frameCtx.pickViewMatrix) {
+            textureState.bindPickCameraTexture (
+                this._program,
+                this._uTextureCameraMatrices
+            );
+            cameraEye = frameCtx.pickOrigin || cameraEye;
+        }
 
         const originCameraEye = [
-            camera.eye[0] - origin[0],
-            camera.eye[1] - origin[1],
-            camera.eye[2] - origin[2],
+            cameraEye[0] - origin[0],
+            cameraEye[1] - origin[1],
+            cameraEye[2] - origin[2],
         ];
 
         gl.uniform3fv(this._uCameraEyeRtc, originCameraEye);
+
+        gl.uniform1i(this._uRenderPass, renderPass);
 
         if (scene.logarithmicDepthBufferEnabled) {
             const logDepthBufFC = 2.0 / (Math.log(camera.project.far + 1.0) / Math.LN2); // TODO: Far from pick project matrix?
@@ -239,11 +249,12 @@ class TrianglesDataTexturePickMeshRenderer {
         if (scene.logarithmicDepthBufferEnabled) {
             src.push("uniform float logDepthBufFC;");
             src.push("out float vFragDepth;");
-            src.push("bool isPerspectiveMatrix(mat4 m) {");
-            src.push("    return (m[2][3] == - 1.0);");
-            src.push("}");
             src.push("out float isPerspective;");
         }
+
+        src.push("bool isPerspectiveMatrix(mat4 m) {");
+        src.push("    return (m[2][3] == - 1.0);");
+        src.push("}");
 
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
@@ -332,10 +343,16 @@ class TrianglesDataTexturePickMeshRenderer {
 
         // when the geometry is not solid, if needed, flip the triangle winding
         src.push("if (solid != 1u) {");
-            src.push("vec3 uCameraEyeRtcInQuantizedSpace = (inverse(worldMatrix * positionsDecodeMatrix) * vec4(uCameraEyeRtc, 1)).xyz;")
-
-            src.push("if (dot(position.xyz - uCameraEyeRtcInQuantizedSpace, normal) < 0.0) {");
-                src.push("position = positions[2 - (gl_VertexID % 3)];");
+            src.push("if (isPerspectiveMatrix(projMatrix)) {");
+                src.push("vec3 uCameraEyeRtcInQuantizedSpace = (inverse(worldMatrix * positionsDecodeMatrix) * vec4(uCameraEyeRtc, 1)).xyz;")
+                src.push("if (dot(position.xyz - uCameraEyeRtcInQuantizedSpace, normal) < 0.0) {");
+                    src.push("position = positions[2 - (gl_VertexID % 3)];");
+                src.push("}");
+            src.push("} else {");
+                src.push("vec3 viewNormal = -normalize((transpose(inverse(viewMatrix*positionsDecodeMatrix)) * vec4(normal,1)).xyz);");
+                src.push("if (viewNormal.z < 0.0) {");
+                    src.push("position = positions[2 - (gl_VertexID % 3)];");
+                src.push("}");
             src.push("}");
         src.push("}");
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
@@ -257,8 +257,8 @@ class TrianglesDataTexturePickMeshRenderer {
         src.push("}");
 
         if (clipping) {
-            src.push("out vec4 vWorldPosition;");
-            src.push("out int vFlags2;");
+            src.push("smooth out vec4 vWorldPosition;");
+            src.push("flat out uvec4 vFlags2;");
         }
 
         src.push("out vec4 vPickColor;");
@@ -402,7 +402,7 @@ class TrianglesDataTexturePickMeshRenderer {
         }
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in int vFlags2;");
+            src.push("flat in uvec4 vFlags2;");
             for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
@@ -317,9 +317,9 @@ class TrianglesDataTexturePickMeshRenderer {
         src.push("vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
 
         // get XYZ offset
-        src.push("vec3 offset = texelFetch (uTexturePerObjectIdOffsets, ivec2(0, objectIndex), 0).rgb;");
+        src.push("vec4 offset = vec4(texelFetch (uTexturePerObjectIdOffsets, objectIndexCoords, 0).rgb, 0.0);");
 
-        src.push("worldPosition.xyz = worldPosition.xyz + offset;");
+        src.push("worldPosition.xyz = worldPosition.xyz + offset.xyz;");
 
         src.push("vec4 viewPosition = viewMatrix * worldPosition; ");
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
@@ -261,10 +261,11 @@ class TrianglesDataTexturePickMeshRenderer {
         src.push("int v_packed_object_id_index = (polygonIndex >> 3) >> 12;")
 
         src.push("int objectIndex = int(texelFetch(uTexturePerPolygonIdPortionIds, ivec2(h_packed_object_id_index, v_packed_object_id_index), 0).r);");
+        src.push("ivec2 objectIndexCoords = ivec2(objectIndex % 512, objectIndex / 512);");
 
         // get flags & flags2
-        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(2, objectIndex), 0);"); // chipmunk
-        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(3, objectIndex), 0);"); // chipmunk
+        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+2, objectIndexCoords.y), 0);"); // chipmunk
+        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+3, objectIndexCoords.y), 0);"); // chipmunk
         
         // flags.w = NOT_RENDERED | PICK
         // renderPass = PICK
@@ -275,9 +276,9 @@ class TrianglesDataTexturePickMeshRenderer {
         src.push("} else {");
 
         // get vertex base
-        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(4, objectIndex), 0));");
+        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+4, objectIndexCoords.y), 0));"); // chipmunk
 
-        src.push("ivec4 packedIndexBaseOffset = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(5, objectIndex), 0));");
+        src.push("ivec4 packedIndexBaseOffset = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+5, objectIndexCoords.y), 0));"); // chipmunk
 
         src.push("int indexBaseOffset = (packedIndexBaseOffset.r << 24) + (packedIndexBaseOffset.g << 16) + (packedIndexBaseOffset.b << 8) + packedIndexBaseOffset.a;");
 
@@ -301,7 +302,7 @@ class TrianglesDataTexturePickMeshRenderer {
         src.push("positions[2] = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.b, indexPositionV.b), 0));")
 
         // get color
-        src.push("uvec4 color = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(0, objectIndex), 0);"); // chipmunk
+        src.push("uvec4 color = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+0, objectIndexCoords.y), 0);"); // chipmunk
 
         src.push(`if (color.a == 0u) {`);
         src.push("   gl_Position = vec4(3.0, 3.0, 3.0, 1.0);"); // Cull vertex
@@ -309,7 +310,7 @@ class TrianglesDataTexturePickMeshRenderer {
         src.push("};");
 
         // get pick-color
-        src.push("vPickColor = vec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(1, objectIndex), 0)) / 255.0;");
+        src.push("vPickColor = vec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+1, objectIndexCoords.y), 0)) / 255.0;");
 
         src.push("vec3 position = positions[gl_VertexID % 3];");
         

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
@@ -291,8 +291,8 @@ class TrianglesDataTexturePickMeshRenderer {
         src.push("ivec3 indexPositionH = uniqueVertexIndexes & 4095;")
         src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 12;")
 
-        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(0, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(1, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(2, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(3, objectIndex), 0));")
-        src.push("mat4 entityMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(4, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(5, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(6, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(7, objectIndex), 0));")
+        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+2, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+3, objectIndexCoords.y), 0));")
+        src.push("mat4 entityMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+4, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+5, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+6, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+7, objectIndexCoords.y), 0));")
 
         src.push("positionsDecodeMatrix = entityMatrix * positionsDecodeMatrix;")
         

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
@@ -257,8 +257,8 @@ class TrianglesDataTexturePickMeshRenderer {
         src.push("int polygonIndex = gl_VertexID / 3;")
 
         // get packed object-id
-        src.push("int h_packed_object_id_index = (polygonIndex >> 3) & 1023;")
-        src.push("int v_packed_object_id_index = (polygonIndex >> 3) >> 10;")
+        src.push("int h_packed_object_id_index = (polygonIndex >> 3) & 4095;")
+        src.push("int v_packed_object_id_index = (polygonIndex >> 3) >> 12;")
 
         src.push("int objectIndex = int(texelFetch(uTexturePerPolygonIdPortionIds, ivec2(h_packed_object_id_index, v_packed_object_id_index), 0).r);");
 
@@ -281,14 +281,14 @@ class TrianglesDataTexturePickMeshRenderer {
 
         src.push("int indexBaseOffset = (packedIndexBaseOffset.r << 24) + (packedIndexBaseOffset.g << 16) + (packedIndexBaseOffset.b << 8) + packedIndexBaseOffset.a;");
 
-        src.push("int h_index = (polygonIndex - indexBaseOffset) & 1023;")
-        src.push("int v_index = (polygonIndex - indexBaseOffset) >> 10;")
+        src.push("int h_index = (polygonIndex - indexBaseOffset) & 4095;")
+        src.push("int v_index = (polygonIndex - indexBaseOffset) >> 12;")
 
         src.push("ivec3 vertexIndices = ivec3(texelFetch(uTexturePerPolygonIdIndices, ivec2(h_index, v_index), 0));");
         src.push("ivec3 uniqueVertexIndexes = vertexIndices + (packedVertexBase.r << 24) + (packedVertexBase.g << 16) + (packedVertexBase.b << 8) + packedVertexBase.a;")
         
-        src.push("ivec3 indexPositionH = uniqueVertexIndexes & 1023;")
-        src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 10;")
+        src.push("ivec3 indexPositionH = uniqueVertexIndexes & 4095;")
+        src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 12;")
 
         src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(0, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(1, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(2, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(3, objectIndex), 0));")
         src.push("mat4 entityMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(4, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(5, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(6, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(7, objectIndex), 0));")

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
@@ -322,27 +322,23 @@ class TrianglesDataTexturePickMeshRenderer {
         src.push("};");
 
         // get pick-color
-
-        // when the geometry is not solid, if needed, flip the triangle winding
-        src.push("vec3 position;");
-
-        src.push("if (solid != 1u) {");
-            src.push("vec3 normal = normalize(cross(positions[2] - positions[0], positions[1] - positions[0]));");
-            src.push("vec3 triangleCenter = (worldMatrix*positionsDecodeMatrix*vec4((positions[0] + positions[1] + positions[2]) / 3.0, 1)).xyz;")
-            src.push("vec3 worldNormal = normalize((transpose(inverse(worldMatrix*positionsDecodeMatrix)) * vec4(normal, 1)).xyz);");
-            src.push("vec3 cameraToTriangleDirection = normalize(triangleCenter - uCameraEyeRtc);")
-            src.push("if (dot(cameraToTriangleDirection, worldNormal) < 0.0) {");
-                src.push("position = positions[2 - (gl_VertexID % 3)];");
-            src.push("} else {");
-                src.push("position = positions[gl_VertexID % 3];");
-            src.push("}");
-        src.push("} else {")
-                src.push("position = positions[gl_VertexID % 3];");
-        src.push("}");
-
         src.push("vPickColor = vec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+1, objectIndexCoords.y), 0)) / 255.0;");
 
-        
+        // get normal
+        src.push("vec3 normal = normalize(cross(positions[2] - positions[0], positions[1] - positions[0]));");
+
+        src.push("vec3 position;");
+        src.push("position = positions[gl_VertexID % 3];");
+
+        // when the geometry is not solid, if needed, flip the triangle winding
+        src.push("if (solid != 1u) {");
+            src.push("vec3 uCameraEyeRtcInQuantizedSpace = (inverse(worldMatrix * positionsDecodeMatrix) * vec4(uCameraEyeRtc, 1)).xyz;")
+
+            src.push("if (dot(position.xyz - uCameraEyeRtcInQuantizedSpace, normal) < 0.0) {");
+                src.push("position = positions[2 - (gl_VertexID % 3)];");
+            src.push("}");
+        src.push("}");
+
         src.push("vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
 
         // get XYZ offset

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsFlatRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsFlatRenderer.js
@@ -1,7 +1,7 @@
-import {Program} from "../../../../../webgl/Program.js";
-import {createRTCViewMat, getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
-import {math} from "../../../../../math/math.js";
-import {WEBGL_INFO} from "../../../../../webglInfo.js";
+import {Program} from "../../../../../../webgl/Program.js";
+import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
+import {math} from "../../../../../../math/math.js";
+import {WEBGL_INFO} from "../../../../../../webglInfo.js";
 
 const tempVec3a = math.vec3();
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsFlatRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsFlatRenderer.js
@@ -1,0 +1,503 @@
+import {Program} from "../../../../../webgl/Program.js";
+import {createRTCViewMat, getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
+import {math} from "../../../../../math/math.js";
+import {WEBGL_INFO} from "../../../../../webglInfo.js";
+
+const tempVec3a = math.vec3();
+
+/**
+ * @private
+ */
+class TrianglesDataTexturePickNormalsFlatRenderer {
+
+    constructor(scene) {
+        this._scene = scene;
+        this._hash = this._getHash();
+        this._allocate();
+    }
+
+    getValid() {
+        return this._hash === this._getHash();
+    };
+
+    _getHash() {
+        return this._scene._sectionPlanesState.getHash();
+    }
+
+    drawLayer(frameCtx, dataTextureLayer, renderPass) {
+        const model = dataTextureLayer.model;
+        const scene = model.scene;
+        const camera = scene.camera;
+        const gl = scene.canvas.gl;
+        const state = dataTextureLayer._state;
+        const origin = dataTextureLayer._state.origin;
+
+        if (!this._program) {
+            this._allocate(dataTextureLayer);
+        }
+
+        if (frameCtx.lastProgramId !== this._program.id) {
+            frameCtx.lastProgramId = this._program.id;
+            this._bindProgram();
+        }
+
+        var rr = this._program.bindTexture(
+            this._uTexturePerObjectIdPositionsDecodeMatrix, 
+            {
+                bind: function (unit) {
+                    gl.activeTexture(gl["TEXTURE" + unit]);
+                    gl.bindTexture(gl.TEXTURE_2D, state.texturePerObjectIdPositionsDecodeMatrix);
+                    return true;
+                },
+                unbind: function (unit) {
+                    gl.activeTexture(gl["TEXTURE" + unit]);
+                    gl.bindTexture(gl.TEXTURE_2D, null);
+                }
+            },
+            1
+        ); // chipmunk
+
+        var rr2 = this._program.bindTexture(
+            this._uTexturePerVertexIdCoordinates, 
+            {
+                bind: function (unit) {
+                    gl.activeTexture(gl["TEXTURE" + unit]);
+                    gl.bindTexture(gl.TEXTURE_2D, state.texturePerVertexIdCoordinates);
+                    return true;
+                },
+                unbind: function (unit) {
+                    gl.activeTexture(gl["TEXTURE" + unit]);
+                    gl.bindTexture(gl.TEXTURE_2D, null);
+                }
+            },
+            2
+        ); // chipmunk
+
+        var rr3 = this._program.bindTexture(
+            this._uTexturePerObjectIdColorsAndFlags,
+            {
+                bind: function (unit) {
+                    gl.activeTexture(gl["TEXTURE" + unit]);
+                    gl.bindTexture(gl.TEXTURE_2D, state.texturePerObjectIdColorsAndFlags);
+                    return true;
+                },
+                unbind: function (unit) {
+                    gl.activeTexture(gl["TEXTURE" + unit]);
+                    gl.bindTexture(gl.TEXTURE_2D, null);
+                }
+            },
+            3
+        ); // chipmunk
+
+        gl.uniform1i(this._uRenderPass, renderPass);
+        gl.uniform1i(this._uPickInvisible, frameCtx.pickInvisible);
+
+        gl.uniformMatrix4fv(this._uWorldMatrix, false, model.worldMatrix);
+
+        const pickViewMatrix = frameCtx.pickViewMatrix || camera.viewMatrix;
+        const viewMatrix = origin ? createRTCViewMat(pickViewMatrix, origin) : pickViewMatrix;
+
+        gl.uniformMatrix4fv(this._uViewMatrix, false, viewMatrix);
+        gl.uniformMatrix4fv(this._uProjMatrix, false, frameCtx.pickProjMatrix);
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            const logDepthBufFC = 2.0 / (Math.log(camera.project.far + 1.0) / Math.LN2);  // TODO: Far should be from projection matrix?
+            gl.uniform1f(this._uLogDepthBufFC, logDepthBufFC);
+        }
+
+        const numSectionPlanes = scene._sectionPlanesState.sectionPlanes.length;
+        if (numSectionPlanes > 0) {
+            const sectionPlanes = scene._sectionPlanesState.sectionPlanes;
+            const baseIndex = dataTextureLayer.layerIndex * numSectionPlanes;
+            const renderFlags = model.renderFlags;
+            for (let sectionPlaneIndex = 0; sectionPlaneIndex < numSectionPlanes; sectionPlaneIndex++) {
+                const sectionPlaneUniforms = this._uSectionPlanes[sectionPlaneIndex];
+                const active = renderFlags.sectionPlanesActivePerLayer[baseIndex + sectionPlaneIndex];
+                gl.uniform1i(sectionPlaneUniforms.active, active ? 1 : 0);
+                if (active) {
+                    const sectionPlane = sectionPlanes[sectionPlaneIndex];
+                    if (origin) {
+                        const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a);
+                        gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
+                    } else {
+                        gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);
+                    }
+                    gl.uniform3fv(sectionPlaneUniforms.dir, sectionPlane.dir);
+                }
+            }
+        }
+
+        //=============================================================
+        // TODO: Use drawElements count and offset to draw only one entity
+        //=============================================================
+
+        if (state.numIndices8Bits > 0) {
+            var rr4 = this._program.bindTexture(
+                this._uTexturePerPolygonIdPortionIds, 
+                {
+                    bind: function (unit) {
+                        gl.activeTexture(gl["TEXTURE" + unit]);
+                        gl.bindTexture(gl.TEXTURE_2D, state.texturePerPolygonIdPortionIds8Bits);
+                        return true;
+                    },
+                    unbind: function (unit) {
+                        gl.activeTexture(gl["TEXTURE" + unit]);
+                        gl.bindTexture(gl.TEXTURE_2D, null);
+                    }
+                },
+                4
+            ); // chipmunk
+    
+            var rr5 = this._program.bindTexture(
+                this._uTexturePerPolygonIdIndices, 
+                {
+                    bind: function (unit) {
+                        gl.activeTexture(gl["TEXTURE" + unit]);
+                        gl.bindTexture(gl.TEXTURE_2D, state.texturePerPolygonIdIndices8Bits);
+                        return true;
+                    },
+                    unbind: function (unit) {
+                        gl.activeTexture(gl["TEXTURE" + unit]);
+                        gl.bindTexture(gl.TEXTURE_2D, null);
+                    }
+                },
+                5
+            ); // chipmunk
+
+            gl.drawArrays(gl.TRIANGLES, 0, state.numIndices8Bits);
+        }
+
+        if (state.numIndices16Bits > 0) {
+            var rr4 = this._program.bindTexture(
+                this._uTexturePerPolygonIdPortionIds, 
+                {
+                    bind: function (unit) {
+                        gl.activeTexture(gl["TEXTURE" + unit]);
+                        gl.bindTexture(gl.TEXTURE_2D, state.texturePerPolygonIdPortionIds16Bits);
+                        return true;
+                    },
+                    unbind: function (unit) {
+                        gl.activeTexture(gl["TEXTURE" + unit]);
+                        gl.bindTexture(gl.TEXTURE_2D, null);
+                    }
+                },
+                4
+            ); // chipmunk
+    
+            var rr5 = this._program.bindTexture(
+                this._uTexturePerPolygonIdIndices, 
+                {
+                    bind: function (unit) {
+                        gl.activeTexture(gl["TEXTURE" + unit]);
+                        gl.bindTexture(gl.TEXTURE_2D, state.texturePerPolygonIdIndices16Bits);
+                        return true;
+                    },
+                    unbind: function (unit) {
+                        gl.activeTexture(gl["TEXTURE" + unit]);
+                        gl.bindTexture(gl.TEXTURE_2D, null);
+                    }
+                },
+                5
+            ); // chipmunk
+
+            gl.drawArrays(gl.TRIANGLES, 0, state.numIndices16Bits);
+        }
+
+        if (state.numIndices32Bits > 0) {
+            var rr4 = this._program.bindTexture(
+                this._uTexturePerPolygonIdPortionIds, 
+                {
+                    bind: function (unit) {
+                        gl.activeTexture(gl["TEXTURE" + unit]);
+                        gl.bindTexture(gl.TEXTURE_2D, state.texturePerPolygonIdPortionIds32Bits);
+                        return true;
+                    },
+                    unbind: function (unit) {
+                        gl.activeTexture(gl["TEXTURE" + unit]);
+                        gl.bindTexture(gl.TEXTURE_2D, null);
+                    }
+                },
+                4
+            ); // chipmunk
+    
+            var rr5 = this._program.bindTexture(
+                this._uTexturePerPolygonIdIndices, 
+                {
+                    bind: function (unit) {
+                        gl.activeTexture(gl["TEXTURE" + unit]);
+                        gl.bindTexture(gl.TEXTURE_2D, state.texturePerPolygonIdIndices32Bits);
+                        return true;
+                    },
+                    unbind: function (unit) {
+                        gl.activeTexture(gl["TEXTURE" + unit]);
+                        gl.bindTexture(gl.TEXTURE_2D, null);
+                    }
+                },
+                5
+            ); // chipmunk
+
+            gl.drawArrays(gl.TRIANGLES, 0, state.numIndices32Bits);
+        }
+
+
+        frameCtx.drawElements++;
+    }
+
+    _allocate() {
+
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+
+        this._program = new Program(gl, this._buildShader());
+
+        if (this._program.errors) {
+            this.errors = this._program.errors;
+            return;
+        }
+
+        const program = this._program;
+
+        this._uRenderPass = program.getLocation("renderPass");
+        this._uPickInvisible = program.getLocation("pickInvisible");
+        this._uPositionsDecodeMatrix = program.getLocation("positionsDecodeMatrix");
+        this._uWorldMatrix = program.getLocation("worldMatrix");
+        this._uViewMatrix = program.getLocation("viewMatrix");
+        this._uProjMatrix = program.getLocation("projMatrix");
+        this._uSectionPlanes = [];
+
+        for (let i = 0, len = scene._sectionPlanesState.sectionPlanes.length; i < len; i++) {
+            this._uSectionPlanes.push({
+                active: program.getLocation("sectionPlaneActive" + i),
+                pos: program.getLocation("sectionPlanePos" + i),
+                dir: program.getLocation("sectionPlaneDir" + i)
+            });
+        }
+
+        this._aPackedVertexId = program.getAttribute("packedVertexId");
+
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            this._uLogDepthBufFC = program.getLocation("logDepthBufFC");
+        }
+
+        this._uTexturePerObjectIdPositionsDecodeMatrix = "uTexturePerObjectIdPositionsDecodeMatrix"; // chipmunk
+        this._uTexturePerObjectIdColorsAndFlags = "uTexturePerObjectIdColorsAndFlags"; // chipmunk
+        this._uTexturePerVertexIdCoordinates = "uTexturePerVertexIdCoordinates"; // chipmunk
+        this._uTexturePerPolygonIdNormals = "uTexturePerPolygonIdNormals"; // chipmunk
+        this._uTexturePerPolygonIdIndices = "uTexturePerPolygonIdIndices"; // chipmunk
+        this._uTexturePerPolygonIdPortionIds = "uTexturePerPolygonIdPortionIds"; // chipmunk
+    }
+
+    _bindProgram() {
+        this._program.bind();
+    }
+
+    _buildShader() {
+        return {
+            vertex: this._buildVertexShader(),
+            fragment: this._buildFragmentShader()
+        };
+    }
+
+    _buildVertexShader() {
+        const scene = this._scene;
+        const clipping = scene._sectionPlanesState.sectionPlanes.length > 0;
+        const src = [];
+        src.push("#version 300 es");
+        src.push("// Triangles dataTexture pick flat normals vertex shader");
+
+        src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
+        src.push("precision highp float;");
+        src.push("precision highp int;");
+        src.push("precision highp usampler2D;");
+        src.push("precision highp isampler2D;");
+        src.push("precision highp sampler2D;");
+        src.push("#else");
+        src.push("precision mediump float;");
+        src.push("precision mediump int;");
+        src.push("precision mediump usampler2D;");
+        src.push("precision mediump isampler2D;");
+        src.push("precision mediump sampler2D;");
+        src.push("#endif");
+
+        src.push("uniform int renderPass;");
+
+        src.push("in uvec3 packedVertexId;");
+
+        if (scene.entityOffsetsEnabled) {
+            src.push("in vec3 offset;");
+        }
+
+        src.push("uniform bool pickInvisible;");
+        src.push("uniform mat4 worldMatrix;");
+        src.push("uniform mat4 viewMatrix;");
+        src.push("uniform mat4 projMatrix;");
+        // src.push("uniform sampler2D uOcclusionTexture;"); // chipmunk
+        src.push("uniform sampler2D uTexturePerObjectIdPositionsDecodeMatrix;"); // chipmunk
+        src.push("uniform usampler2D uTexturePerObjectIdColorsAndFlags;"); // chipmunk
+        src.push("uniform usampler2D uTexturePerVertexIdCoordinates;"); // chipmunk
+        src.push("uniform usampler2D uTexturePerPolygonIdIndices;"); // chipmunk
+        src.push("uniform isampler2D uTexturePerPolygonIdNormals;"); // chipmunk
+        src.push("uniform usampler2D uTexturePerPolygonIdPortionIds;"); // chipmunk
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("uniform float logDepthBufFC;");
+            src.push("out float vFragDepth;");
+            src.push("bool isPerspectiveMatrix(mat4 m) {");
+            src.push("    return (m[2][3] == - 1.0);");
+            src.push("}");
+            src.push("out float isPerspective;");
+        }
+        src.push("out vec4 vWorldPosition;");
+        if (clipping) {
+            src.push("out int vFlags2;");
+        }
+        src.push("void main(void) {");
+
+        // constants
+        // src.push("int objectIndex = int(packedVertexId.g) & 1023;");
+        src.push("int polygonIndex = gl_VertexID / 3;")
+
+        src.push("int h_normal_index = polygonIndex & 1023;")
+        src.push("int v_normal_index = polygonIndex >> 10;")
+
+        // get packed object-id
+        src.push("int h_packed_object_id_index = ((polygonIndex >> 3) / 2) & 1023;")
+        src.push("int v_packed_object_id_index = ((polygonIndex >> 3) / 2) >> 10;")
+
+        src.push("ivec3 packedObjectId = ivec3(texelFetch(uTexturePerPolygonIdPortionIds, ivec2(h_packed_object_id_index, v_packed_object_id_index), 0).rgb);");
+
+        src.push("int objectIndex;")
+        src.push("if (((polygonIndex >> 3) % 2) == 0) {")
+        src.push("  objectIndex = (packedObjectId.r << 4) + (packedObjectId.g >> 4);")
+        src.push("} else {") 
+        src.push("  objectIndex = ((packedObjectId.g & 15) << 8) + packedObjectId.b;")
+        src.push("}")
+
+        // get vertex base
+        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(4, objectIndex), 0));"); // chipmunk
+
+        src.push("int h_index = polygonIndex & 1023;")
+        src.push("int v_index = polygonIndex >> 10;")
+
+        src.push("ivec3 vertexIndices = ivec3(texelFetch(uTexturePerPolygonIdIndices, ivec2(h_index, v_index), 0));");
+        src.push("ivec3 uniqueVertexIndexes = vertexIndices + (packedVertexBase.r << 24) + (packedVertexBase.g << 16) + (packedVertexBase.b << 8) + packedVertexBase.a;")
+        
+        src.push("ivec3 indexPositionH = uniqueVertexIndexes & 1023;")
+        src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 10;")
+
+        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(0, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(1, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(2, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(3, objectIndex), 0));")
+
+        // get flags & flags2
+        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(2, objectIndex), 0);"); // chipmunk
+        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(3, objectIndex), 0);"); // chipmunk
+        
+        // get position
+        src.push("vec3 position1 = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.r, indexPositionV.r), 0));")
+        src.push("vec3 position2 = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.g, indexPositionV.g), 0));")
+        src.push("vec3 position3 = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.b, indexPositionV.b), 0));")
+
+        // get normal
+        src.push("vec3 normal = normalize(cross(position3 - position1, position2 - position1));");
+
+        src.push("int vertexNumber = gl_VertexID % 3;");
+        src.push("vec3 position;");
+        src.push("if (vertexNumber == 0) position = position1;");
+        src.push("else if (vertexNumber == 1) position = position2;");
+        src.push("else position = position3;");
+
+        // flags.w = NOT_RENDERED | PICK
+        // renderPass = PICK
+        src.push(`if (int(flags.w) != renderPass) {`);
+        src.push("      gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
+        src.push("  } else {");
+        src.push("      vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
+        if (scene.entityOffsetsEnabled) {
+            src.push("      worldPosition.xyz = worldPosition.xyz + offset;");
+        }
+        src.push("      vec4 viewPosition  = viewMatrix * worldPosition; ");
+        src.push("      vWorldPosition = worldPosition;");
+        if (clipping) {
+            src.push("      vFlags2 = flags2.r;");
+        }
+        src.push("vec4 clipPos = projMatrix * viewPosition;");
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("vFragDepth = 1.0 + clipPos.w;");
+            src.push("isPerspective = float (isPerspectiveMatrix(projMatrix));");
+        }
+        src.push("gl_Position = clipPos;");
+        src.push("  }");
+        src.push("}");
+        return src;
+    }
+
+    _buildFragmentShader() {
+        const scene = this._scene;
+        const sectionPlanesState = scene._sectionPlanesState;
+        const clipping = sectionPlanesState.sectionPlanes.length > 0;
+        const src = [];
+        src.push ('#version 300 es');
+        src.push("// Triangles dataTexture pick flat normals fragment shader");
+        src.push("#extension GL_OES_standard_derivatives : enable");
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("#extension GL_EXT_frag_depth : enable");
+        }
+        src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
+        src.push("precision highp float;");
+        src.push("precision highp int;");
+        src.push("#else");
+        src.push("precision mediump float;");
+        src.push("precision mediump int;");
+        src.push("#endif");
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("in float isPerspective;");
+            src.push("uniform float logDepthBufFC;");
+            src.push("in float vFragDepth;");
+        }
+        src.push("in vec4 vWorldPosition;");
+        if (clipping) {
+            src.push("in int vFlags2;");
+            for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
+                src.push("uniform bool sectionPlaneActive" + i + ";");
+                src.push("uniform vec3 sectionPlanePos" + i + ";");
+                src.push("uniform vec3 sectionPlaneDir" + i + ";");
+            }
+        }
+        src.push("out vec4 outNormal;");
+        src.push("void main(void) {");
+        if (clipping) {
+            src.push("  bool clippable = vFlags2 > 0;");
+            src.push("  if (clippable) {");
+            src.push("      float dist = 0.0;");
+            for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
+                src.push("      if (sectionPlaneActive" + i + ") {");
+                src.push("          dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
+                src.push("      }");
+            }
+            src.push("      if (dist > 0.0) { discard; }");
+            src.push("  }");
+        }
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("    gl_FragDepth = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;");
+        }
+        src.push("  vec3 xTangent = dFdx( vWorldPosition.xyz );");
+        src.push("  vec3 yTangent = dFdy( vWorldPosition.xyz );");
+        src.push("  vec3 worldNormal = normalize( cross( xTangent, yTangent ) );");
+        src.push("  outNormal = vec4((worldNormal * 0.5) + 0.5, 1.0);");
+        src.push("}");
+        return src;
+    }
+
+    webglContextRestored() {
+        this._program = null;
+    }
+
+    destroy() {
+        if (this._program) {
+            this._program.destroy();
+        }
+        this._program = null;
+    }
+}
+
+export {TrianglesDataTexturePickNormalsFlatRenderer};

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsFlatRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsFlatRenderer.js
@@ -355,15 +355,15 @@ class TrianglesDataTexturePickNormalsFlatRenderer {
         src.push("void main(void) {");
 
         // constants
-        // src.push("int objectIndex = int(packedVertexId.g) & 1023;");
+        // src.push("int objectIndex = int(packedVertexId.g) & 4095;");
         src.push("int polygonIndex = gl_VertexID / 3;")
 
-        src.push("int h_normal_index = polygonIndex & 1023;")
-        src.push("int v_normal_index = polygonIndex >> 10;")
+        src.push("int h_normal_index = polygonIndex & 4095;")
+        src.push("int v_normal_index = polygonIndex >> 12;")
 
         // get packed object-id
-        src.push("int h_packed_object_id_index = ((polygonIndex >> 3) / 2) & 1023;")
-        src.push("int v_packed_object_id_index = ((polygonIndex >> 3) / 2) >> 10;")
+        src.push("int h_packed_object_id_index = ((polygonIndex >> 3) / 2) & 4095;")
+        src.push("int v_packed_object_id_index = ((polygonIndex >> 3) / 2) >> 12;")
 
         src.push("ivec3 packedObjectId = ivec3(texelFetch(uTexturePerPolygonIdPortionIds, ivec2(h_packed_object_id_index, v_packed_object_id_index), 0).rgb);");
 
@@ -377,14 +377,14 @@ class TrianglesDataTexturePickNormalsFlatRenderer {
         // get vertex base
         src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(4, objectIndex), 0));"); // chipmunk
 
-        src.push("int h_index = polygonIndex & 1023;")
-        src.push("int v_index = polygonIndex >> 10;")
+        src.push("int h_index = polygonIndex & 4095;")
+        src.push("int v_index = polygonIndex >> 12;")
 
         src.push("ivec3 vertexIndices = ivec3(texelFetch(uTexturePerPolygonIdIndices, ivec2(h_index, v_index), 0));");
         src.push("ivec3 uniqueVertexIndexes = vertexIndices + (packedVertexBase.r << 24) + (packedVertexBase.g << 16) + (packedVertexBase.b << 8) + packedVertexBase.a;")
         
-        src.push("ivec3 indexPositionH = uniqueVertexIndexes & 1023;")
-        src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 10;")
+        src.push("ivec3 indexPositionH = uniqueVertexIndexes & 4095;")
+        src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 12;")
 
         src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(0, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(1, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(2, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(3, objectIndex), 0));")
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsFlatRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsFlatRenderer.js
@@ -387,7 +387,7 @@ class TrianglesDataTexturePickNormalsFlatRenderer {
         src.push("ivec3 indexPositionH = uniqueVertexIndexes & 4095;")
         src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 12;")
 
-        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(0, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(1, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(2, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(3, objectIndex), 0));")
+        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+2, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+3, objectIndexCoords.y), 0));")
 
         // get flags & flags2
         src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+2, objectIndexCoords.y), 0);"); // chipmunk

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsFlatRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsFlatRenderer.js
@@ -373,9 +373,10 @@ class TrianglesDataTexturePickNormalsFlatRenderer {
         src.push("} else {") 
         src.push("  objectIndex = ((packedObjectId.g & 15) << 8) + packedObjectId.b;")
         src.push("}")
+        src.push("ivec2 objectIndexCoords = ivec2(objectIndex % 512, objectIndex / 512);");
 
         // get vertex base
-        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(4, objectIndex), 0));"); // chipmunk
+        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+4, objectIndexCoords.y), 0));"); // chipmunk // chipmunk
 
         src.push("int h_index = polygonIndex & 4095;")
         src.push("int v_index = polygonIndex >> 12;")
@@ -389,8 +390,8 @@ class TrianglesDataTexturePickNormalsFlatRenderer {
         src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(0, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(1, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(2, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(3, objectIndex), 0));")
 
         // get flags & flags2
-        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(2, objectIndex), 0);"); // chipmunk
-        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(3, objectIndex), 0);"); // chipmunk
+        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+2, objectIndexCoords.y), 0);"); // chipmunk
+        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+3, objectIndexCoords.y), 0);"); // chipmunk
         
         // get position
         src.push("vec3 position1 = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.r, indexPositionV.r), 0));")

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsFlatRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsFlatRenderer.js
@@ -376,7 +376,7 @@ class TrianglesDataTexturePickNormalsFlatRenderer {
         src.push("ivec2 objectIndexCoords = ivec2(objectIndex % 512, objectIndex / 512);");
 
         // get vertex base
-        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+4, objectIndexCoords.y), 0));"); // chipmunk // chipmunk
+        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+4, objectIndexCoords.y), 0));"); // chipmunk // chipmunk
 
         src.push("int h_index = polygonIndex & 4095;")
         src.push("int v_index = polygonIndex >> 12;")
@@ -390,8 +390,8 @@ class TrianglesDataTexturePickNormalsFlatRenderer {
         src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+2, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+3, objectIndexCoords.y), 0));")
 
         // get flags & flags2
-        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+2, objectIndexCoords.y), 0);"); // chipmunk
-        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+3, objectIndexCoords.y), 0);"); // chipmunk
+        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+2, objectIndexCoords.y), 0);"); // chipmunk
+        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+3, objectIndexCoords.y), 0);"); // chipmunk
         
         // get position
         src.push("vec3 position1 = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.r, indexPositionV.r), 0));")

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
@@ -291,7 +291,7 @@ class TrianglesDataTexturePickNormalsRenderer {
         src.push("positions[2] = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.b, indexPositionV.b), 0));")
 
         // get normal
-        src.push("vec3 normal = normalize(cross(positions[2] - positions[0], positions[1] - positions[0]));");
+        src.push("vec3 normal = -normalize(cross(positions[2] - positions[0], positions[1] - positions[0]));");
 
         src.push("vec3 position = positions[gl_VertexID % 3];");
         

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
@@ -306,7 +306,7 @@ class TrianglesDataTexturePickNormalsRenderer {
 
         src.push("mat4 entityNormalMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(8, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(9, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(10, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(11, objectIndex), 0));")
 
-        src.push("vec4 worldNormal =  worldNormalMatrix * (vec4(normal, 1) * entityNormalMatrix); ");
+        src.push("vec4 worldNormal = entityNormalMatrix * worldNormalMatrix * vec4(normal, 1); ");
 
         src.push("vWorldNormal = worldNormal.xyz;");
         src.push("vec4 clipPos = projMatrix * viewPosition;");

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
@@ -1,7 +1,6 @@
-import {Program} from "../../../../../webgl/Program.js";
-import {createRTCViewMat, getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
-import {math} from "../../../../../math/math.js";
-import {WEBGL_INFO} from "../../../../../webglInfo.js";
+import {Program} from "../../../../../../webgl/Program.js";
+import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
+import {math} from "../../../../../../math/math.js";
 
 const tempVec3a = math.vec3();
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
@@ -49,7 +49,8 @@ class TrianglesDataTexturePickNormalsRenderer {
             this._uTexturePerVertexIdCoordinates, 
             this._uTexturePerObjectIdColorsAndFlags, 
             this._uTextureCameraMatrices, 
-            this._uTextureModelMatrices, 
+            this._uTextureModelMatrices,
+            this._uTexturePerObjectIdOffsets
         );
 
         gl.uniform1i(this._uRenderPass, renderPass);
@@ -162,6 +163,7 @@ class TrianglesDataTexturePickNormalsRenderer {
         this._uTexturePerPolygonIdPortionIds = "uTexturePerPolygonIdPortionIds"; // chipmunk
         this._uTextureCameraMatrices = "uTextureCameraMatrices"; // chipmunk
         this._uTextureModelMatrices = "uTextureModelMatrices"; // chipmunk
+        this._uTexturePerObjectIdOffsets = "uTexturePerObjectIdOffsets"; // chipmunk
     }
 
     _bindProgram() {
@@ -205,6 +207,7 @@ class TrianglesDataTexturePickNormalsRenderer {
         src.push("uniform bool pickInvisible;");
         src.push("uniform mediump sampler2D uTexturePerObjectIdPositionsDecodeMatrix;"); // chipmunk
         src.push("uniform lowp usampler2D uTexturePerObjectIdColorsAndFlags;"); // chipmunk
+        src.push("uniform highp sampler2D uTexturePerObjectIdOffsets;"); // chipmunk
         src.push("uniform mediump usampler2D uTexturePerVertexIdCoordinates;"); // chipmunk
         src.push("uniform highp usampler2D uTexturePerPolygonIdIndices;"); // chipmunk
         src.push("uniform mediump usampler2D uTexturePerPolygonIdPortionIds;"); // chipmunk
@@ -294,9 +297,10 @@ class TrianglesDataTexturePickNormalsRenderer {
         
         src.push("vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
 
-        if (scene.entityOffsetsEnabled) {
-            src.push("worldPosition.xyz = worldPosition.xyz + offset;");
-        }
+        // get XYZ offset
+        src.push("vec3 offset = texelFetch (uTexturePerObjectIdOffsets, ivec2(0, objectIndex), 0).rgb;");
+
+        src.push("worldPosition.xyz = worldPosition.xyz + offset;");
 
         src.push("vec4 viewPosition = viewMatrix * worldPosition; ");
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
@@ -205,7 +205,7 @@ class TrianglesDataTexturePickNormalsRenderer {
         }
 
         src.push("uniform bool pickInvisible;");
-        src.push("uniform mediump sampler2D uTexturePerObjectIdPositionsDecodeMatrix;"); // chipmunk
+        src.push("uniform highp sampler2D uTexturePerObjectIdPositionsDecodeMatrix;"); // chipmunk
         src.push("uniform lowp usampler2D uTexturePerObjectIdColorsAndFlags;"); // chipmunk
         src.push("uniform highp sampler2D uTexturePerObjectIdOffsets;"); // chipmunk
         src.push("uniform mediump usampler2D uTexturePerVertexIdCoordinates;"); // chipmunk

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
@@ -1,0 +1,391 @@
+import {Program} from "../../../../../webgl/Program.js";
+import {createRTCViewMat, getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
+import {math} from "../../../../../math/math.js";
+import {WEBGL_INFO} from "../../../../../webglInfo.js";
+
+const tempVec3a = math.vec3();
+
+/**
+ * @private
+ */
+class TrianglesDataTexturePickNormalsRenderer {
+
+    constructor(scene) {
+        this._scene = scene;
+        this._hash = this._getHash();
+        this._allocate();
+    }
+
+    getValid() {
+        return this._hash === this._getHash();
+    };
+
+    _getHash() {
+        return this._scene._sectionPlanesState.getHash();
+    }
+
+    drawLayer(frameCtx, dataTextureLayer, renderPass) {
+
+        const model = dataTextureLayer.model;
+        const scene = model.scene;
+        const camera = scene.camera;
+        const gl = scene.canvas.gl;
+        const state = dataTextureLayer._state;
+        const textureState = state.textureState;
+        const origin = dataTextureLayer._state.origin;
+
+        if (!this._program) {
+            this._allocate(dataTextureLayer);
+        }
+
+        if (frameCtx.lastProgramId !== this._program.id) {
+            frameCtx.lastProgramId = this._program.id;
+            this._bindProgram();
+        }
+        
+        textureState.bindCommonTextures (
+            this._program,
+            this._uTexturePerObjectIdPositionsDecodeMatrix, 
+            this._uTexturePerVertexIdCoordinates, 
+            this._uTexturePerObjectIdColorsAndFlags, 
+            this._uTextureCameraMatrices, 
+            this._uTextureModelMatrices, 
+        );
+
+        gl.uniform1i(this._uRenderPass, renderPass);
+        gl.uniform1i(this._uPickInvisible, frameCtx.pickInvisible);
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            const logDepthBufFC = 2.0 / (Math.log(camera.project.far + 1.0) / Math.LN2);  // TODO: Far should be from projection matrix?
+            gl.uniform1f(this._uLogDepthBufFC, logDepthBufFC);
+        }
+
+        const numSectionPlanes = scene._sectionPlanesState.sectionPlanes.length;
+        if (numSectionPlanes > 0) {
+            const sectionPlanes = scene._sectionPlanesState.sectionPlanes;
+            const baseIndex = dataTextureLayer.layerIndex * numSectionPlanes;
+            const renderFlags = model.renderFlags;
+            for (let sectionPlaneIndex = 0; sectionPlaneIndex < numSectionPlanes; sectionPlaneIndex++) {
+                const sectionPlaneUniforms = this._uSectionPlanes[sectionPlaneIndex];
+                if (sectionPlaneUniforms) {
+                    const active = renderFlags.sectionPlanesActivePerLayer[baseIndex + sectionPlaneIndex];
+                    gl.uniform1i(sectionPlaneUniforms.active, active ? 1 : 0);
+                    if (active) {
+                        const sectionPlane = sectionPlanes[sectionPlaneIndex];
+                        if (origin) {
+                            const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a);
+                            gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
+                        } else {
+                            gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);
+                        }
+                        gl.uniform3fv(sectionPlaneUniforms.dir, sectionPlane.dir);
+                    }
+                }
+            }
+        }
+
+        if (state.numIndices8Bits > 0)
+        {
+            textureState.bindTriangleIndicesTextures(
+                this._program,
+                this._uTexturePerPolygonIdPortionIds, 
+                this._uTexturePerPolygonIdIndices, 
+                8 // 8 bits indices
+            );
+
+            gl.drawArrays(gl.TRIANGLES, 0, state.numIndices8Bits);
+        }
+
+        if (state.numIndices16Bits > 0)
+        {
+            textureState.bindTriangleIndicesTextures(
+                this._program,
+                this._uTexturePerPolygonIdPortionIds, 
+                this._uTexturePerPolygonIdIndices, 
+                16 // 16 bits indices
+            );
+
+            gl.drawArrays(gl.TRIANGLES, 0, state.numIndices16Bits);
+        }
+        
+        if (state.numIndices32Bits > 0)
+        {
+            textureState.bindTriangleIndicesTextures(
+                this._program,
+                this._uTexturePerPolygonIdPortionIds, 
+                this._uTexturePerPolygonIdIndices, 
+                32 // 32 bits indices
+            );
+
+            gl.drawArrays(gl.TRIANGLES, 0, state.numIndices32Bits);
+        }
+
+        frameCtx.drawElements++;
+    }
+
+    _allocate() {
+
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+
+        this._program = new Program(gl, this._buildShader());
+
+        if (this._program.errors) {
+            this.errors = this._program.errors;
+            return;
+        }
+
+        const program = this._program;
+
+        this._uRenderPass = program.getLocation("renderPass");
+        this._uPickInvisible = program.getLocation("pickInvisible");
+
+        this._uSectionPlanes = [];
+
+        for (let i = 0, len = scene._sectionPlanesState.sectionPlanes.length; i < len; i++) {
+            this._uSectionPlanes.push({
+                active: program.getLocation("sectionPlaneActive" + i),
+                pos: program.getLocation("sectionPlanePos" + i),
+                dir: program.getLocation("sectionPlaneDir" + i)
+            });
+        }
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            this._uLogDepthBufFC = program.getLocation("logDepthBufFC");
+        }
+
+        this._uTexturePerObjectIdPositionsDecodeMatrix = "uTexturePerObjectIdPositionsDecodeMatrix"; // chipmunk
+        this._uTexturePerObjectIdColorsAndFlags = "uTexturePerObjectIdColorsAndFlags"; // chipmunk
+        this._uTexturePerVertexIdCoordinates = "uTexturePerVertexIdCoordinates"; // chipmunk
+        this._uTexturePerPolygonIdNormals = "uTexturePerPolygonIdNormals"; // chipmunk
+        this._uTexturePerPolygonIdIndices = "uTexturePerPolygonIdIndices"; // chipmunk
+        this._uTexturePerPolygonIdPortionIds = "uTexturePerPolygonIdPortionIds"; // chipmunk
+        this._uTextureCameraMatrices = "uTextureCameraMatrices"; // chipmunk
+        this._uTextureModelMatrices = "uTextureModelMatrices"; // chipmunk
+    }
+
+    _bindProgram() {
+        this._program.bind();
+    }
+
+    _buildShader() {
+        return {
+            vertex: this._buildVertexShader(),
+            fragment: this._buildFragmentShader()
+        };
+    }
+
+    _buildVertexShader() {
+        const scene = this._scene;
+        const clipping = scene._sectionPlanesState.sectionPlanes.length > 0;
+        const src = [];
+        src.push("#version 300 es");
+        src.push("// Triangles dataTexture pick normals vertex shader");
+
+        src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
+        src.push("precision highp float;");
+        src.push("precision highp int;");
+        src.push("precision highp usampler2D;");
+        src.push("precision highp isampler2D;");
+        src.push("precision highp sampler2D;");
+        src.push("#else");
+        src.push("precision mediump float;");
+        src.push("precision mediump int;");
+        src.push("precision mediump usampler2D;");
+        src.push("precision mediump isampler2D;");
+        src.push("precision mediump sampler2D;");
+        src.push("#endif");
+
+        src.push("uniform int renderPass;");
+
+        if (scene.entityOffsetsEnabled) {
+            src.push("in vec3 offset;");
+        }
+
+        src.push("uniform bool pickInvisible;");
+        src.push("uniform mediump sampler2D uTexturePerObjectIdPositionsDecodeMatrix;"); // chipmunk
+        src.push("uniform lowp usampler2D uTexturePerObjectIdColorsAndFlags;"); // chipmunk
+        src.push("uniform mediump usampler2D uTexturePerVertexIdCoordinates;"); // chipmunk
+        src.push("uniform highp usampler2D uTexturePerPolygonIdIndices;"); // chipmunk
+        src.push("uniform mediump usampler2D uTexturePerPolygonIdPortionIds;"); // chipmunk
+        src.push("uniform highp sampler2D uTextureCameraMatrices;"); // chipmunk
+        src.push("uniform highp sampler2D uTextureModelMatrices;"); // chipmunk
+
+        src.push("vec3 positions[3];")
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("uniform float logDepthBufFC;");
+            src.push("out float vFragDepth;");
+            src.push("bool isPerspectiveMatrix(mat4 m) {");
+            src.push("    return (m[2][3] == - 1.0);");
+            src.push("}");
+            src.push("out float isPerspective;");
+        }
+
+        if (clipping) {
+            src.push("out vec4 vWorldPosition;");
+            src.push("out int vFlags2;");
+        }
+
+        src.push("out vec3 vWorldNormal;");
+
+        src.push("void main(void) {");
+
+        // camera matrices
+        src.push ("mat4 viewMatrix = mat4 (texelFetch (uTextureCameraMatrices, ivec2(0, 0), 0), texelFetch (uTextureCameraMatrices, ivec2(1, 0), 0), texelFetch (uTextureCameraMatrices, ivec2(2, 0), 0), texelFetch (uTextureCameraMatrices, ivec2(3, 0), 0));");
+        src.push ("mat4 viewNormalMatrix = mat4 (texelFetch (uTextureCameraMatrices, ivec2(0, 1), 0), texelFetch (uTextureCameraMatrices, ivec2(1, 1), 0), texelFetch (uTextureCameraMatrices, ivec2(2, 1), 0), texelFetch (uTextureCameraMatrices, ivec2(3, 1), 0));");
+        src.push ("mat4 projMatrix = mat4 (texelFetch (uTextureCameraMatrices, ivec2(0, 2), 0), texelFetch (uTextureCameraMatrices, ivec2(1, 2), 0), texelFetch (uTextureCameraMatrices, ivec2(2, 2), 0), texelFetch (uTextureCameraMatrices, ivec2(3, 2), 0));");
+
+        // model matrices
+        src.push ("mat4 worldMatrix = mat4 (texelFetch (uTextureModelMatrices, ivec2(0, 0), 0), texelFetch (uTextureModelMatrices, ivec2(1, 0), 0), texelFetch (uTextureModelMatrices, ivec2(2, 0), 0), texelFetch (uTextureModelMatrices, ivec2(3, 0), 0));");
+        src.push ("mat4 worldNormalMatrix = mat4 (texelFetch (uTextureModelMatrices, ivec2(0, 1), 0), texelFetch (uTextureModelMatrices, ivec2(1, 1), 0), texelFetch (uTextureModelMatrices, ivec2(2, 1), 0), texelFetch (uTextureModelMatrices, ivec2(3, 1), 0));");
+
+        // constants
+        src.push("int polygonIndex = gl_VertexID / 3;")
+
+        // get packed object-id
+        src.push("int h_packed_object_id_index = (polygonIndex >> 3) & 1023;")
+        src.push("int v_packed_object_id_index = (polygonIndex >> 3) >> 10;")
+
+        src.push("int objectIndex = int(texelFetch(uTexturePerPolygonIdPortionIds, ivec2(h_packed_object_id_index, v_packed_object_id_index), 0).r);");
+
+        // get flags & flags2
+        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(2, objectIndex), 0);"); // chipmunk
+        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(3, objectIndex), 0);"); // chipmunk
+        
+        // flags.w = NOT_RENDERED | PICK
+        // renderPass = PICK
+
+        src.push(`if (int(flags.w) != renderPass) {`);
+        src.push("   gl_Position = vec4(3.0, 3.0, 3.0, 1.0);"); // Cull vertex
+        src.push("   return;"); // Cull vertex
+        src.push("} else {");
+
+        // get vertex base
+        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(4, objectIndex), 0));");
+
+        src.push("ivec4 packedIndexBaseOffset = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(5, objectIndex), 0));");
+
+        src.push("int indexBaseOffset = (packedIndexBaseOffset.r << 24) + (packedIndexBaseOffset.g << 16) + (packedIndexBaseOffset.b << 8) + packedIndexBaseOffset.a;");
+
+        src.push("int h_index = (polygonIndex - indexBaseOffset) & 1023;")
+        src.push("int v_index = (polygonIndex - indexBaseOffset) >> 10;")
+
+        src.push("ivec3 vertexIndices = ivec3(texelFetch(uTexturePerPolygonIdIndices, ivec2(h_index, v_index), 0));");
+        src.push("ivec3 uniqueVertexIndexes = vertexIndices + (packedVertexBase.r << 24) + (packedVertexBase.g << 16) + (packedVertexBase.b << 8) + packedVertexBase.a;")
+        
+        src.push("ivec3 indexPositionH = uniqueVertexIndexes & 1023;")
+        src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 10;")
+
+        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(0, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(1, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(2, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(3, objectIndex), 0));")
+        src.push("mat4 entityMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(4, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(5, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(6, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(7, objectIndex), 0));")
+
+        src.push("positionsDecodeMatrix = entityMatrix * positionsDecodeMatrix;")
+        
+        // get position
+        src.push("positions[0] = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.r, indexPositionV.r), 0));")
+        src.push("positions[1] = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.g, indexPositionV.g), 0));")
+        src.push("positions[2] = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.b, indexPositionV.b), 0));")
+
+        // get normal
+        src.push("vec3 normal = normalize(cross(positions[2] - positions[0], positions[1] - positions[0]));");
+
+        src.push("vec3 position = positions[gl_VertexID % 3];");
+        
+        src.push("vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
+
+        if (scene.entityOffsetsEnabled) {
+            src.push("worldPosition.xyz = worldPosition.xyz + offset;");
+        }
+
+        src.push("vec4 viewPosition = viewMatrix * worldPosition; ");
+
+        src.push("mat4 entityNormalMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(8, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(9, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(10, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(11, objectIndex), 0));")
+
+        src.push("vec4 worldNormal =  worldNormalMatrix * (vec4(normal, 1) * entityNormalMatrix); ");
+
+        src.push("vWorldNormal = worldNormal.xyz;");
+        src.push("vec4 clipPos = projMatrix * viewPosition;");
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("vFragDepth = 1.0 + clipPos.w;");
+            src.push("isPerspective = float (isPerspectiveMatrix(projMatrix));");
+        }
+        if (clipping) {
+            src.push("      vWorldPosition = worldPosition;");
+            src.push("      vFlags2 = flags2.w;");
+        }
+        src.push("gl_Position = clipPos;");
+        src.push("}");
+
+        src.push("}");
+
+        return src;
+    }
+
+    _buildFragmentShader() {
+        const scene = this._scene;
+        const sectionPlanesState = scene._sectionPlanesState;
+        const clipping = sectionPlanesState.sectionPlanes.length > 0;
+        const src = [];
+        src.push ('#version 300 es');
+        src.push("// Triangles dataTexture pick normals fragment shader");
+        src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
+        src.push("precision highp float;");
+        src.push("precision highp int;");
+        src.push("#else");
+        src.push("precision mediump float;");
+        src.push("precision mediump int;");
+        src.push("#endif");
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("in float isPerspective;");
+            src.push("uniform float logDepthBufFC;");
+            src.push("in float vFragDepth;");
+        }
+        if (clipping) {
+            src.push("varying vec4 vWorldPosition;");
+            src.push("varying vec4 vFlags2;");
+            for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
+                src.push("uniform bool sectionPlaneActive" + i + ";");
+                src.push("uniform vec3 sectionPlanePos" + i + ";");
+                src.push("uniform vec3 sectionPlaneDir" + i + ";");
+            }
+        }
+        src.push("in vec3 vWorldNormal;");
+        src.push("out vec4 outNormal;");
+        src.push("void main(void) {");
+        if (clipping) {
+            src.push("  bool clippable = (vFlags2 > 0.0);");
+            src.push("  if (clippable) {");
+            src.push("      float dist = 0.0;");
+            for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
+                src.push("      if (sectionPlaneActive" + i + ") {");
+                src.push("          dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
+                src.push("      }");
+            }
+            src.push("      if (dist > 0.0) { discard; }");
+            src.push("  }");
+        }
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            // src.push("    gl_FragDepth = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;");
+            src.push("    gl_FragDepth = log2( vFragDepth ) * logDepthBufFC * 0.5;");
+        }
+        src.push("    outNormal = vec4((vWorldNormal * 0.5) + 0.5, 1.0);");
+        src.push("}");
+        return src;
+    }
+
+    webglContextRestored() {
+        this._program = null;
+    }
+
+    destroy() {
+        if (this._program) {
+            this._program.destroy();
+        }
+        this._program = null;
+    }
+}
+
+export {TrianglesDataTexturePickNormalsRenderer};

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
@@ -250,7 +250,7 @@ class TrianglesDataTexturePickNormalsRenderer {
 
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out int vFlags2;");
+            src.push("flat out uint vFlags2;");
         }
 
         src.push("out vec3 vWorldNormal;");
@@ -390,8 +390,8 @@ class TrianglesDataTexturePickNormalsRenderer {
             src.push("in float vFragDepth;");
         }
         if (clipping) {
-            src.push("varying vec4 vWorldPosition;");
-            src.push("varying vec4 vFlags2;");
+            src.push("in vec4 vWorldPosition;");
+            src.push("flat in uint vFlags2;");
             for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -402,7 +402,7 @@ class TrianglesDataTexturePickNormalsRenderer {
         src.push("out vec4 outNormal;");
         src.push("void main(void) {");
         if (clipping) {
-            src.push("  bool clippable = (vFlags2 > 0.0);");
+            src.push("  bool clippable = vFlags2 > 0u;");
             src.push("  if (clippable) {");
             src.push("      float dist = 0.0;");
             for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
@@ -244,8 +244,8 @@ class TrianglesDataTexturePickNormalsRenderer {
         src.push("int polygonIndex = gl_VertexID / 3;")
 
         // get packed object-id
-        src.push("int h_packed_object_id_index = (polygonIndex >> 3) & 1023;")
-        src.push("int v_packed_object_id_index = (polygonIndex >> 3) >> 10;")
+        src.push("int h_packed_object_id_index = (polygonIndex >> 3) & 4095;")
+        src.push("int v_packed_object_id_index = (polygonIndex >> 3) >> 12;")
 
         src.push("int objectIndex = int(texelFetch(uTexturePerPolygonIdPortionIds, ivec2(h_packed_object_id_index, v_packed_object_id_index), 0).r);");
 
@@ -268,14 +268,14 @@ class TrianglesDataTexturePickNormalsRenderer {
 
         src.push("int indexBaseOffset = (packedIndexBaseOffset.r << 24) + (packedIndexBaseOffset.g << 16) + (packedIndexBaseOffset.b << 8) + packedIndexBaseOffset.a;");
 
-        src.push("int h_index = (polygonIndex - indexBaseOffset) & 1023;")
-        src.push("int v_index = (polygonIndex - indexBaseOffset) >> 10;")
+        src.push("int h_index = (polygonIndex - indexBaseOffset) & 4095;")
+        src.push("int v_index = (polygonIndex - indexBaseOffset) >> 12;")
 
         src.push("ivec3 vertexIndices = ivec3(texelFetch(uTexturePerPolygonIdIndices, ivec2(h_index, v_index), 0));");
         src.push("ivec3 uniqueVertexIndexes = vertexIndices + (packedVertexBase.r << 24) + (packedVertexBase.g << 16) + (packedVertexBase.b << 8) + packedVertexBase.a;")
         
-        src.push("ivec3 indexPositionH = uniqueVertexIndexes & 1023;")
-        src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 10;")
+        src.push("ivec3 indexPositionH = uniqueVertexIndexes & 4095;")
+        src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 12;")
 
         src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(0, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(1, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(2, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(3, objectIndex), 0));")
         src.push("mat4 entityMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(4, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(5, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(6, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(7, objectIndex), 0));")

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
@@ -278,8 +278,8 @@ class TrianglesDataTexturePickNormalsRenderer {
         src.push("ivec3 indexPositionH = uniqueVertexIndexes & 4095;")
         src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 12;")
 
-        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(0, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(1, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(2, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(3, objectIndex), 0));")
-        src.push("mat4 entityMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(4, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(5, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(6, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(7, objectIndex), 0));")
+        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+2, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+3, objectIndexCoords.y), 0));")
+        src.push("mat4 entityMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+4, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+5, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+6, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*8+7, objectIndexCoords.y), 0));")
 
         src.push("positionsDecodeMatrix = entityMatrix * positionsDecodeMatrix;")
         

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
@@ -305,20 +305,17 @@ class TrianglesDataTexturePickNormalsRenderer {
         src.push("vec3 normal = normalize(cross(positions[2] - positions[0], positions[1] - positions[0]));");
 
 
-        // when the geometry is not solid, if needed, flip the triangle winding
         src.push("vec3 position;");
+        src.push("position = positions[gl_VertexID % 3];");
 
+        // when the geometry is not solid, if needed, flip the triangle winding
         src.push("if (solid != 1u) {");
-            src.push("vec3 triangleCenter = (worldMatrix*positionsDecodeMatrix*vec4((positions[0] + positions[1] + positions[2]) / 3.0, 1)).xyz;")
-            src.push("vec3 worldNormal = normalize((transpose(inverse(worldMatrix*positionsDecodeMatrix)) * vec4(normal, 1)).xyz);");
-            src.push("vec3 cameraToTriangleDirection = normalize(triangleCenter - uCameraEyeRtc);")
-            src.push("if (dot(cameraToTriangleDirection, worldNormal) < 0.0) {");
-                src.push("position = positions[2 - (gl_VertexID % 3)];");
-            src.push("} else {");
-                src.push("position = positions[gl_VertexID % 3];");
+            src.push("vec3 uCameraEyeRtcInQuantizedSpace = (inverse(worldMatrix * positionsDecodeMatrix) * vec4(uCameraEyeRtc, 1)).xyz;")
+
+            src.push("if (dot(position.xyz - uCameraEyeRtcInQuantizedSpace, normal) < 0.0) {");
+            src.push("position = positions[2 - (gl_VertexID % 3)];");
+            src.push("normal = -normal;");
             src.push("}");
-        src.push("} else {")
-                src.push("position = positions[gl_VertexID % 3];");
         src.push("}");
 
         src.push("normal = -normal;");

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
@@ -52,14 +52,26 @@ class TrianglesDataTexturePickNormalsRenderer {
             this._uTexturePerObjectIdOffsets
         );
 
-        gl.uniform1i(this._uRenderPass, renderPass);
+        let cameraEye = camera.eye;
+
+        if (frameCtx.pickViewMatrix) {
+            textureState.bindPickCameraTexture (
+                this._program,
+                this._uTextureCameraMatrices
+            );
+            cameraEye = frameCtx.pickOrigin || cameraEye;
+        }
 
         const originCameraEye = [
-            camera.eye[0] - origin[0],
-            camera.eye[1] - origin[1],
-            camera.eye[2] - origin[2],
+            cameraEye[0] - origin[0],
+            cameraEye[1] - origin[1],
+            cameraEye[2] - origin[2],
         ];
 
+        gl.uniform3fv(this._uCameraEyeRtc, originCameraEye);
+        
+        gl.uniform1i(this._uRenderPass, renderPass);
+        
         gl.uniform3fv(this._uCameraEyeRtc, originCameraEye);
 
         gl.uniform1i(this._uPickInvisible, frameCtx.pickInvisible);
@@ -229,11 +241,12 @@ class TrianglesDataTexturePickNormalsRenderer {
         if (scene.logarithmicDepthBufferEnabled) {
             src.push("uniform float logDepthBufFC;");
             src.push("out float vFragDepth;");
-            src.push("bool isPerspectiveMatrix(mat4 m) {");
-            src.push("    return (m[2][3] == - 1.0);");
-            src.push("}");
             src.push("out float isPerspective;");
         }
+
+        src.push("bool isPerspectiveMatrix(mat4 m) {");
+        src.push("    return (m[2][3] == - 1.0);");
+        src.push("}");
 
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
@@ -310,11 +323,18 @@ class TrianglesDataTexturePickNormalsRenderer {
 
         // when the geometry is not solid, if needed, flip the triangle winding
         src.push("if (solid != 1u) {");
-            src.push("vec3 uCameraEyeRtcInQuantizedSpace = (inverse(worldMatrix * positionsDecodeMatrix) * vec4(uCameraEyeRtc, 1)).xyz;")
-
-            src.push("if (dot(position.xyz - uCameraEyeRtcInQuantizedSpace, normal) < 0.0) {");
-            src.push("position = positions[2 - (gl_VertexID % 3)];");
-            src.push("normal = -normal;");
+            src.push("if (isPerspectiveMatrix(projMatrix)) {");
+                src.push("vec3 uCameraEyeRtcInQuantizedSpace = (inverse(worldMatrix * positionsDecodeMatrix) * vec4(uCameraEyeRtc, 1)).xyz;")
+                src.push("if (dot(position.xyz - uCameraEyeRtcInQuantizedSpace, normal) < 0.0) {");
+                    src.push("position = positions[2 - (gl_VertexID % 3)];");
+                    src.push("normal = -normal;");
+                src.push("}");
+            src.push("} else {");
+                src.push("vec3 viewNormal = -normalize((transpose(inverse(viewMatrix*positionsDecodeMatrix)) * vec4(normal,1)).xyz);");
+                src.push("if (viewNormal.z < 0.0) {");
+                    src.push("position = positions[2 - (gl_VertexID % 3)];");
+                    src.push("normal = -normal;");
+                src.push("}");
             src.push("}");
         src.push("}");
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
@@ -235,12 +235,10 @@ class TrianglesDataTexturePickNormalsRenderer {
 
         // camera matrices
         src.push ("mat4 viewMatrix = mat4 (texelFetch (uTextureCameraMatrices, ivec2(0, 0), 0), texelFetch (uTextureCameraMatrices, ivec2(1, 0), 0), texelFetch (uTextureCameraMatrices, ivec2(2, 0), 0), texelFetch (uTextureCameraMatrices, ivec2(3, 0), 0));");
-        src.push ("mat4 viewNormalMatrix = mat4 (texelFetch (uTextureCameraMatrices, ivec2(0, 1), 0), texelFetch (uTextureCameraMatrices, ivec2(1, 1), 0), texelFetch (uTextureCameraMatrices, ivec2(2, 1), 0), texelFetch (uTextureCameraMatrices, ivec2(3, 1), 0));");
         src.push ("mat4 projMatrix = mat4 (texelFetch (uTextureCameraMatrices, ivec2(0, 2), 0), texelFetch (uTextureCameraMatrices, ivec2(1, 2), 0), texelFetch (uTextureCameraMatrices, ivec2(2, 2), 0), texelFetch (uTextureCameraMatrices, ivec2(3, 2), 0));");
 
         // model matrices
         src.push ("mat4 worldMatrix = mat4 (texelFetch (uTextureModelMatrices, ivec2(0, 0), 0), texelFetch (uTextureModelMatrices, ivec2(1, 0), 0), texelFetch (uTextureModelMatrices, ivec2(2, 0), 0), texelFetch (uTextureModelMatrices, ivec2(3, 0), 0));");
-        src.push ("mat4 worldNormalMatrix = mat4 (texelFetch (uTextureModelMatrices, ivec2(0, 1), 0), texelFetch (uTextureModelMatrices, ivec2(1, 1), 0), texelFetch (uTextureModelMatrices, ivec2(2, 1), 0), texelFetch (uTextureModelMatrices, ivec2(3, 1), 0));");
 
         // constants
         src.push("int polygonIndex = gl_VertexID / 3;")
@@ -303,12 +301,10 @@ class TrianglesDataTexturePickNormalsRenderer {
 
         src.push("vec4 viewPosition = viewMatrix * worldPosition; ");
 
-        src.push("mat4 entityNormalMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(8, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(9, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(10, objectIndex), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(11, objectIndex), 0));")
-
-        src.push("vec4 worldNormal = entityNormalMatrix * worldNormalMatrix * vec4(normal, 1); ");
-
-        src.push("vWorldNormal = worldNormal.xyz;");
+        src.push("vWorldNormal = normal.xyz;");
+        
         src.push("vec4 clipPos = projMatrix * viewPosition;");
+
         if (scene.logarithmicDepthBufferEnabled) {
             src.push("vFragDepth = 1.0 + clipPos.w;");
             src.push("isPerspective = float (isPerspectiveMatrix(projMatrix));");

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
@@ -53,6 +53,15 @@ class TrianglesDataTexturePickNormalsRenderer {
         );
 
         gl.uniform1i(this._uRenderPass, renderPass);
+
+        const originCameraEye = [
+            camera.eye[0] - origin[0],
+            camera.eye[1] - origin[1],
+            camera.eye[2] - origin[2],
+        ];
+
+        gl.uniform3fv(this._uCameraEyeRtc, originCameraEye);
+
         gl.uniform1i(this._uPickInvisible, frameCtx.pickInvisible);
 
         if (scene.logarithmicDepthBufferEnabled) {
@@ -163,6 +172,7 @@ class TrianglesDataTexturePickNormalsRenderer {
         this._uTextureCameraMatrices = "uTextureCameraMatrices"; // chipmunk
         this._uTextureModelMatrices = "uTextureModelMatrices"; // chipmunk
         this._uTexturePerObjectIdOffsets = "uTexturePerObjectIdOffsets"; // chipmunk
+        this._uCameraEyeRtc = program.getLocation("uCameraEyeRtc"); // chipmunk
     }
 
     _bindProgram() {
@@ -212,6 +222,7 @@ class TrianglesDataTexturePickNormalsRenderer {
         src.push("uniform mediump usampler2D uTexturePerPolygonIdPortionIds;"); // chipmunk
         src.push("uniform highp sampler2D uTextureCameraMatrices;"); // chipmunk
         src.push("uniform highp sampler2D uTextureModelMatrices;"); // chipmunk
+        src.push("uniform vec3 uCameraEyeRtc;"); // chipmunk
 
         src.push("vec3 positions[3];")
 
@@ -251,8 +262,8 @@ class TrianglesDataTexturePickNormalsRenderer {
         src.push("ivec2 objectIndexCoords = ivec2(objectIndex % 512, objectIndex / 512);");
 
         // get flags & flags2
-        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+2, objectIndexCoords.y), 0);"); // chipmunk
-        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+3, objectIndexCoords.y), 0);"); // chipmunk
+        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+2, objectIndexCoords.y), 0);"); // chipmunk
+        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+3, objectIndexCoords.y), 0);"); // chipmunk
         
         // flags.w = NOT_RENDERED | PICK
         // renderPass = PICK
@@ -263,9 +274,9 @@ class TrianglesDataTexturePickNormalsRenderer {
         src.push("} else {");
 
         // get vertex base
-        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+4, objectIndexCoords.y), 0));"); // chipmunk
+        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+4, objectIndexCoords.y), 0));"); // chipmunk
 
-        src.push("ivec4 packedIndexBaseOffset = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+5, objectIndexCoords.y), 0));"); // chipmunk
+        src.push("ivec4 packedIndexBaseOffset = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+5, objectIndexCoords.y), 0));"); // chipmunk
 
         src.push("int indexBaseOffset = (packedIndexBaseOffset.r << 24) + (packedIndexBaseOffset.g << 16) + (packedIndexBaseOffset.b << 8) + packedIndexBaseOffset.a;");
 
@@ -283,15 +294,34 @@ class TrianglesDataTexturePickNormalsRenderer {
 
         src.push("positionsDecodeMatrix = entityMatrix * positionsDecodeMatrix;")
         
+        src.push("uint solid = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+7, objectIndexCoords.y), 0).r;"); // chipmunk
+
         // get position
         src.push("positions[0] = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.r, indexPositionV.r), 0));")
         src.push("positions[1] = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.g, indexPositionV.g), 0));")
         src.push("positions[2] = vec3(texelFetch(uTexturePerVertexIdCoordinates, ivec2(indexPositionH.b, indexPositionV.b), 0));")
 
         // get normal
-        src.push("vec3 normal = -normalize(cross(positions[2] - positions[0], positions[1] - positions[0]));");
+        src.push("vec3 normal = normalize(cross(positions[2] - positions[0], positions[1] - positions[0]));");
 
-        src.push("vec3 position = positions[gl_VertexID % 3];");
+
+        // when the geometry is not solid, if needed, flip the triangle winding
+        src.push("vec3 position;");
+
+        src.push("if (solid != 1u) {");
+            src.push("vec3 triangleCenter = (worldMatrix*positionsDecodeMatrix*vec4((positions[0] + positions[1] + positions[2]) / 3.0, 1)).xyz;")
+            src.push("vec3 worldNormal = normalize((transpose(inverse(worldMatrix*positionsDecodeMatrix)) * vec4(normal, 1)).xyz);");
+            src.push("vec3 cameraToTriangleDirection = normalize(triangleCenter - uCameraEyeRtc);")
+            src.push("if (dot(cameraToTriangleDirection, worldNormal) < 0.0) {");
+                src.push("position = positions[2 - (gl_VertexID % 3)];");
+            src.push("} else {");
+                src.push("position = positions[gl_VertexID % 3];");
+            src.push("}");
+        src.push("} else {")
+                src.push("position = positions[gl_VertexID % 3];");
+        src.push("}");
+
+        src.push("normal = -normal;");
         
         src.push("vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
@@ -248,10 +248,11 @@ class TrianglesDataTexturePickNormalsRenderer {
         src.push("int v_packed_object_id_index = (polygonIndex >> 3) >> 12;")
 
         src.push("int objectIndex = int(texelFetch(uTexturePerPolygonIdPortionIds, ivec2(h_packed_object_id_index, v_packed_object_id_index), 0).r);");
+        src.push("ivec2 objectIndexCoords = ivec2(objectIndex % 512, objectIndex / 512);");
 
         // get flags & flags2
-        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(2, objectIndex), 0);"); // chipmunk
-        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(3, objectIndex), 0);"); // chipmunk
+        src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+2, objectIndexCoords.y), 0);"); // chipmunk
+        src.push("uvec4 flags2 = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+3, objectIndexCoords.y), 0);"); // chipmunk
         
         // flags.w = NOT_RENDERED | PICK
         // renderPass = PICK
@@ -262,9 +263,9 @@ class TrianglesDataTexturePickNormalsRenderer {
         src.push("} else {");
 
         // get vertex base
-        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(4, objectIndex), 0));");
+        src.push("ivec4 packedVertexBase = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+4, objectIndexCoords.y), 0));"); // chipmunk
 
-        src.push("ivec4 packedIndexBaseOffset = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(5, objectIndex), 0));");
+        src.push("ivec4 packedIndexBaseOffset = ivec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*7+5, objectIndexCoords.y), 0));"); // chipmunk
 
         src.push("int indexBaseOffset = (packedIndexBaseOffset.r << 24) + (packedIndexBaseOffset.g << 16) + (packedIndexBaseOffset.b << 8) + packedIndexBaseOffset.a;");
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
@@ -296,9 +296,9 @@ class TrianglesDataTexturePickNormalsRenderer {
         src.push("vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
 
         // get XYZ offset
-        src.push("vec3 offset = texelFetch (uTexturePerObjectIdOffsets, ivec2(0, objectIndex), 0).rgb;");
+        src.push("vec4 offset = vec4(texelFetch (uTexturePerObjectIdOffsets, objectIndexCoords, 0).rgb, 0.0);");
 
-        src.push("worldPosition.xyz = worldPosition.xyz + offset;");
+        src.push("worldPosition.xyz = worldPosition.xyz + offset.xyz;");
 
         src.push("vec4 viewPosition = viewMatrix * worldPosition; ");
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureShadowRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureShadowRenderer.js
@@ -1,6 +1,6 @@
-import {Program} from "../../../../../webgl/Program.js";
-import {math} from "../../../../../math/math.js";
-import {getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
+import {Program} from "../../../../../../webgl/Program.js";
+import {math} from "../../../../../../math/math.js";
+import {getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
 
 const tempVec3a = math.vec3();
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureShadowRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureShadowRenderer.js
@@ -1,0 +1,242 @@
+import {Program} from "../../../../../webgl/Program.js";
+import {math} from "../../../../../math/math.js";
+import {getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
+
+const tempVec3a = math.vec3();
+
+/**
+ * Renders DataTextureLayer fragment depths to a shadow map.
+ *
+ * @private
+ */
+class TrianglesDataTextureShadowRenderer {
+
+    constructor(scene) {
+        this._scene = scene;
+        this._hash = this._getHash();
+        this._allocate();
+    }
+
+    getValid() {
+        return this._hash === this._getHash();
+    };
+
+    _getHash() {
+        return this._scene._sectionPlanesState.getHash();
+    }
+
+    drawLayer(frameCtx, dataTextureLayer) {
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+        const state = dataTextureLayer._state;
+        if (!this._program) {
+            this._allocate();
+        }
+        if (frameCtx.lastProgramId !== this._program.id) {
+            frameCtx.lastProgramId = this._program.id;
+            this._bindProgram(frameCtx);
+        }
+        gl.uniformMatrix4fv(this._uPositionsDecodeMatrix, false, dataTextureLayer._state.positionsDecodeMatrix);
+        if (scene.logarithmicDepthBufferEnabled) {
+            gl.uniform1f(this._uZFar, scene.camera.project.far)
+        }
+        this._aPosition.bindArrayBuffer(state.positionsBuf);
+        if (this._aColor) { // Needed for masking out transparent entities using alpha channel
+            this._aColor.bindArrayBuffer(state.colorsBuf);
+        }
+        if (this._aFlags) {
+            this._aFlags.bindArrayBuffer(state.flagsBuf);
+        }
+        if (this._aFlags2) {
+            this._aFlags2.bindArrayBuffer(state.flags2Buf);
+        }
+        if (this._aOffset) {
+            this._aOffset.bindArrayBuffer(state.offsetsBuf);
+        }
+        state.indicesBuf.bind();
+
+        // TODO: Section planes need to be set if RTC center has changed since last RTC center recorded on frameCtx
+
+        const numSectionPlanes = scene._sectionPlanesState.sectionPlanes.length;
+        if (numSectionPlanes > 0) {
+            const sectionPlanes = scene._sectionPlanesState.sectionPlanes;
+            const baseIndex = dataTextureLayer.layerIndex * numSectionPlanes;
+            const renderFlags = model.renderFlags;
+            const origin = dataTextureLayer._state.origin;
+            for (let sectionPlaneIndex = 0; sectionPlaneIndex < numSectionPlanes; sectionPlaneIndex++) {
+                const sectionPlaneUniforms = this._uSectionPlanes[sectionPlaneIndex];
+                if (sectionPlaneUniforms) {
+                    const active = renderFlags.sectionPlanesActivePerLayer[baseIndex + sectionPlaneIndex];
+                    gl.uniform1i(sectionPlaneUniforms.active, active ? 1 : 0);
+                    if (active) {
+                        const sectionPlane = sectionPlanes[sectionPlaneIndex];
+                        if (origin) {
+                            const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a);
+                            gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
+                        } else {
+                            gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);
+                        }
+                        gl.uniform3fv(sectionPlaneUniforms.dir, sectionPlane.dir);
+                    }
+                }
+            }
+        }
+
+        gl.drawElements(gl.TRIANGLES, state.indicesBuf.numItems, state.indicesBuf.itemType, 0);
+    }
+
+    _allocate() {
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+        const sectionPlanesState = scene._sectionPlanesState;
+        this._program = new Program(gl, this._buildShader());
+        if (this._program.errors) {
+            this.errors = this._program.errors;
+            return;
+        }
+        const program = this._program;
+        this._uPositionsDecodeMatrix = program.getLocation("positionsDecodeMatrix");
+        this._uShadowViewMatrix = program.getLocation("shadowViewMatrix");
+        this._uShadowProjMatrix = program.getLocation("shadowProjMatrix");
+        if (scene.logarithmicDepthBufferEnabled) {
+            this._uZFar = program.getLocation("zFar");
+        }
+        this._uSectionPlanes = [];
+        const sectionPlanes = sectionPlanesState.sectionPlanes;
+        for (let i = 0, len = sectionPlanes.length; i < len; i++) {
+            this._uSectionPlanes.push({
+                active: program.getLocation("sectionPlaneActive" + i),
+                pos: program.getLocation("sectionPlanePos" + i),
+                dir: program.getLocation("sectionPlaneDir" + i)
+            });
+        }
+        this._aPosition = program.getAttribute("position");
+        this._aOffset = program.getAttribute("offset");
+        this._aColor = program.getAttribute("color");
+        this._aFlags = program.getAttribute("flags");
+        this._aFlags2 = program.getAttribute("flags2");
+    }
+
+    _bindProgram(frameCtx) {
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+        const program = this._program;
+        program.bind();
+        gl.uniformMatrix4fv(this._uShadowViewMatrix, false, frameCtx.shadowViewMatrix);
+        gl.uniformMatrix4fv(this._uShadowProjMatrix, false, frameCtx.shadowProjMatrix);
+        this._lastLightId = null;
+    }
+
+    _buildShader() {
+        return {
+            vertex: this._buildVertexShader(),
+            fragment: this._buildFragmentShader()
+        };
+    }
+
+
+    _buildVertexShader() {
+        const scene = this._scene;
+        const clipping = scene._sectionPlanesState.sectionPlanes.length > 0;
+        const src = [];
+        src.push("// Batched geometry shadow vertex shader");
+        src.push("attribute vec3 position;");
+        if (scene.entityOffsetsEnabled) {
+            src.push("attribute vec3 offset;");
+        }
+        src.push("attribute vec4 color;");
+        src.push("attribute vec4 flags;");
+        src.push("attribute vec4 flags2;");
+        src.push("uniform mat4 shadowViewMatrix;");
+        src.push("uniform mat4 shadowProjMatrix;");
+        src.push("uniform mat4 positionsDecodeMatrix;");
+        if (clipping) {
+            src.push("varying vec4 vWorldPosition;");
+            src.push("varying vec4 vFlags2;");
+        }
+        src.push("varying vec4 vViewPosition;");
+        src.push("void main(void) {");
+        src.push("  bool visible        = (float(flags.x) > 0.0);");
+        src.push("  bool transparent    = ((float(color.a) / 255.0) < 1.0);");
+        src.push("  if (!visible || transparent) {");
+        src.push("      gl_Position = vec4(0.0, 0.0, 0.0, 0.0);");
+        src.push("  } else {");
+        src.push("      vec4 worldPosition = positionsDecodeMatrix * vec4(position, 1.0); ");
+        if (scene.entityOffsetsEnabled) {
+            src.push("      worldPosition.xyz = worldPosition.xyz + offset;");
+        }
+        src.push("      vec4 viewPosition  = shadowViewMatrix * worldPosition; ");
+        if (clipping) {
+            src.push("      vWorldPosition = worldPosition;");
+            src.push("      vFlags2 = flags2;");
+        }
+        src.push("      vViewPosition = viewPosition;");
+        src.push("      gl_Position = shadowProjMatrix * viewPosition;");
+        src.push("  }");
+        src.push("}");
+        return src;
+    }
+
+    _buildFragmentShader() {
+        const scene = this._scene;
+        const sectionPlanesState = scene._sectionPlanesState;
+        const clipping = (sectionPlanesState.sectionPlanes.length > 0);
+        const src = [];
+        src.push("// Batched geometry shadow fragment shader");
+        src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
+        src.push("precision highp float;");
+        src.push("precision highp int;");
+        src.push("#else");
+        src.push("precision mediump float;");
+        src.push("precision mediump int;");
+        src.push("#endif");
+        if (clipping) {
+            src.push("varying vec4 vWorldPosition;");
+            src.push("varying vec4 vFlags2;");
+            for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
+                src.push("uniform bool sectionPlaneActive" + i + ";");
+                src.push("uniform vec3 sectionPlanePos" + i + ";");
+                src.push("uniform vec3 sectionPlaneDir" + i + ";");
+            }
+        }
+        src.push("varying vec4 vViewPosition;");
+
+        src.push("vec4 encodeFloat( const in float v ) {");
+        src.push("  const vec4 bitShift = vec4(256 * 256 * 256, 256 * 256, 256, 1.0);");
+        src.push("  const vec4 bitMask = vec4(0, 1.0 / 256.0, 1.0 / 256.0, 1.0 / 256.0);");
+        src.push("  vec4 comp = fract(v * bitShift);");
+        src.push("  comp -= comp.xxyz * bitMask;");
+        src.push("  return comp;");
+        src.push("}");
+
+        src.push("void main(void) {");
+        if (clipping) {
+            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  if (clippable) {");
+            src.push("      float dist = 0.0;");
+            for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
+                src.push("      if (sectionPlaneActive" + i + ") {");
+                src.push("          dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
+                src.push("      }");
+            }
+            src.push("      if (dist > 0.0) { discard; }");
+            src.push("  }");
+        }
+        src.push("    gl_FragColor = encodeFloat( gl_FragCoord.z); ");
+        src.push("}");
+        return src;
+    }
+
+    webglContextRestored() {
+        this._program = null;
+    }
+
+    destroy() {
+        if (this._program) {
+            this._program.destroy();
+        }
+        this._program = null;
+    }
+}
+
+export {TrianglesDataTextureShadowRenderer};

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureShadowRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureShadowRenderer.js
@@ -26,6 +26,7 @@ class TrianglesDataTextureShadowRenderer {
     }
 
     drawLayer(frameCtx, dataTextureLayer) {
+        return; // TODO
         const scene = this._scene;
         const gl = scene.canvas.gl;
         const state = dataTextureLayer._state;

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureSilhouetteRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureSilhouetteRenderer.js
@@ -1,0 +1,329 @@
+import {Program} from "../../../../../webgl/Program.js";
+import {RENDER_PASSES} from "../../../RENDER_PASSES.js";
+import {createRTCViewMat, getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
+import {math} from "../../../../../math/math.js";
+import {WEBGL_INFO} from "../../../../../webglInfo.js";
+
+const defaultColor = new Float32Array([1, 1, 1]);
+const tempVec3a = math.vec3();
+
+/**
+ * @private
+ */
+class TrianglesDataTextureSilhouetteRenderer {
+
+    constructor(scene, primitiveType) {
+        this._scene = scene;
+        this._hash = this._getHash();
+        this._allocate();
+    }
+
+    getValid() {
+        return this._hash === this._getHash();
+    };
+
+    _getHash() {
+        return this._scene._sectionPlanesState.getHash();
+    }
+
+    drawLayer(frameCtx, dataTextureLayer, renderPass) {
+
+        const model = dataTextureLayer.model;
+        const scene = model.scene;
+        const camera = scene.camera;
+        const gl = scene.canvas.gl;
+        const state = dataTextureLayer._state;
+        const origin = dataTextureLayer._state.origin
+
+        if (!this._program) {
+            this._allocate();
+            if (this.errors) {
+                return;
+            }
+        }
+
+        if (frameCtx.lastProgramId !== this._program.id) {
+            frameCtx.lastProgramId = this._program.id;
+            this._bindProgram();
+        }
+
+        gl.uniform1i(this._uRenderPass, renderPass);
+
+        if (renderPass === RENDER_PASSES.SILHOUETTE_XRAYED) {
+            const material = scene.xrayMaterial._state;
+            const fillColor = material.fillColor;
+            const fillAlpha = material.fillAlpha;
+            gl.uniform4f(this._uColor, fillColor[0], fillColor[1], fillColor[2], fillAlpha);
+
+        } else if (renderPass === RENDER_PASSES.SILHOUETTE_HIGHLIGHTED) {
+            const material = scene.highlightMaterial._state;
+            const fillColor = material.fillColor;
+            const fillAlpha = material.fillAlpha;
+            gl.uniform4f(this._uColor, fillColor[0], fillColor[1], fillColor[2], fillAlpha);
+
+        } else if (renderPass === RENDER_PASSES.SILHOUETTE_SELECTED) {
+            const material = scene.selectedMaterial._state;
+            const fillColor = material.fillColor;
+            const fillAlpha = material.fillAlpha;
+            gl.uniform4f(this._uColor, fillColor[0], fillColor[1], fillColor[2], fillAlpha);
+
+        } else {
+            gl.uniform4fv(this._uColor, defaultColor);
+        }
+
+        const viewMat = (origin) ? createRTCViewMat(camera.viewMatrix, origin) : camera.viewMatrix;
+        gl.uniformMatrix4fv(this._uViewMatrix, false, viewMat);
+
+        gl.uniformMatrix4fv(this._uWorldMatrix, false, model.worldMatrix);
+
+        const numSectionPlanes = scene._sectionPlanesState.sectionPlanes.length;
+        if (numSectionPlanes > 0) {
+            const sectionPlanes = scene._sectionPlanesState.sectionPlanes;
+            const baseIndex = dataTextureLayer.layerIndex * numSectionPlanes;
+            const renderFlags = model.renderFlags;
+            for (let sectionPlaneIndex = 0; sectionPlaneIndex < numSectionPlanes; sectionPlaneIndex++) {
+                const sectionPlaneUniforms = this._uSectionPlanes[sectionPlaneIndex];
+                if (sectionPlaneUniforms) {
+                    const active = renderFlags.sectionPlanesActivePerLayer[baseIndex + sectionPlaneIndex];
+                    gl.uniform1i(sectionPlaneUniforms.active, active ? 1 : 0);
+                    if (active) {
+                        const sectionPlane = sectionPlanes[sectionPlaneIndex];
+                        if (origin) {
+                            const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a);
+                            gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
+                        } else {
+                            gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);
+                        }
+                        gl.uniform3fv(sectionPlaneUniforms.dir, sectionPlane.dir);
+                    }
+                }
+            }
+        }
+
+        gl.uniformMatrix4fv(this._uPositionsDecodeMatrix, false, dataTextureLayer._state.positionsDecodeMatrix);
+
+        this._aPosition.bindArrayBuffer(state.positionsBuf);
+
+        if (this._aOffset) {
+            this._aOffset.bindArrayBuffer(state.offsetsBuf);
+        }
+
+        if (this._aFlags) {
+            this._aFlags.bindArrayBuffer(state.flagsBuf);
+        }
+
+        if (this._aFlags2) {
+            this._aFlags2.bindArrayBuffer(state.flags2Buf);
+        }
+
+        state.indicesBuf.bind();
+
+        gl.drawElements(gl.TRIANGLES, state.indicesBuf.numItems, state.indicesBuf.itemType, 0);
+    }
+
+    _allocate() {
+
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+
+        this._program = new Program(gl, this._buildShader());
+
+        if (this._program.errors) {
+            this.errors = this._program.errors;
+            return;
+        }
+
+        const program = this._program;
+
+        this._uRenderPass = program.getLocation("renderPass");
+        this._uPositionsDecodeMatrix = program.getLocation("positionsDecodeMatrix");
+        this._uWorldMatrix = program.getLocation("worldMatrix");
+        this._uViewMatrix = program.getLocation("viewMatrix");
+        this._uProjMatrix = program.getLocation("projMatrix");
+        this._uColor = program.getLocation("color");
+        this._uSectionPlanes = [];
+
+        for (let i = 0, len = scene._sectionPlanesState.sectionPlanes.length; i < len; i++) {
+            this._uSectionPlanes.push({
+                active: program.getLocation("sectionPlaneActive" + i),
+                pos: program.getLocation("sectionPlanePos" + i),
+                dir: program.getLocation("sectionPlaneDir" + i)
+            });
+        }
+
+        this._aPosition = program.getAttribute("position");
+        this._aOffset = program.getAttribute("offset");
+        this._aFlags = program.getAttribute("flags");
+        this._aFlags2 = program.getAttribute("flags2");
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            this._uLogDepthBufFC = program.getLocation("logDepthBufFC");
+        }
+    }
+
+    _bindProgram() {
+
+        const scene = this._scene;
+        const gl = scene.canvas.gl;
+        const project = scene.camera.project;
+
+        this._program.bind();
+
+        gl.uniformMatrix4fv(this._uProjMatrix, false, project.matrix);
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            const logDepthBufFC = 2.0 / (Math.log(project.far + 1.0) / Math.LN2);
+            gl.uniform1f(this._uLogDepthBufFC, logDepthBufFC);
+        }
+    }
+
+    _buildShader() {
+        return {
+            vertex: this._buildVertexShader(),
+            fragment: this._buildFragmentShader()
+        };
+    }
+
+    _buildVertexShader() {
+
+        const scene = this._scene;
+        const sectionPlanesState = scene._sectionPlanesState;
+        const clipping = sectionPlanesState.sectionPlanes.length > 0;
+
+        const src = [];
+
+        src.push("// Triangles dataTexture silhouette vertex shader");
+        if (scene.logarithmicDepthBufferEnabled && WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+            src.push("#extension GL_EXT_frag_depth : enable");
+        }
+        src.push("uniform int renderPass;");
+
+        src.push("attribute vec3 position;");
+        if (scene.entityOffsetsEnabled) {
+            src.push("attribute vec3 offset;");
+        }
+        src.push("attribute vec4 flags;");
+        src.push("attribute vec4 flags2;");
+        src.push("uniform mat4 worldMatrix;");
+        src.push("uniform mat4 viewMatrix;");
+        src.push("uniform mat4 projMatrix;");
+        src.push("uniform mat4 positionsDecodeMatrix;");
+        src.push("uniform vec4 color;");
+
+        if (scene.logarithmicDepthBufferEnabled) {
+            src.push("uniform float logDepthBufFC;");
+            if (WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+                src.push("varying float vFragDepth;");
+            }
+            src.push("bool isPerspectiveMatrix(mat4 m) {");
+            src.push("    return (m[2][3] == - 1.0);");
+            src.push("}");
+            src.push("varying float isPerspective;");
+        }
+
+        if (clipping) {
+            src.push("varying vec4 vWorldPosition;");
+            src.push("varying vec4 vFlags2;");
+        }
+
+        src.push("void main(void) {");
+
+        // flags.y = NOT_RENDERED | SILHOUETTE_HIGHLIGHTED | SILHOUETTE_SELECTED | SILHOUETTE_XRAYED
+        // renderPass = SILHOUETTE_HIGHLIGHTED | SILHOUETTE_SELECTED | | SILHOUETTE_XRAYED
+
+        src.push(`if (int(flags.y) != renderPass) {`);
+        src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
+        src.push("} else {");
+
+        src.push("      vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
+        if (scene.entityOffsetsEnabled) {
+            src.push("      worldPosition.xyz = worldPosition.xyz + offset;");
+        }
+        src.push("vec4 viewPosition  = viewMatrix * worldPosition; ");
+        if (clipping) {
+            src.push("vWorldPosition = worldPosition;");
+            src.push("vFlags2 = flags2;");
+        }
+        src.push("vec4 clipPos = projMatrix * viewPosition;");
+        if (scene.logarithmicDepthBufferEnabled) {
+            if (WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+                src.push("vFragDepth = 1.0 + clipPos.w;");
+            } else {
+                src.push("clipPos.z = log2( max( 1e-6, clipPos.w + 1.0 ) ) * logDepthBufFC - 1.0;");
+                src.push("clipPos.z *= clipPos.w;");
+            }
+            src.push("isPerspective = float (isPerspectiveMatrix(projMatrix));");
+        }
+        src.push("gl_Position = clipPos;");
+        src.push("}");
+        src.push("}");
+        return src;
+    }
+
+    _buildFragmentShader() {
+        const scene = this._scene;
+        const sectionPlanesState = scene._sectionPlanesState;
+        let i;
+        let len;
+        const clipping = sectionPlanesState.sectionPlanes.length > 0;
+        const src = [];
+        src.push("// Triangles dataTexture silhouette fragment shader");
+        if (scene.logarithmicDepthBufferEnabled && WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+            src.push("#extension GL_EXT_frag_depth : enable");
+        }
+        src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
+        src.push("precision highp float;");
+        src.push("precision highp int;");
+        src.push("#else");
+        src.push("precision mediump float;");
+        src.push("precision mediump int;");
+        src.push("#endif");
+        if (scene.logarithmicDepthBufferEnabled && WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+            src.push("varying float isPerspective;");
+            src.push("uniform float logDepthBufFC;");
+            src.push("varying float vFragDepth;");
+        }
+        if (clipping) {
+            src.push("varying vec4 vWorldPosition;");
+            src.push("varying vec4 vFlags2;");
+            for (i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
+                src.push("uniform bool sectionPlaneActive" + i + ";");
+                src.push("uniform vec3 sectionPlanePos" + i + ";");
+                src.push("uniform vec3 sectionPlaneDir" + i + ";");
+            }
+        }
+        src.push("uniform vec4 color;");
+        src.push("void main(void) {");
+        if (clipping) {
+            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  if (clippable) {");
+            src.push("  float dist = 0.0;");
+            for (i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
+                src.push("if (sectionPlaneActive" + i + ") {");
+                src.push("   dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
+                src.push("}");
+            }
+            src.push("  if (dist > 0.0) { discard; }");
+            src.push("}");
+        }
+        if (scene.logarithmicDepthBufferEnabled && WEBGL_INFO.SUPPORTED_EXTENSIONS["EXT_frag_depth"]) {
+            src.push("    gl_FragDepthEXT = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;");
+        }
+        src.push("gl_FragColor = color;");
+        src.push("}");
+        return src;
+    }
+
+    webglContextRestored() {
+        this._program = null;
+    }
+
+    destroy() {
+        if (this._program) {
+            this._program.destroy();
+        }
+        this._program = null;
+    }
+}
+
+export {TrianglesDataTextureSilhouetteRenderer};

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureSilhouetteRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureSilhouetteRenderer.js
@@ -1,8 +1,8 @@
-import {Program} from "../../../../../webgl/Program.js";
+import {Program} from "../../../../../../webgl/Program.js";
 import {RENDER_PASSES} from "../../../RENDER_PASSES.js";
-import {createRTCViewMat, getPlaneRTCPos} from "../../../../../math/rtcCoords.js";
-import {math} from "../../../../../math/math.js";
-import {WEBGL_INFO} from "../../../../../webglInfo.js";
+import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
+import {math} from "../../../../../../math/math.js";
+import {WEBGL_INFO} from "../../../../../../webglInfo.js";
 
 const defaultColor = new Float32Array([1, 1, 1]);
 const tempVec3a = math.vec3();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/xeokit-cluster.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesDataTexture/xeokit-cluster.js
@@ -1,0 +1,418 @@
+/**
+ * @author https://github.com/tmarti, with support from https://tribia.com/
+ * @license MIT
+ */
+
+var makeClusters = function (inputData) {
+    function countEntityTriangles (entity)
+    {
+        var numTriangles = 0;
+    
+        entity.meshes.forEach (function (mesh) {
+            numTriangles += mesh.numTriangles;
+        });
+    
+        return numTriangles;
+    }
+    
+    function scanCellsForEntities (cellSideInMeters, entityFilterFunc)
+    {
+        var filterFunc = entityFilterFunc || function (entity) {
+            return true;
+        };
+    
+        var sizeX = inputData.aabbTree.data.maxX - inputData.aabbTree.data.minX;
+        var sizeZ = inputData.aabbTree.data.maxZ - inputData.aabbTree.data.minZ;
+    
+        var numCellsPerAxisX = 10;
+        var numCellsPerAxisZ = 10;
+    
+        var stepX = sizeX / numCellsPerAxisX;
+        var stepZ = sizeZ / numCellsPerAxisZ;
+    
+        var cells = [];
+    
+        var x = inputData.aabbTree.data.minX;
+    
+        for (var i = 0; i < numCellsPerAxisX; i++, x += stepX)
+        {
+            var z = inputData.aabbTree.data.minZ;
+    
+            for (var j = 0; j < numCellsPerAxisZ; j++, z += stepZ)
+            {
+                cells.push ({
+                    minX: x,
+                    maxX: x+stepX,
+                    minY: -100000000.0,
+                    maxY:  100000000.0,
+                    minZ: z,
+                    maxZ: z+stepZ,
+                    indexX: i,
+                    indexZ: j,
+                });
+            }
+        }
+    
+        var scanResult = {
+            cellsByEntity: {},
+            entitiesByCell: {},
+            cellsX: numCellsPerAxisX,
+            cellsZ: numCellsPerAxisZ,
+        };
+    
+        (cells || []).forEach (function (cell) {
+            inputData.aabbTree.search(
+                cell
+            ).filter (function (x) {
+                return filterFunc (x.entity); 
+            }).forEach (function (x) {
+                var id = x.entity.id;
+    
+                scanResult.cellsByEntity [id] = scanResult.cellsByEntity [id] || {
+                    cells: [],
+                    entity: x.entity,
+                };
+    
+                scanResult.cellsByEntity [id].cells.push (cell);
+    
+                var cellId = cell.indexX + "_" + cell.indexZ;
+    
+                scanResult.entitiesByCell [cellId] = scanResult.entitiesByCell [cellId] || {
+                    entities: [],
+                    cell: cell,
+                };
+    
+                scanResult.entitiesByCell[cellId].entities.push (x.entity);
+            });
+        });
+    
+        return scanResult;
+    }
+    
+    /**
+     * Get maximum cells that clustered entities can use in order to make sure that at least
+     * ```minPercentOfClusteredPolygons``` % polygons are clustered.
+     * @param {float} minPercentOfClusteredPolygons 
+     */
+    function getMaxCellsPerEntity (
+        minPercentOfClusteredPolygons,
+        cellsByEntity)
+    {
+        var trianglesForEntityCellsCount = {};
+        var totalTriangles = 0;
+    
+        Object.keys (cellsByEntity).forEach (function (entityId) {
+            var entityCells = cellsByEntity[entityId].cells;
+            var numCellsForEntity = entityCells.length;
+            var entity = cellsByEntity[entityId].entity;
+    
+            var numTriangles = countEntityTriangles (entity);
+    
+            trianglesForEntityCellsCount [numCellsForEntity] =
+                (trianglesForEntityCellsCount [numCellsForEntity] || 0) + numTriangles;
+    
+            totalTriangles += numTriangles;
+        });
+    
+        var cellsCounts = Object.keys (trianglesForEntityCellsCount);
+    
+        cellsCounts.sort(function (a, b) {
+            return a - b;
+        });
+    
+        var cellCount = 0;
+        var accum = 0.0;
+    
+        for (var i = 0; i < cellsCounts.length && accum < minPercentOfClusteredPolygons; i++)
+        {
+            cellCount = cellsCounts[i];
+    
+            accum += trianglesForEntityCellsCount[cellCount] / totalTriangles;
+        }
+    
+        return {
+            maxCellsPerEntity: cellCount,
+            polygonStats: {
+                percentClustered: accum,
+                numberClustered: Math.round (accum * totalTriangles),
+                numberUnclustered: totalTriangles - Math.round (accum * totalTriangles)    ,
+            },
+        };
+    }
+    
+    function generateSpiralIndexes (sizeX, sizeY)
+    {
+        var state = {
+            pos: {
+                x: 0,
+                y: 0,
+            },
+            left: 0,
+            right: sizeX,
+            top: 0,
+            bottom: sizeY,
+            dir: 0, // 0 right, 1 down, 2 left, 3 up 
+        };
+    
+        function mustTurn ()
+        {
+            if (state.dir == 0 && (state.pos.x + 1) >= state.right)
+                return true;
+            
+            if (state.dir == 1 && (state.pos.y + 1) >= state.bottom)
+                return true;
+    
+            if (state.dir == 2 && (state.pos.x - 1) <= (state.left - 1))
+                return true;
+    
+            if (state.dir == 3 && (state.pos.y - 1) <= (state.top -1))
+                return true;
+    
+            return false;
+        }
+    
+        function turn ()
+        {
+            state.dir = (state.dir + 1) % 4;
+    
+            if (state.dir == 0) state.left++;
+            if (state.dir == 1) state.top++;
+            if (state.dir == 2) state.right--;
+            if (state.dir == 3) state.bottom--;
+        }
+    
+        function advance ()
+        {
+            if (mustTurn ())
+                turn ();
+    
+            if (state.dir == 0) state.pos.x++;
+            if (state.dir == 1) state.pos.y++;
+            if (state.dir == 2) state.pos.x--;
+            if (state.dir == 3) state.pos.y--;
+        }
+    
+        var retVal = [];
+    
+        for (var len = sizeX*sizeY; retVal.length < len; advance ())
+        {
+            retVal.push (
+                state.pos.x + "_" + state.pos.y
+            );
+        }
+    
+        return retVal;
+    }
+    
+    function getAllEntitesOnCell (cellId, maxCellsPerEntity, entitiesByCell, cellsByEntity)
+    {
+        var ebc = entitiesByCell [cellId] || {
+            entities: [],
+        };
+    
+        return ebc.entities.filter (function (entity) {
+            return cellsByEntity [entity.id].cells.length <= maxCellsPerEntity;
+        });
+    }
+    
+    function generateEntityMappings (cellsX, cellsZ, maxCellsPerEntity, entitiesByCell, cellsByEntity, maxPolygonsPerCluster)
+    {
+        var processedEntities = {};
+    
+        // Create clusters for entities
+        var previousState = {
+            accumEntities: [],
+        };
+    
+        var entityClusters = [];
+    
+        generateSpiralIndexes (
+            cellsX,
+            cellsZ
+        ).forEach (function (cellId) {
+            var entities = getAllEntitesOnCell (
+                cellId,
+                maxCellsPerEntity,
+                entitiesByCell,
+                cellsByEntity
+            ).filter (function (entity) {
+                return !(entity.id in processedEntities);
+            });
+            
+            entities.forEach (function (entity) {
+               processedEntities [entity.id] = true; 
+            });
+    
+            entities.sort (function (e1, e2) {
+                return countEntityTriangles(e1) - countEntityTriangles (e2);
+            });
+    
+            var entitiesToProcess = previousState.accumEntities.concat(entities);
+    
+            var accumEntities = [];
+    
+            var remainingTriangles = maxPolygonsPerCluster;
+    
+            var i = 0;
+            do {
+                for (; i < entitiesToProcess.length; i++)
+                {
+                    var entity = entitiesToProcess [i];
+                    var numTriangles = countEntityTriangles (entity);
+    
+                    if (numTriangles > remainingTriangles)
+                    {
+                        entityClusters.push (accumEntities);
+                        accumEntities = [];
+                        remainingTriangles = maxPolygonsPerCluster;
+                    }
+    
+                    accumEntities.push (entity);
+                    remainingTriangles -= numTriangles;
+                }
+            } while (i < entitiesToProcess.length);
+    
+            previousState.accumEntities = accumEntities;
+        });
+    
+        if (previousState.accumEntities.length)
+        {
+            entityClusters.push (previousState.accumEntities);
+        }
+    
+        // Create shared clusters for unclustered entities
+        var unClusteredEntities = [];
+    
+        Object.keys (cellsByEntity).forEach (function (entityId) {
+            if (!(entityId in processedEntities))
+            {
+                unClusteredEntities.push (cellsByEntity[entityId].entity);
+            }
+        });
+        
+        var remainingTriangles = maxPolygonsPerCluster;
+        var accumEntities = [];
+    
+        unClusteredEntities.forEach (function (entity) {
+            var numTriangles = countEntityTriangles (entity);
+    
+            if (numTriangles > remainingTriangles)
+            {
+                entityClusters.push (accumEntities);
+                accumEntities = [];
+                remainingTriangles = maxPolygonsPerCluster;
+            }
+    
+            accumEntities.push (entity);
+            remainingTriangles -= numTriangles;
+        });
+    
+        if (accumEntities.length)
+        {
+            entityClusters.push (accumEntities);
+        }
+    
+        // Prepare return value
+        var entityIdToClusterIdMapping = {};
+    
+        entityClusters.forEach (function (cluster, clusterIndex) {
+            cluster.forEach (function (entity) {
+                entityIdToClusterIdMapping [entity.id] = clusterIndex;
+            });
+        });
+    
+        return {
+            clusters: entityClusters,
+            entityIdToClusterIdMapping: entityIdToClusterIdMapping,
+        };
+    }
+    
+    function generateClusters (cfg)
+    {
+        // console.time ("scanCells");
+        var scanResult = scanCellsForEntities (
+            cfg.cellSideInMeters,
+            cfg.entityFilterFunc
+        );
+        // console.timeEnd ("scanCells");
+    
+        // console.time ("stats-max-cells");
+        var maxCellsResult = getMaxCellsPerEntity(
+            cfg.minPercentOfClustredPolygons,
+            scanResult.cellsByEntity
+        );
+        // console.timeEnd ("stats-max-cells");
+        // console.log (maxCellsResult);
+    
+        // console.time ("clustering");
+        var clusteringResult = generateEntityMappings (
+            scanResult.cellsX,
+            scanResult.cellsZ,
+            maxCellsResult.maxCellsPerEntity,
+            scanResult.entitiesByCell,
+            scanResult.cellsByEntity,
+            cfg.maxPolygonsPerCluster
+        );
+        // console.timeEnd ("clustering");
+    
+        //console.log (clusteringResult);
+    
+        // var visibleClusters = {};
+    
+        // inputData.aabbTree.searchCustom(
+        //     inputData._aabbIntersectsCameraFrustum,
+        //     inputData._aabbContainedInCameraFrustum
+        // ).forEach (function (aabb) {
+        //     var clusterId = clusteringResult.entityIdToClusterIdMapping [aabb.entity.id];
+    
+        //     visibleClusters[clusterId] = true;
+        // });
+    
+        return {
+            clusters: {
+                // visible: Object.keys (visibleClusters).length,
+                total: clusteringResult.clusters.length,
+            },
+            clusteringResult: clusteringResult,
+        };
+    };
+    
+    var totalClusters = 0;
+    // var totalVisibleClusters = 0;
+    
+    // console.time ("clustering");
+    
+    var generateClustersResult = generateClusters ({
+        cellSideInMeters: 0.05,
+        entityFilterFunc: function (entity) {
+            return true;
+        },
+        maxPolygonsPerCluster: 90000,
+        minPercentOfClustredPolygons: 0.9,
+    });
+
+    // totalVisibleClusters += generateClustersResult.clusters.visible;
+    totalClusters += generateClustersResult.clusters.total;
+
+    // console.timeEnd ("clustering");
+    
+    console.log ("Total clusters: " + totalClusters);
+
+    // console.log (generateClustersResult);
+    // console.log ("Total visible clusters: " + totalVisibleClusters);
+    // console.log ("Visible clusters %: " + (totalVisibleClusters / totalClusters * 100).toFixed (2));
+
+    var orderedEntityIds = [];
+
+    generateClustersResult.clusteringResult.clusters.forEach (function (cluster) {
+        cluster.forEach (function (item) {
+            orderedEntityIds.push (item.id);
+        });
+    });
+
+    generateClustersResult.orderedEntityIds = orderedEntityIds;
+
+    return generateClustersResult;
+};
+
+export {makeClusters}

--- a/src/viewer/scene/webgl/Program.js
+++ b/src/viewer/scene/webgl/Program.js
@@ -111,6 +111,8 @@ class Program {
                 location = gl.getUniformLocation(this.handle, uName);
                 if ((u.type === gl.SAMPLER_2D) || (u.type === gl.SAMPLER_CUBE) || (u.type === 35682)) {
                     this.samplers[uName] = new Sampler(gl, location);
+                } else if (gl instanceof WebGL2RenderingContext && (u.type === gl.UNSIGNED_INT_SAMPLER_2D || u.type === gl.INT_SAMPLER_2D)) {
+                    this.samplers[uName] = new Sampler(gl, location);
                 } else {
                     this.uniforms[uName] = location;
                 }

--- a/src/viewer/scene/webgl/Renderer.js
+++ b/src/viewer/scene/webgl/Renderer.js
@@ -465,8 +465,9 @@ const Renderer = function (scene, options) {
         shadowRenderBuf.unbind();
     }
 
-    const drawColor = (function () { // Draws the drawables in drawableListSorted
-
+    function drawColor (params)
+    {
+    // const drawColor = (function () { // Draws the drawables in drawableListSorted
         const normalDrawSAOBin = [];
         const normalEdgesOpaqueBin = [];
         const normalFillTransparentBin = [];
@@ -487,7 +488,8 @@ const Renderer = function (scene, options) {
         const selectedFillTransparentBin = [];
         const selectedEdgesTransparentBin = [];
 
-        return function (params) {
+        // return function (params) {
+        {
 
             const ambientColorAndIntensity = scene._lightsState.getAmbientColorAndIntensity();
 
@@ -892,8 +894,10 @@ const Renderer = function (scene, options) {
             if (unbindOutputFrameBuffer) {
                 unbindOutputFrameBuffer(params.pass);
             }
-        };
-    })();
+        // };
+        }
+    }
+    // })();
 
     /**
      * Picks an Entity.

--- a/src/viewer/scene/webgl/Renderer.js
+++ b/src/viewer/scene/webgl/Renderer.js
@@ -10,6 +10,7 @@ import {createRTCViewMat} from "../math/rtcCoords.js";
 import {SAODepthLimitedBlurRenderer} from "./sao/SAODepthLimitedBlurRenderer.js";
 import {RenderBufferManager} from "./RenderBufferManager.js";
 import {getExtension} from "./getExtension.js";
+import {DataTexturePeformanceModel} from "../models/VBOSceneModel/DataTexturePeformanceModel.js"
 
 /**
  * @private
@@ -989,7 +990,7 @@ const Renderer = function (scene, options) {
                         const drawableList = drawableTypeInfo[type].drawableList;    
                         for (let i = 0, len = drawableList.length; i < len; i++) {
                             const drawable = drawableList[i];
-                            if (drawable.constructor.name == 'DataTexturePeformanceModel') {
+                            if (drawable instanceof DataTexturePeformanceModel) {
                                 drawable.pickCameraTexture._updateViewMatrix (
                                     pickViewMatrix,
                                     pickProjMatrix

--- a/src/viewer/scene/webgl/Renderer.js
+++ b/src/viewer/scene/webgl/Renderer.js
@@ -991,10 +991,12 @@ const Renderer = function (scene, options) {
                         for (let i = 0, len = drawableList.length; i < len; i++) {
                             const drawable = drawableList[i];
                             if (drawable instanceof DataTexturePeformanceModel) {
-                                drawable.pickCameraTexture._updateViewMatrix (
-                                    pickViewMatrix,
-                                    pickProjMatrix
-                                );
+                                if (drawable.pickCameraTexture) {
+                                    drawable.pickCameraTexture._updateViewMatrix (
+                                        pickViewMatrix,
+                                        pickProjMatrix
+                                    );
+                                }
                             }
                         }
                     }

--- a/src/viewer/scene/webgl/Renderer.js
+++ b/src/viewer/scene/webgl/Renderer.js
@@ -983,8 +983,6 @@ const Renderer = function (scene, options) {
 
             if (null !== pickViewMatrix)
             {
-                // debugger;
-
                 // data-textures: update the pick-camera-matrices of all DataTexturePeformanceModel's
                 for (let type in drawableTypeInfo) {
                     if (drawableTypeInfo.hasOwnProperty(type)) {

--- a/src/viewer/scene/webgl/Renderer.js
+++ b/src/viewer/scene/webgl/Renderer.js
@@ -927,7 +927,7 @@ const Renderer = function (scene, options) {
             pickResult.reset();
 
             updateDrawlist();
-
+    
             let look;
             let pickViewMatrix = null;
             let pickProjMatrix = null;
@@ -981,11 +981,32 @@ const Renderer = function (scene, options) {
                 canvasPos[1] = canvas.clientHeight * 0.5;
             }
 
+            if (null !== pickViewMatrix)
+            {
+                // debugger;
+
+                // data-textures: update the pick-camera-matrices of all DataTexturePeformanceModel's
+                for (let type in drawableTypeInfo) {
+                    if (drawableTypeInfo.hasOwnProperty(type)) {
+                        const drawableList = drawableTypeInfo[type].drawableList;    
+                        for (let i = 0, len = drawableList.length; i < len; i++) {
+                            const drawable = drawableList[i];
+                            if (drawable.constructor.name == 'DataTexturePeformanceModel') {
+                                drawable.pickCameraTexture._updateViewMatrix (
+                                    pickViewMatrix,
+                                    pickProjMatrix
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+
             const pickBuffer = renderBufferManager.getRenderBuffer("pick");
 
             pickBuffer.bind();
 
-            const pickable = gpuPickPickable(pickBuffer, canvasPos, pickViewMatrix, pickProjMatrix, params);
+            const pickable = gpuPickPickable(pickBuffer, canvasPos, pickViewMatrix, pickProjMatrix, params, pickResult);
 
             if (!pickable) {
                 pickBuffer.unbind();
@@ -1063,11 +1084,12 @@ const Renderer = function (scene, options) {
         };
     })();
 
-    function gpuPickPickable(pickBuffer, canvasPos, pickViewMatrix, pickProjMatrix, params) {
+    function gpuPickPickable(pickBuffer, canvasPos, pickViewMatrix, pickProjMatrix, params, pickResult) {
 
         frameCtx.reset();
         frameCtx.backfaces = true;
         frameCtx.frontface = true; // "ccw"
+        frameCtx.pickOrigin = pickResult.origin;
         frameCtx.pickViewMatrix = pickViewMatrix;
         frameCtx.pickProjMatrix = pickProjMatrix;
         frameCtx.pickInvisible = !!params.pickInvisible;
@@ -1129,6 +1151,7 @@ const Renderer = function (scene, options) {
         frameCtx.reset();
         frameCtx.backfaces = true;
         frameCtx.frontface = true; // "ccw"
+        frameCtx.pickOrigin = pickResult.origin;
         frameCtx.pickViewMatrix = pickViewMatrix; // Can be null
         frameCtx.pickProjMatrix = pickProjMatrix; // Can be null
         // frameCtx.pickInvisible = !!params.pickInvisible;
@@ -1169,6 +1192,7 @@ const Renderer = function (scene, options) {
             frameCtx.reset();
             frameCtx.backfaces = true;
             frameCtx.frontface = true; // "ccw"
+            frameCtx.pickOrigin = pickResult.origin;
             frameCtx.pickViewMatrix = pickViewMatrix;
             frameCtx.pickProjMatrix = pickProjMatrix;
             frameCtx.pickZNear = nearAndFar[0];
@@ -1244,6 +1268,7 @@ const Renderer = function (scene, options) {
         frameCtx.reset();
         frameCtx.backfaces = true;
         frameCtx.frontface = true; // "ccw"
+        frameCtx.pickOrigin = pickResult.origin;
         frameCtx.pickViewMatrix = pickViewMatrix;
         frameCtx.pickProjMatrix = pickProjMatrix;
 

--- a/src/viewer/scene/webgl/convertConstant.js
+++ b/src/viewer/scene/webgl/convertConstant.js
@@ -49,6 +49,7 @@ import {
     UnsignedByteType,
     RGBA_BPTC_Format,
     sRGBEncoding,
+    // _SRGBAFormat,
     RepeatWrapping,
     ClampToEdgeWrapping,
     NearestFilter,


### PR DESCRIPTION
⚙️ _[WIP] Will keep updating this PR description_ ⚙️

## Introducing `DataTexturePerformanceModel` 🚀 

This is a variation of `PeformanceModel` where all the GPU data is stored in data textures.

GPU memory savings are bigger than 80% (both with instanced and non-instanced geometries) when using the `DataTexturePerformanceModel`.

> 💡This is achieved by using a combination of _creative geometry management techniques_ 💡 
>
>  _**TODO: document the techniques introduced in this PR**_

**It requires `WebGL2` support in the browser**

- https://caniuse.com/webgl2

## Feature toggled! ⚡ 

A toggle is introduced in `XKTLoaderPlugin` to enable the new techniques that optimize GPU RAM usage.

To enable the GPU optimizations, load your `XKT` files with:

```js
xktLoaderPlugin.load ({
    // Same arguments you would use today
    ...,

    // This toggles on the GPU optimizations
    useDataTextures: true,
}); 
```

This should be able to load any XKT file from version `v1` to `v9` (latest today).

## Toggle-able extensions 🔧

### Dynamic Level Of Detail mechanism

When enabled, this extension will try to match a target frame-rate in the Viewer and, if that is not possible, it will keep progressively hiding the most complex objects until the target frame-rate is reached.

When the frame-rate recovers (e.g. when the camera remains steady), it will keep unhiding the previously hidden objects.

The heuristic to know which objects should be hidden first is based on the number of triangles of each object.

By default, the following triangles limits are used:

> `[ 2000, 600, 150, 80, 20 ]`
> - 1st, objects with more than 2000 triangles will be hidden
> - 2nd, objects with more than 600 triangles
> - ...
> - but objects with 20 triangles or less will remain always visible

This is adjustable on a per-model basis:

```js
xktLoaderPlugin.load ({
    // Same arguments you would use today
    ...,

    // This toggles on the GPU optimizations
    useDataTextures: {
        // For this model, set the target frame-rate to 15 fps for LOD mechanism
        targetLodFps: 15,
    },
}); 
```

### View Frustum Culling mechanism

When enabled, this extension will pre-cull all objects outside of the Camera Frustum (this is, objects outside the Field of View of the Camera).

This extension does not cause any visible difference in the render or its quality, but when the camera is close to or inside a model, it's usually the case that only a % of the objects are in the Camera Field of View, and it's in those cases where this extension is able to boost the frame-rate in some cases up to 2x.

> As a technical note, the implementation stands on top of [an efficient `r*tree` based data structure](https://github.com/Eronana/rbush-3d) to boost the Frustum Containment calculations and minimize the number of calculations.
>
> _See the Wikipedia article on `r*trees`: https://en.wikipedia.org/wiki/R*-tree_

In cases where all objects are visible by the Camera, this mechanism adds no noticeable overhead to the frame-rate.

This extension is toggle-able on a per-model basis:

```js
xktLoaderPlugin.load ({
    // Same arguments you would use today
    ...,

    // This toggles on the GPU optimizations
    useDataTextures: {
        // For this model, enable View Frustum Culling
        enableViewFrustumCulling: true,
    },
}); 
```

### Use them together!

```js
xktLoaderPlugin.load ({
    // Same arguments you would use today
    ...,

    // This toggles on the GPU optimizations
    useDataTextures: {
        // For this model, enable both LOD and VFC mechanisms
        targetLodFps: 15,
        enableViewFrustumCulling: true,
    },
}); 
```

## What is working:

- non-instanced geometry rendering (triangles/edges) and picking
- instanced geometry rendering (triangles/edges) and picking
- full illumination support
- out-of-box-support for per-object XYZ offsets
- section plane support
- arbitrary ray-picking
- non-solid geometry rendering (using a novel way to do it)

## What is missing in the `Renderers`

- SAO rendering
- Not all `shader renderers` are migrated. The following ones are missing:
  - `...DepthRenderer.js`
  - `...NormalsRenderer.js`
  - `...OcclusionRenderer.js`
  - `...ShadowRenderer.js`
  - `...ColorQualityRenderer.js`

## What is not covered by the GPU optimizations (yet, to decide if this will be also optimized)

- Lines-based models
- Point-Set-based models

## Some GPU statistics

> `xeokit` is using today around 67 bytes/triangle on the GPU

1. 55.8 M triangles model not using instancing

```
+200k objects
655.23 MB of GPU-RAM
11.15 GPU-bytes/triangle
```

2. 32 M triangles model using instancing

```
+100k objects
125.79 MB of GPU-RAM
3.69 GPU-bytes/triangle
``` 