### PR TITLE
Fix: component.id should be string

### DIFF
--- a/types/viewer/scene/scene/Scene.d.ts
+++ b/types/viewer/scene/scene/Scene.d.ts
@@ -18,7 +18,7 @@ export declare class Scene extends Component {
    * @param callback Called fired on the event
    * @param scope  Scope for the callback
    */
-  on(event: "modelLoaded", callback: (modelId: number) => void, scope?: any): string;
+  on(event: "modelLoaded", callback: (modelId: string) => void, scope?: any): string;
 
   /**
    * Fires when a model is unloaded
@@ -26,7 +26,7 @@ export declare class Scene extends Component {
    * @param callback Called fired on the event
    * @param scope  Scope for the callback
    */
-  on(event: "modelUnloaded", callback: (modelId: number) => void, scope?: any): string;
+  on(event: "modelUnloaded", callback: (modelId: string) => void, scope?: any): string;
 
   /**
    * Fired when about to render a frame for a Scene.


### PR DESCRIPTION
In previous update string was removed, should have been number. This fixes that error