### PR TITLE
Additional data-textures feature toggles

### DIFF
--- a/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
+++ b/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
@@ -744,6 +744,7 @@ class XKTLoaderPlugin extends Plugin {
                 targetLodFps: params.useDataTextures.targetLodFps || false,
                 enableViewFrustumCulling: params.useDataTextures.enableViewFrustumCulling || false,
                 disableVertexWelding: params.useDataTextures.disableVertexWelding || false,
+                disableIndexRebucketing: params.useDataTextures.disableIndexRebucketing || false,
             }));
         } else {
             sceneModel = new VBOSceneModel(this.viewer.scene, utils.apply(params, {

--- a/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
+++ b/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
@@ -743,6 +743,7 @@ class XKTLoaderPlugin extends Plugin {
                 origin: params.origin,
                 targetLodFps: params.useDataTextures.targetLodFps || false,
                 enableViewFrustumCulling: params.useDataTextures.enableViewFrustumCulling || false,
+                disableVertexWelding: params.useDataTextures.disableVertexWelding || false,
             }));
         } else {
             sceneModel = new VBOSceneModel(this.viewer.scene, utils.apply(params, {

--- a/src/viewer/scene/models/DataTextureSceneModel/DataTextureSceneModel.js
+++ b/src/viewer/scene/models/DataTextureSceneModel/DataTextureSceneModel.js
@@ -63,6 +63,7 @@ class DataTextureSceneModel extends Component {
      * @param {Boolean} [cfg.pbrEnabled=false] Indicates if physically-based rendering (PBR) will apply to the dataTexturePerformanceModel. Only works when {@link Scene#pbrEnabled} is also ````true````.
      * @param {Number} [cfg.edgeThreshold=10] When xraying, highlighting, selecting or edging, this is the threshold angle between normals of adjacent triangles, below which their shared wireframe edge is not drawn.
      * @param {Boolean} [cfg.disableVertexWelding] Disable vertex welding when loading geometry into the GPU. Default is ```false```.
+     * @param {Boolean} [cfg.disableIndexRebucketing] Disable index rebucketing when loading geometry into the GPU. Default is ```false```.
      */
     constructor(owner, cfg = {}) {
         super(owner, cfg);
@@ -79,6 +80,15 @@ class DataTextureSceneModel extends Component {
          * @type {Boolean}
          */
         this._enableVertexWelding = !cfg.disableVertexWelding;
+
+        /**
+         * Enable demotion of index bitness then loading geometry into the ```TrianglesDataTextureLayer```.
+         * 
+         * The rebucketing is applied per-geometry.
+         * 
+         * @type {Boolean}
+         */
+        this._enableIndexRebucketing = !cfg.disableIndexRebucketing;
 
         this._targetLodFps = cfg.targetLodFps;
 
@@ -1135,7 +1145,8 @@ class DataTextureSceneModel extends Component {
 
             preparedGeometryCfg = prepareMeshGeometry (
                 geometryCfg,
-                this._enableVertexWelding
+                this._enableVertexWelding,
+                this._enableIndexRebucketing
             );
 
             if (instancing) {

--- a/src/viewer/scene/models/DataTextureSceneModel/DataTextureSceneModel.js
+++ b/src/viewer/scene/models/DataTextureSceneModel/DataTextureSceneModel.js
@@ -62,6 +62,7 @@ class DataTextureSceneModel extends Component {
      * @param {Boolean} [cfg.saoEnabled=true] Indicates if Scalable Ambient Obscurance (SAO) will apply to this dataTexturePerformanceModel. SAO is configured by the Scene's {@link SAO} component.
      * @param {Boolean} [cfg.pbrEnabled=false] Indicates if physically-based rendering (PBR) will apply to the dataTexturePerformanceModel. Only works when {@link Scene#pbrEnabled} is also ````true````.
      * @param {Number} [cfg.edgeThreshold=10] When xraying, highlighting, selecting or edging, this is the threshold angle between normals of adjacent triangles, below which their shared wireframe edge is not drawn.
+     * @param {Boolean} [cfg.disableVertexWelding] Disable vertex welding when loading geometry into the GPU. Default is ```false```.
      */
     constructor(owner, cfg = {}) {
         super(owner, cfg);
@@ -69,6 +70,15 @@ class DataTextureSceneModel extends Component {
         if (!(this.scene.canvas.gl instanceof WebGL2RenderingContext)) {
             throw "Using a DataTextureSceneModel requires the usage of webgl2";
         }
+
+        /**
+         * Enable welding vertices when loading geometry into the ```TrianglesDataTextureLayer```.
+         * 
+         * The welding is applied per-geometry.
+         * 
+         * @type {Boolean}
+         */
+        this._enableVertexWelding = !cfg.disableVertexWelding;
 
         this._targetLodFps = cfg.targetLodFps;
 
@@ -1123,7 +1133,10 @@ class DataTextureSceneModel extends Component {
 
             geometryCfg.edgeIndices = edgeIndices;
 
-            preparedGeometryCfg = prepareMeshGeometry (geometryCfg);
+            preparedGeometryCfg = prepareMeshGeometry (
+                geometryCfg,
+                this._enableVertexWelding
+            );
 
             if (instancing) {
                 this._preparedInstancingGeometries[geometryId] = preparedGeometryCfg;

--- a/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js
+++ b/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js
@@ -1744,7 +1744,7 @@ class TrianglesDataTextureLayer {
  * 
  * @returns {object} The mesh information enrichened with `.preparedBuckets` key.
  */
-function prepareMeshGeometry (geometryCfg, enableVertexWelding) {
+function prepareMeshGeometry (geometryCfg, enableVertexWelding, enableIndexRebucketing) {
     let uniquePositions, uniqueIndices, uniqueEdgeIndices;
 
     if (enableVertexWelding) {
@@ -1763,26 +1763,29 @@ function prepareMeshGeometry (geometryCfg, enableVertexWelding) {
         uniqueEdgeIndices = geometryCfg.edgeIndices;
     }
 
-    let numUniquePositions = uniquePositions.length / 3;
+    let buckets;
 
-    let buckets = rebucketPositions (
-        {
+    if (enableIndexRebucketing) {
+        let numUniquePositions = uniquePositions.length / 3;
+
+        buckets = rebucketPositions (
+            {
+                positions: uniquePositions,
+                indices: uniqueIndices,
+                edgeIndices: uniqueEdgeIndices,
+            },
+            (numUniquePositions > (1<< 16)) ? 16 : 8,
+            // true
+        );    
+    } else {
+        buckets = [{
             positions: uniquePositions,
             indices: uniqueIndices,
             edgeIndices: uniqueEdgeIndices,
-        },
-        (numUniquePositions > (1<< 16)) ? 16 : 8,
-        // true
-    );
+        }];
+    }
 
     geometryCfg.preparedBuckets = buckets;
-
-    // chipmunk
-    // geometryCfg.preparedBuckets = [{
-    //     positions: uniquePositions,
-    //     indices: uniqueIndices,
-    //     edgeIndices: uniqueEdgeIndices,
-    // }];
 
     return geometryCfg;
 }

--- a/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js
+++ b/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/TrianglesDataTextureLayer.js
@@ -1744,18 +1744,24 @@ class TrianglesDataTextureLayer {
  * 
  * @returns {object} The mesh information enrichened with `.preparedBuckets` key.
  */
-function prepareMeshGeometry (geometryCfg) {
+function prepareMeshGeometry (geometryCfg, enableVertexWelding) {
     let uniquePositions, uniqueIndices, uniqueEdgeIndices;
 
-    [
-        uniquePositions,
-        uniqueIndices,
-        uniqueEdgeIndices,
-    ] = uniquifyPositions.uniquifyPositions ({
-        positions: geometryCfg.positions,
-        indices: geometryCfg.indices,
-        edgeIndices: geometryCfg.edgeIndices
-    });
+    if (enableVertexWelding) {
+        [
+            uniquePositions,
+            uniqueIndices,
+            uniqueEdgeIndices,
+        ] = uniquifyPositions.uniquifyPositions ({
+            positions: geometryCfg.positions,
+            indices: geometryCfg.indices,
+            edgeIndices: geometryCfg.edgeIndices
+        });
+    } else {
+        uniquePositions = geometryCfg.positions;
+        uniqueIndices = geometryCfg.indices;
+        uniqueEdgeIndices = geometryCfg.edgeIndices;
+    }
 
     let numUniquePositions = uniquePositions.length / 3;
 


### PR DESCRIPTION
## Description

A couple loading options have been added to `XKTLoaderPlugin` when using data-textures:

```js
const model = xktLoaderPlugin.load({
    ...,
    useDataTextures: {
        ...,

        // optional: will enable/disable welding vertex positions when loading geometry,
        disableVertexWelding: true/false, // default: false

        // optional: will enable/disable adaptive demotion of triangles' indices bitness then loading geometry
        disableIndexRebucketing: true/false, // default: false
    }
});
```

- `useDataTextures.disableVertexWelding` is interesting in case the XKT files already contain welded vertices positions. In that case setting this value to `true` will speed up the loading of the XKT files.
- `useDataTextures.disableIndexRebucketing` is interesting to set it to `true` in case we want to save further load time, at the expense of slightly increased VRAM usage.

## Backwards compatible

The default values of the new options are made in such a way that the current behaviour in `main` branch is kept.

The default values correspond to maximum VRAM savings.

## Independent of other `data-texture` feature toggles

The two options introduced in this PR can be toggled separately, and they're also toggleable independent of the values of the already existing feature toggles for `data-textures`:

- `useDataTextures.targetLodFps`
- `useDataTextures.enableViewFrustumCulling`