### PR TITLE
remove buffer.flags & flags2 arrays

### DIFF
--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/linesBatching/LinesBatchingBuffer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/linesBatching/LinesBatchingBuffer.js
@@ -13,8 +13,6 @@ class LinesBatchingBuffer {
         this.maxIndices = maxGeometryBatchSize * 3; // Rough rule-of-thumb
         this.positions = [];
         this.colors = [];
-        this.flags = [];
-        this.flags2 = [];
         this.offsets = [];
         this.indices = [];
     }

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsBatching/PointsBatchingBuffer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsBatching/PointsBatchingBuffer.js
@@ -15,8 +15,6 @@ class PointsBatchingBuffer {
         this.colors = [];
         this.intensities = [];
         this.pickColors = [];
-        this.flags = [];
-        this.flags2 = [];
         this.offsets = [];
     }
 }

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/TrianglesBatchingBuffer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/TrianglesBatchingBuffer.js
@@ -17,8 +17,6 @@ class TrianglesBatchingBuffer {
         this.metallicRoughness = [];
         this.normals = [];
         this.pickColors = [];
-        this.flags = [];
-        this.flags2 = [];
         this.offsets = [];
         this.indices = [];
         this.edgeIndices = [];


### PR DESCRIPTION
VBOSceneModel Layer state flagsBuf & flags2Buf [are not populate from buffer data](https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/TrianglesBatchingLayer.js#L499-L500) but from [initFlags calls](https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/TrianglesBatchingLayer.js#L550).