### PR TITLE
Fire error event from WebIFCLoaderPlugin when loading a modal fails

### DIFF
--- a/src/plugins/WebIFCLoaderPlugin/WebIFCLoaderPlugin.js
+++ b/src/plugins/WebIFCLoaderPlugin/WebIFCLoaderPlugin.js
@@ -618,10 +618,15 @@ class WebIFCLoaderPlugin extends Plugin {
         }
 
         this.on("initialized", () => {
-            if (params.src) {
-                this._loadModel(params.src, params, options, sceneModel);
-            } else {
-                this._parseModel(params.ifc, params, options, sceneModel);
+            try {
+                if (params.src) {
+                    this._loadModel(params.src, params, options, sceneModel);
+                } else {
+                    this._parseModel(params.ifc, params, options, sceneModel);
+                }
+            } catch (e) {
+                this.error(e);
+                sceneModel.fire("error", e);
             }
         });
 


### PR DESCRIPTION
Fixes https://github.com/xeokit/xeokit-sdk/issues/1054

Wraps the `initialized` function in a try catch block that dispatches all caught errors to the `onSceneLoadError ` handler.

Open Questions:
- What style guide do you use and how do you apply it? 

