### PR TITLE
[data-textures]: implement a smart deferred flags update mechanism

### DIFF
--- a/src/viewer/scene/models/DataTextureSceneModel/DataTextureSceneModel.js
+++ b/src/viewer/scene/models/DataTextureSceneModel/DataTextureSceneModel.js
@@ -1448,8 +1448,6 @@ class DataTextureSceneModel extends Component {
             return;
         }
 
-        this.beginDeferredFlagsInAllLayers ();
-
         if (this._vfcManager) {
             this._vfcManager.finalize (
                 function () {
@@ -1478,9 +1476,7 @@ class DataTextureSceneModel extends Component {
             node._finalize2();
         }
 
-
         // Sort layers to reduce WebGL shader switching when rendering them
-
         this._layerList.sort((a, b) => {
             if (a.sortId < b.sortId) {
                 return -1;
@@ -1496,8 +1492,6 @@ class DataTextureSceneModel extends Component {
             layer.layerIndex = i;
         }
 
-        this.commitDeferredFlagsInAllLayers ();
-
         this.glRedraw();
 
         this.scene._aabbDirty = true;
@@ -1511,6 +1505,11 @@ class DataTextureSceneModel extends Component {
                 [ 2000, 600, 150, 80, 20 ],
                 this._targetLodFps
             );
+        }
+
+        for (let i = 0, len = this._layerList.length; i < len; i++) {
+            const layer = this._layerList[i];
+            layer.attachToRenderingEvent();
         }
     }
 
@@ -1551,33 +1550,6 @@ class DataTextureSceneModel extends Component {
             if (layerVisible) {
                 renderFlags.visibleLayers[renderFlags.numVisibleLayers++] = layerIndex;
             }
-        }
-    }
-
-    /**
-     * This will start a "set-flags transaction" in all Layers of this Model.
-     */
-    beginDeferredFlagsInAllLayers ()
-    {
-        for (let i = 0, len = this._layerList.length; i < len; i++)
-        {
-            const layer = this._layerList[i];
-
-            layer.beginDeferredFlags ();
-        }
-    }
-    
-    /**
-     * This will commit any previously started "set-flags transaction" in all
-     * Layers of this Model.
-     */
-    commitDeferredFlagsInAllLayers ()
-    {
-        for (let i = 0, len = this._layerList.length; i < len; i++)
-        {
-            const layer = this._layerList[i];
-
-            layer.commitDeferredFlags ();
         }
     }
 

--- a/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/LodCullingManager.js
+++ b/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/LodCullingManager.js
@@ -349,8 +349,6 @@ class LodCullingManager {
         let lodState = this.lodState;
         const model = this.model;
         
-        model.beginDeferredFlagsInAllLayers ();
-
         let retVal = false;
 
         if (currentFPS < lodState.targetFps)
@@ -370,8 +368,6 @@ class LodCullingManager {
             }
         }
 
-        model.commitDeferredFlagsInAllLayers ();
-
         if (retVal) {
             console.log ("LOD level = " + lodState.lodLevelIndex);
         }
@@ -383,8 +379,6 @@ class LodCullingManager {
     {
         const model = this.model;
         
-        model.beginDeferredFlagsInAllLayers ();
-
         let retVal = false;
 
         let decreasedLevel = false;
@@ -392,8 +386,6 @@ class LodCullingManager {
         do {
             retVal |= (decreasedLevel = this._decreaseLODLevelIndex());
         } while (decreasedLevel);
-
-        model.commitDeferredFlagsInAllLayers ();   
 
         if (retVal) {
             console.log ("LOD resetted");

--- a/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/ViewFrustumCullingManager.js
+++ b/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/ViewFrustumCullingManager.js
@@ -354,16 +354,12 @@ const VISIBILITY_CHECK_ENVOLVES_V = (1 << 14);
         const internalNodesList = this._internalNodesList;
         const lastVisibleFrameOfNodes = this._lastVisibleFrameOfNodes;
 
-        model.beginDeferredFlagsInAllLayers ();
-
         for (let i = 0, len = internalNodesList.length; i < len; i++)
         {
             if (internalNodesList[i]) {
                 internalNodesList[i].culledVFC = lastVisibleFrameOfNodes[i] !== cullFrame;
             }
         }
-
-        model.commitDeferredFlagsInAllLayers ();
     }
 
     /**


### PR DESCRIPTION
If the number of updated per-object properties in a frame is less than a threshold, they will be updated directly.

If the number of updates is instead bigger than a threshold (by default 10), the ones above the threshold will be batched, and the batch flushed just before rendering the frame.

This completely solves https://github.com/xeokit/xeokit-sdk/issues/1033