### PR TITLE
Scene object events for XRayed, Highlighted and Selected

### DIFF
--- a/src/plugins/TreeViewPlugin/ModelTreeView.js
+++ b/src/plugins/TreeViewPlugin/ModelTreeView.js
@@ -112,6 +112,36 @@ class ModelTreeView {
             this._muteTreeEvents = false;
         });
 
+        this._onObjectXrayed = this._viewer.scene.on('objectXRayed', (entity) => {
+          if (this._muteSceneEvents) {
+            return;
+          }
+          const objectId = entity.id;
+          const node = this._objectNodes[objectId];
+          if (!node) {
+            return; // Not in this tree
+          }
+    
+          this._muteTreeEvents = true;
+          const xrayed = entity.xrayed;
+          const updated = (xrayed !== node.xrayed);
+          if (!updated) {
+            return;
+          }
+          node.xrayed = xrayed;
+          const listItemElementId = 'node-' + node.nodeId;
+          const listItemElement = document.getElementById(listItemElementId);
+          if (listItemElement !== null) {
+            if (xrayed) {
+              listItemElement.classList.add('xrayed-node');
+            } else {
+              listItemElement.classList.remove('xrayed-node');
+            }
+          }
+    
+          this._muteTreeEvents = false;
+        });
+
         this.switchExpandHandler = (event) => {
             event.preventDefault();
             event.stopPropagation();
@@ -593,6 +623,7 @@ class ModelTreeView {
                     if (entity) {
                         const visible = entity.visible;
                         node.numEntities = 1;
+                        node.xrayed = entity.xrayed;
                         if (visible) {
                             node.numVisibleEntities = 1;
                             node.checked = true;
@@ -645,6 +676,9 @@ class ModelTreeView {
         const nodeElement = document.createElement('li');
         //const nodeId = this._objectToNodeID(node.objectId);
         const nodeId = node.nodeId;
+        if (node.xrayed) {
+          nodeElement.classList.add('xrayed-node');
+        }
         nodeElement.id = 'node-' + nodeId;
         if (node.children.length > 0) {
             const switchElementId = "switch-" + nodeId;

--- a/src/plugins/TreeViewPlugin/TreeViewNode.js
+++ b/src/plugins/TreeViewPlugin/TreeViewNode.js
@@ -83,6 +83,15 @@ class TreeViewNode {
     get checked() {
 
     }
+
+    /** Whether or not the TreeViewNode is currently xrayed.
+     *
+     * @type {Boolean}
+     * @abstract
+     */
+     get xrayed() {
+
+    }
 }
 
 export {TreeViewNode};

--- a/src/viewer/scene/scene/Scene.js
+++ b/src/viewer/scene/scene/Scene.js
@@ -1062,7 +1062,7 @@ class Scene extends Component {
         }
     }
 
-    _objectXRayedUpdated(entity) {
+    _objectXRayedUpdated(entity, notify = true) {
         if (entity.xrayed) {
             if (ASSERT_OBJECT_STATE_UPDATE && this.xrayedObjects[entity.id]) {
                 console.error("Redundant object xray update (xrayed=true)");
@@ -1079,9 +1079,12 @@ class Scene extends Component {
             this._numXRayedObjects--;
         }
         this._xrayedObjectIds = null; // Lazy regenerate
+        if (notify) {
+          this.fire("objectXRayed", entity, true);
+        }
     }
 
-    _objectHighlightedUpdated(entity) {
+    _objectHighlightedUpdated(entity, notify = true) {
         if (entity.highlighted) {
             if (ASSERT_OBJECT_STATE_UPDATE && this.highlightedObjects[entity.id]) {
                 console.error("Redundant object highlight update (highlighted=true)");
@@ -1098,9 +1101,12 @@ class Scene extends Component {
             this._numHighlightedObjects--;
         }
         this._highlightedObjectIds = null; // Lazy regenerate
+        if (notify) {
+          this.fire("objectHighlighted", entity, true);
+        }
     }
 
-    _objectSelectedUpdated(entity) {
+    _objectSelectedUpdated(entity, notify = true) {
         if (entity.selected) {
             if (ASSERT_OBJECT_STATE_UPDATE && this.selectedObjects[entity.id]) {
                 console.error("Redundant object select update (selected=true)");
@@ -1117,6 +1123,9 @@ class Scene extends Component {
             this._numSelectedObjects--;
         }
         this._selectedObjectIds = null; // Lazy regenerate
+        if (notify) {
+          this.fire("objectSelected", entity, true);
+        }
     }
 
     _objectColorizeUpdated(entity, colorized) {

--- a/types/plugins/TreeViewPlugin/TreeViewNode.d.ts
+++ b/types/plugins/TreeViewPlugin/TreeViewNode.d.ts
@@ -63,4 +63,11 @@ export declare class TreeViewNode {
    * @abstract
    */
   get checked(): boolean;
+
+  /** Whether or not the TreeViewNode is currently xrayed.
+   *
+   * @type {Boolean}
+   * @abstract
+   */
+     get xrayed(): boolean;
 }

--- a/types/viewer/scene/scene/Scene.d.ts
+++ b/types/viewer/scene/scene/Scene.d.ts
@@ -63,7 +63,7 @@ export declare class Scene extends Component {
    * @param callback Called fired on the event
    * @param scope  Scope for the callback
    */
-   on(event: "objectVisibility", callback: (entity: VBOSceneModel | Mesh | Node) => void, scope?: any): string;
+   on(event: "objectVisibility" | "objectXRayed" | "objectHighlighted" | "objectSelected", callback: (entity: VBOSceneModel | Mesh | Node) => void, scope?: any): string;
 
    /**
    * Fired on each game loop iteration.


### PR DESCRIPTION
Enabled the scene to fire events when an entity is x-rayed, highlighted or selected. This behavior is similar to the visibility updated event.

The TreeViewPlugin has been updated to listen to the objectXRayed event, this allows the treeview to use a different styling for x-rayed entities. As soon as this is merged, the following can be added to the xeokit-bim-viewer stylesheet:

```css
.xeokit-objectsTab .xrayed-node,
.xeokit-storeysTab .xrayed-node,
.xeokit-classesTab .xrayed-node { /* Appearance of xrayed node */
    color: rgba(0, 0, 0, 0.3);
}
```

Typescript typing also updated