### PR TITLE
[fix]: make sure to restore `gl.pixelStatei` changes in `Texture2D` class

### DIFF
--- a/src/viewer/scene/webgl/Texture2D.js
+++ b/src/viewer/scene/webgl/Texture2D.js
@@ -127,9 +127,17 @@ class Texture2D {
         let generateMipMap = false;
 
         gl.bindTexture(this.target, this.texture);
+
+        const bak1 = gl.getParameter(gl.UNPACK_FLIP_Y_WEBGL);
         gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, this.flipY);
+
+        const bak2 = gl.getParameter(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL);
         gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, this.premultiplyAlpha);
+
+        const bak3 = gl.getParameter(gl.UNPACK_ALIGNMENT);
         gl.pixelStorei(gl.UNPACK_ALIGNMENT, this.unpackAlignment);
+
+        const bak4 = gl.getParameter(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL);;
         gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, gl.NONE);
 
         const minFilter = convertConstant(gl, this.minFilter);
@@ -185,6 +193,11 @@ class Texture2D {
         }
 
         gl.bindTexture(this.target, null);
+
+        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, bak1);
+        gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL, bak2);
+        gl.pixelStorei(gl.UNPACK_ALIGNMENT, bak3);
+        gl.pixelStorei(gl.UNPACK_COLORSPACE_CONVERSION_WEBGL, bak4);
     }
 
     setCompressedData({mipmaps, props = {}}) {


### PR DESCRIPTION
## Description

This fix introduces a better compability mechanism between previously existing `Texture2D` class and the new data-textures optimization when scenes ar set-up containing both data-tex-models and textures readable-geometries.

The key that was causing the bug was the `Texture2D` class modifying the default values for `gl.pixelStorei` w/out later restoring its values. Looks like in WebGL the last set values for `gl.pixelStorei` are carried to newer textures created after setting them, and this created a collision between the tweakable parameters (such as inverted-Y for the SkyBox example) and the (default) parameters used by data-textures data storage.

Before the fix, for the OTT Conference Center when the SkyBox was enabled:

<img width="913" alt="image" src="https://github.com/xeokit/xeokit-sdk/assets/2405414/6826f8f6-5d76-45ee-bdc6-e2fa38771f31">

After the fix:

https://github.com/xeokit/xeokit-sdk/assets/2405414/9604fb1d-89ec-45d1-9533-3ff73881a826

