### PR TITLE
Fix JS imports by adding the proper `.js` suffix to the `import`-ed files

### DIFF
--- a/src/viewer/scene/models/VBOSceneModel/VBOSceneModel.js
+++ b/src/viewer/scene/models/VBOSceneModel/VBOSceneModel.js
@@ -13,13 +13,13 @@ import {PointsInstancingLayer} from './lib/layers/pointsInstancing/PointsInstanc
 import {ENTITY_FLAGS} from './lib/ENTITY_FLAGS.js';
 import {RenderFlags} from "../../webgl/RenderFlags.js";
 import {worldToRTCPositions} from "../../math/rtcCoords.js";
-import {VBOSceneModelTextureSet} from "./lib/VBOSceneModelTextureSet";
-import {VBOSceneModelGeometry} from "./lib/VBOSceneModelGeometry";
-import {VBOSceneModelTexture} from "./lib/VBOSceneModelTexture";
-import {SceneModel} from "../SceneModel";
-import {Texture2D} from "../../webgl/Texture2D";
+import {VBOSceneModelTextureSet} from "./lib/VBOSceneModelTextureSet.js";
+import {VBOSceneModelGeometry} from "./lib/VBOSceneModelGeometry.js";
+import {VBOSceneModelTexture} from "./lib/VBOSceneModelTexture.js";
+import {SceneModel} from "../SceneModel.js";
+import {Texture2D} from "../../webgl/Texture2D.js";
 import {utils} from "../../utils.js";
-import {getKTX2TextureTranscoder} from "../../utils/";
+import {getKTX2TextureTranscoder} from "../../utils/textureTranscoders/KTX2TextureTranscoder/KTX2TextureTranscoder.js";
 import {
     LinearFilter,
     LinearMipmapLinearFilter,
@@ -32,7 +32,7 @@ import {
     MirroredRepeatWrapping,
     LinearMipMapNearestFilter,
     NearestFilter
-} from "../../constants/constants";
+} from "../../constants/constants.js";
 
 const tempVec3a = math.vec3();
 const tempMat4 = math.mat4();

