### PR TITLE
Chrome-for-Mac: improved mitigation for data-textures when SAO enabled

### DIFF
--- a/src/viewer/scene/webgl/sao/SAODepthLimitedBlurRenderer.js
+++ b/src/viewer/scene/webgl/sao/SAODepthLimitedBlurRenderer.js
@@ -203,7 +203,7 @@ class SAODepthLimitedBlurRenderer {
         const positions = new Float32Array([1, 1, 0, -1, 1, 0, -1, -1, 0, 1, -1, 0]);
 
         // Mitigation: if Uint8Array is used, the geometry is corrupted on OSX when using Chrome with data-textures
-        const indices = new Uint16Array([0, 1, 2, 0, 2, 3]);
+        const indices = new Uint32Array([0, 1, 2, 0, 2, 3]);
 
         this._positionsBuf = new ArrayBuf(gl, gl.ARRAY_BUFFER, positions, positions.length, 3, gl.STATIC_DRAW);
         this._uvBuf = new ArrayBuf(gl, gl.ARRAY_BUFFER, uv, uv.length, 2, gl.STATIC_DRAW);

--- a/src/viewer/scene/webgl/sao/SAOOcclusionRenderer.js
+++ b/src/viewer/scene/webgl/sao/SAOOcclusionRenderer.js
@@ -335,7 +335,7 @@ class SAOOcclusionRenderer {
         const positions = new Float32Array([1, 1, 0, -1, 1, 0, -1, -1, 0, 1, -1, 0]);
         
         // Mitigation: if Uint8Array is used, the geometry is corrupted on OSX when using Chrome with data-textures
-        const indices = new Uint16Array([0, 1, 2, 0, 2, 3]);
+        const indices = new Uint32Array([0, 1, 2, 0, 2, 3]);
 
         this._positionsBuf = new ArrayBuf(gl, gl.ARRAY_BUFFER, positions, positions.length, 3, gl.STATIC_DRAW);
         this._uvBuf = new ArrayBuf(gl, gl.ARRAY_BUFFER, uv, uv.length, 2, gl.STATIC_DRAW);


### PR DESCRIPTION
## Description

Improvement over a previous mitigation where models containing objects with > 2^16 triangles, when using data-textures, got corrupted in Chrome for Mac when enabling SAO.

In the following demo videos, notice that LOD mechanism is toggled on, so while moving the camera some geometry is hidden to increase frame-rate.

- In the video `before-mitigation`, though, the geometry gets corrupted and random triangles appear or get removed.
- In the video `after-mitigation`, works well.

The problem needs further tracking: right now SAO with data-textures seem to work well, but a similar problem related to binding index-buffers of 8 or 16 bites (when using `gl.drawElements` in addition to data-textures `gl.drawArrays`: this is, DataTexture models together with ReadableGeometry models) is causing the geometry sometimes corrupt also on Chrome for Mac.

## Before this improved mitigation

https://user-images.githubusercontent.com/2405414/234825237-26e356c7-b55b-47d8-acca-4d66fa67f8bd.mov

## After the mitigation

https://user-images.githubusercontent.com/2405414/234825660-1885c763-fc7d-4c54-a547-c7e9b671f89f.mov

