### PR TITLE
Fixed CameraControl picking and made double click time frame configurable

### DIFF
--- a/src/viewer/scene/CameraControl/CameraControl.js
+++ b/src/viewer/scene/CameraControl/CameraControl.js
@@ -1606,7 +1606,7 @@ class CameraControl extends Component {
     /**
      * Sets the double click time frame length in milliseconds.
      * 
-     * If two mouse click events occurs within time frame, it is considered a double click. 
+     * If two mouse click events occur within this time frame, it is considered a double click. 
      * 
      * Default is ````250````
      * 

--- a/src/viewer/scene/CameraControl/CameraControl.js
+++ b/src/viewer/scene/CameraControl/CameraControl.js
@@ -639,6 +639,7 @@ class CameraControl extends Component {
             pointerEnabled: true,
             constrainVertical: false,
             smartPivot: false,
+            doubleClickTimeFrame: 250,
 
             // Rotation
 
@@ -1600,6 +1601,30 @@ class CameraControl extends Component {
      */
     get smartPivot() {
         return this._configs.smartPivot;
+    }
+
+    /**
+     * Sets the double click time frame length in milliseconds.
+     * 
+     * If two mouse click events occurs within time frame, it is considered a double click. 
+     * 
+     * Default is ````250````
+     * 
+     * @param {Number} value New double click time frame.
+     */
+    set doubleClickTimeFrame(value) {
+        this._configs.doubleClickTimeFrame = (value !== undefined && value !== null) ? value : 250;
+    }
+
+    /**
+     * Gets the double click time frame length in milliseconds.
+     *  
+     * Default is ````250````
+     * 
+     * @param {Number} value Current double click time frame.
+     */
+    get doubleClickTimeFrame() {
+        return this._configs.doubleClickTimeFrame;
     }
 
     /**

--- a/src/viewer/scene/CameraControl/lib/handlers/MousePickHandler.js
+++ b/src/viewer/scene/CameraControl/lib/handlers/MousePickHandler.js
@@ -236,23 +236,26 @@ class MousePickHandler {
 
             if (this._clicks === 1) { // First click
 
+                pickController.pickCursorPos = states.pointerCanvasPos;
+                pickController.schedulePickEntity = configs.doublePickFlyTo;
+                pickController.schedulePickSurface = pickedSurfaceSubs;
+                pickController.update();
+
+                const firstClickPickResult = pickController.pickResult;
+                const firstClickPickSurface = pickController.pickedSurface;
+
                 this._timeout = setTimeout(() => {
 
-                    pickController.pickCursorPos = states.pointerCanvasPos;
-                    pickController.schedulePickEntity = configs.doublePickFlyTo;
-                    pickController.schedulePickSurface = pickedSurfaceSubs;
-                    pickController.update();
+                    if (firstClickPickResult) {
 
-                    if (pickController.pickResult) {
+                        cameraControl.fire("picked", firstClickPickResult, true);
 
-                        cameraControl.fire("picked", pickController.pickResult, true);
+                        if (firstClickPickSurface) {
 
-                        if (pickController.pickedSurface) {
-
-                            cameraControl.fire("pickedSurface", pickController.pickResult, true);
+                            cameraControl.fire("pickedSurface", firstClickPickResult, true);
 
                             if ((!configs.firstPerson) && configs.followPointer) {
-                                controllers.pivotController.setPivotPos(pickController.pickResult.worldPos);
+                                controllers.pivotController.setPivotPos(firstClickPickResult.worldPos);
                                 if (controllers.pivotController.startPivot()) {
                                     controllers.pivotController.showPivot();
                                 }
@@ -266,7 +269,7 @@ class MousePickHandler {
 
                     this._clicks = 0;
 
-                }, 250);  // FIXME: Too short for track pads
+                }, configs.doubleClickTimeFrame);
 
             } else { // Second click
 


### PR DESCRIPTION
Currently when a user attempts to pick an object with a single mouse click, there is a fixed delay of 250 ms to determine if the mouse click was a single or a double click. If it was determined that the click was a single click, it then performs a pick on the current cursor position. If a user clicks on an object, and then moves the cursor over another object, it is the latter object that is picked instead of the first. 

This was fixed by immediately performing a pick when the first mouse click occurs, and caching the picking result in a variable. If after 250 ms the click was confirmed to be a single click, it would then use the cached picking result when emitting events. This results in the object being clicked on being selected, even if the mouse cursor moves away from the object during the double click time frame.

In addition, I made the previously fixed 250ms value into a config variable (doubleClickTimeFrame) with public accessors.

This should fix issue #333 