--- a/src/viewer/scene/models/VBOSceneModel/lib/VBOSceneModelGeometry.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/VBOSceneModelGeometry.js
@@ -1,8 +1,8 @@
-import {math} from "../../../math";
-import {ArrayBuf} from "../../../webgl/ArrayBuf";
-import {geometryCompressionUtils} from "../../../math/geometryCompressionUtils";
-import {octEncodeNormals, quantizePositions} from "./compression";
-import {buildEdgeIndices} from "../../../math/buildEdgeIndices";
+import {math} from "../../../math/math.js";
+import {ArrayBuf} from "../../../webgl/ArrayBuf.js";
+import {geometryCompressionUtils} from "../../../math/geometryCompressionUtils.js";
+import {octEncodeNormals, quantizePositions} from "./compression.js";
+import {buildEdgeIndices} from "../../../math/buildEdgeIndices.js";
 
 /**
  * Instantiated by VBOSceneModel#createGeometry

--- a/src/viewer/scene/models/VBOSceneModel/lib/VBOSceneModelTexture.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/VBOSceneModelTexture.js
@@ -1,4 +1,4 @@
-import {Texture2D} from "../../../webgl/Texture2D";
+import {Texture2D} from "../../../webgl/Texture2D.js";
 
 /**
  * Instantiated by VBOSceneModel#createTexture

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/TrianglesBatchingRenderers.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/TrianglesBatchingRenderers.js
@@ -12,7 +12,7 @@ import {TrianglesBatchingNormalsRenderer} from "./renderers/TrianglesBatchingNor
 import {TrianglesBatchingShadowRenderer} from "./renderers/TrianglesBatchingShadowRenderer.js";
 import {TrianglesBatchingPBRRenderer} from "./renderers/TrianglesBatchingPBRRenderer.js";
 import {TrianglesBatchingPickNormalsFlatRenderer} from "./renderers/TrianglesBatchingPickNormalsFlatRenderer.js";
-import {TrianglesBatchingColorTextureRenderer} from "./renderers/TrianglesBatchingColorTextureRenderer";
+import {TrianglesBatchingColorTextureRenderer} from "./renderers/TrianglesBatchingColorTextureRenderer.js";
 
 /**
  * @private

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingColorTextureRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingColorTextureRenderer.js
@@ -1,5 +1,5 @@
 import {Program} from "../../../../../../webgl/Program.js";
-import {math} from "../../../../../../math";
+import {math} from "../../../../../../math/math.js";
 import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
 import {WEBGL_INFO} from "../../../../../../webglInfo.js";
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingPBRRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingPBRRenderer.js
@@ -1,8 +1,8 @@
 import {Program} from "../../../../../../webgl/Program.js";
-import {math} from "../../../../../../math";
+import {math} from "../../../../../../math/math.js";
 import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
 import {WEBGL_INFO} from "../../../../../../webglInfo.js";
-import {LinearEncoding, sRGBEncoding} from "../../../../../../constants/constants";
+import {LinearEncoding, sRGBEncoding} from "../../../../../../constants/constants.js";
 
 const tempVec4 = math.vec4();
 const tempVec3a = math.vec3();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/TrianglesInstancingRenderers.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/TrianglesInstancingRenderers.js
@@ -12,7 +12,7 @@ import {TrianglesInstancingNormalsRenderer} from "./renderers/TrianglesInstancin
 import {TrianglesInstancingShadowRenderer} from "./renderers/TrianglesInstancingShadowRenderer.js";
 import {TrianglesInstancingPBRRenderer} from "./renderers/TrianglesInstancingPBRRenderer.js";
 import {TrianglesInstancingPickNormalsFlatRenderer} from "./renderers/TrianglesInstancingPickNormalsFlatRenderer.js";
-import {TrianglesInstancingColorTextureRenderer} from "./renderers/TrianglesInstancingColorTextureRenderer";
+import {TrianglesInstancingColorTextureRenderer} from "./renderers/TrianglesInstancingColorTextureRenderer.js";
 
 /**
  * @private

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingDepthRenderer.js
@@ -1,6 +1,6 @@
 import {Program} from "../../../../../../webgl/Program.js";
 import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
-import {math} from "../../../../../../math";
+import {math} from "../../../../../../math/math.js";
 
 const tempVec3a = math.vec3();
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingEdgesColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingEdgesColorRenderer.js
@@ -1,7 +1,7 @@
 import {Program} from "../../../../../../webgl/Program.js";
 import {RENDER_PASSES} from "../../../RENDER_PASSES.js";
 import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
-import {math} from "../../../../../../math";
+import {math} from "../../../../../../math/math.js";
 
 const tempVec3a = math.vec3();
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingEdgesRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingEdgesRenderer.js
@@ -1,7 +1,7 @@
 import {Program} from "../../../../../../webgl/Program.js";
 import {RENDER_PASSES} from "../../../RENDER_PASSES.js";
 import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
-import {math} from "../../../../../../math";
+import {math} from "../../../../../../math/math.js";
 
 const tempVec3a = math.vec3();
 const defaultColor = new Float32Array([0,0,0,1]);

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingPBRRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingPBRRenderer.js
@@ -2,7 +2,7 @@ import {Program} from "../../../../../../webgl/Program.js";
 import {math} from "../../../../../../math/math.js";
 import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
 import {WEBGL_INFO} from "../../../../../../webglInfo.js";
-import {LinearEncoding, sRGBEncoding} from "../../../../../../constants/constants";
+import {LinearEncoding, sRGBEncoding} from "../../../../../../constants/constants.js";
 
 const tempVec4 = math.vec4();
 const tempVec3a = math.vec3();

--- a/src/viewer/scene/utils/textureTranscoders/KTX2TextureTranscoder/KTX2TextureTranscoder.js
+++ b/src/viewer/scene/utils/textureTranscoders/KTX2TextureTranscoder/KTX2TextureTranscoder.js
@@ -1,5 +1,5 @@
-import {FileLoader} from "../../FileLoader";
-import {WorkerPool} from "../../WorkerPool";
+import {FileLoader} from "../../FileLoader.js";
+import {WorkerPool} from "../../WorkerPool.js";
 import {
     LinearEncoding,
     LinearFilter,
@@ -15,7 +15,7 @@ import {
     RGBA_S3TC_DXT5_Format,
     RGBAFormat,
     sRGBEncoding
-} from "../../../constants/constants";
+} from "../../../constants/constants.js";
 
 const KTX2TransferSRGB = 2;
 const KTX2_ALPHA_PREMULTIPLIED = 1;

--- a/src/viewer/scene/webgl/Renderer.js
+++ b/src/viewer/scene/webgl/Renderer.js
@@ -9,7 +9,7 @@ import {SAOOcclusionRenderer} from "./sao/SAOOcclusionRenderer.js";
 import {createRTCViewMat} from "../math/rtcCoords.js";
 import {SAODepthLimitedBlurRenderer} from "./sao/SAODepthLimitedBlurRenderer.js";
 import {RenderBufferManager} from "./RenderBufferManager.js";
-import {getExtension} from "./getExtension";
+import {getExtension} from "./getExtension.js";
 
 /**
  * @private

--- a/src/viewer/scene/webgl/Texture2D.js
+++ b/src/viewer/scene/webgl/Texture2D.js
@@ -1,5 +1,5 @@
 import {utils} from '../utils.js';
-import {convertConstant} from "./convertConstant";
+import {convertConstant} from "./convertConstant.js";
 import {
     NearestFilter,
     NearestMipmapLinearFilter,
@@ -11,8 +11,8 @@ import {
     ClampToEdgeWrapping,
     LinearFilter,
     NearestMipmapNearestFilter
-} from "../constants/constants";
-import {getExtension} from "./getExtension";
+} from "../constants/constants.js";
+import {getExtension} from "./getExtension.js";
 
 const color = new Uint8Array([0, 0, 0, 1]);
 

--- a/src/viewer/scene/webgl/convertConstant.js
+++ b/src/viewer/scene/webgl/convertConstant.js
@@ -59,7 +59,7 @@ import {
     NearestMipMapLinearFilter, LinearMipMapLinearFilter
 } from '../constants/constants.js';
 
-import {getExtension} from "./getExtension";
+import {getExtension} from "./getExtension.js";
 
 /**
  * @private


### PR DESCRIPTION
This PR simply adds the needed suffix to the `import` statements added by latest changes to `xeokit-sdk:master` branch.

This is needed for example so the JS files are found when xeokit-sdk is served from a server using `node/express`.