### PR TITLE
Reduce VBOSceneModel flags memory footprint

### DIFF
--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/linesBatching/LinesBatchingLayer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/linesBatching/LinesBatchingLayer.js
@@ -537,6 +537,9 @@ class LinesBatchingLayer {
         this._setFlags(portionId, flags, transparent);
     }
 
+    /**
+     * flags are 4bits values encoded on a 32bit base. color flag on the first 4 bits, silhouette flag on the next 4 bits and so on for edge, pick and clippable.
+     */
     _setFlags(portionId, flags, transparent, deferred = false) {
 
         if (!this._finalized) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/linesBatching/renderers/LinesBatchingColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/linesBatching/renderers/LinesBatchingColorRenderer.js
@@ -1,7 +1,6 @@
 import {Program} from "../../../../../../webgl/Program.js";
 import {math} from "../../../../../../math/math.js";
 import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
-import {WEBGL_INFO} from "../../../../../../webglInfo.js";
 
 const tempVec3a = math.vec3();
 
@@ -89,10 +88,6 @@ class LinesBatchingColorRenderer {
             this._aFlags.bindArrayBuffer(state.flagsBuf);
         }
 
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf);
-        }
-
         if (this._aOffset) {
             this._aOffset.bindArrayBuffer(state.offsetsBuf);
         }
@@ -138,7 +133,6 @@ class LinesBatchingColorRenderer {
         this._aOffset = program.getAttribute("offset");
         this._aColor = program.getAttribute("color");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
 
         if (scene.logarithmicDepthBufferEnabled) {
             this._uLogDepthBufFC = program.getLocation("logDepthBufFC");
@@ -179,8 +173,7 @@ class LinesBatchingColorRenderer {
         src.push("uniform int renderPass;");
         src.push("in vec3 position;");
         src.push("in vec4 color;");
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
         if (scene.entityOffsetsEnabled) {
             src.push("in vec3 offset;");
         }
@@ -194,13 +187,14 @@ class LinesBatchingColorRenderer {
         }
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
         src.push("out vec4 vColor;");
         src.push("void main(void) {");
-        // flags.x = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
+        // colorFlag = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
         // renderPass = COLOR_OPAQUE
-        src.push(`if (int(flags.x) != renderPass) {`);
+        src.push(`int colorFlag = int(flags) & 0xF;`);
+        src.push(`if (colorFlag != renderPass) {`);
         src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
         src.push("} else {");
         src.push("vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
@@ -211,7 +205,7 @@ class LinesBatchingColorRenderer {
         src.push("vColor = vec4(float(color.r) / 255.0, float(color.g) / 255.0, float(color.b) / 255.0, float(color.a) / 255.0);");
         if (clipping) {
             src.push("vWorldPosition = worldPosition;");
-            src.push("vFlags2 = flags2;");
+            src.push("vFlags = flags;");
         }
         src.push("vec4 clipPos = projMatrix * viewPosition;");
         if (scene.logarithmicDepthBufferEnabled) {
@@ -243,7 +237,7 @@ class LinesBatchingColorRenderer {
         }
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -254,7 +248,7 @@ class LinesBatchingColorRenderer {
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/linesInstancing/LinesInstancingLayer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/linesInstancing/LinesInstancingLayer.js
@@ -8,6 +8,7 @@ import {getInstancingRenderers} from "./LinesInstancingRenderers.js";
 
 
 const tempUint8Vec4 = new Uint8Array(4);
+const tempFloat32 = new Float32Array(1);
 
 const tempVec4a = math.vec4([0, 0, 0, 1]);
 const tempVec4b = math.vec4([0, 0, 0, 1]);
@@ -216,7 +217,7 @@ class LinesInstancingLayer {
         }
         const gl = this.model.scene.canvas.gl;
         const colorsLength = this._colors.length;
-        const flagsLength = colorsLength;
+        const flagsLength = colorsLength / 4;
         if (colorsLength > 0) {
             let notNormalized = false;
             this._state.colorsBuf = new ArrayBuf(gl, gl.ARRAY_BUFFER, new Uint8Array(this._colors), this._colors.length, 4, gl.DYNAMIC_DRAW, notNormalized);
@@ -226,9 +227,7 @@ class LinesInstancingLayer {
             // Because we only build flags arrays here, 
             // get their length from the colors array
             let notNormalized = false;
-            let normalized = true;
-            this._state.flagsBuf = new ArrayBuf(gl, gl.ARRAY_BUFFER, new Uint8Array(flagsLength), flagsLength, 4, gl.DYNAMIC_DRAW, notNormalized);
-            this._state.flags2Buf = new ArrayBuf(gl, gl.ARRAY_BUFFER, new Uint8Array(flagsLength), flagsLength, 4, gl.DYNAMIC_DRAW, normalized);
+            this._state.flagsBuf = new ArrayBuf(gl, gl.ARRAY_BUFFER, new Float32Array(flagsLength), flagsLength, 1, gl.DYNAMIC_DRAW, notNormalized);
         }
         if (this.model.scene.entityOffsetsEnabled) {
             if (this._offsets.length > 0) {
@@ -290,7 +289,6 @@ class LinesInstancingLayer {
             this.model.numTransparentLayerPortions++;
         }
         this._setFlags(portionId, flags, meshTransparent);
-        this._setFlags2(portionId, flags);
     }
 
     setVisible(portionId, flags, meshTransparent) {
@@ -374,7 +372,7 @@ class LinesInstancingLayer {
             this._numClippableLayerPortions--;
             this.model.numClippableLayerPortions--;
         }
-        this._setFlags2(portionId, flags);
+        this._setFlags(portionId, flags);
     }
 
     setCollidable(portionId, flags) {
@@ -394,7 +392,7 @@ class LinesInstancingLayer {
             this._numPickableLayerPortions--;
             this.model.numPickableLayerPortions--;
         }
-        this._setFlags2(portionId, flags, meshTransparent);
+        this._setFlags(portionId, flags, meshTransparent);
     }
 
     setCulled(portionId, flags, meshTransparent) {
@@ -447,79 +445,65 @@ class LinesInstancingLayer {
         const pickable = !!(flags & ENTITY_FLAGS.PICKABLE);
         const culled = !!(flags & ENTITY_FLAGS.CULLED);
 
-        // Normal fill
-
-        let f0;
+        let colorFlag;
         if (!visible || culled || xrayed
             || (highlighted && !this.model.scene.highlightMaterial.glowThrough)
             || (selected && !this.model.scene.selectedMaterial.glowThrough) ) {
-            f0 = RENDER_PASSES.NOT_RENDERED;
+            colorFlag = RENDER_PASSES.NOT_RENDERED;
         } else {
             if (meshTransparent) {
-                f0 = RENDER_PASSES.COLOR_TRANSPARENT;
+                colorFlag = RENDER_PASSES.COLOR_TRANSPARENT;
             } else {
-                f0 = RENDER_PASSES.COLOR_OPAQUE;
+                colorFlag = RENDER_PASSES.COLOR_OPAQUE;
             }
         }
 
-        // Emphasis fill
-
-        let f1;
+        let silhouetteFlag;
         if (!visible || culled) {
-            f1 = RENDER_PASSES.NOT_RENDERED;
+            silhouetteFlag = RENDER_PASSES.NOT_RENDERED;
         } else if (selected) {
-            f1 = RENDER_PASSES.SILHOUETTE_SELECTED;
+            silhouetteFlag = RENDER_PASSES.SILHOUETTE_SELECTED;
         } else if (highlighted) {
-            f1 = RENDER_PASSES.SILHOUETTE_HIGHLIGHTED;
+            silhouetteFlag = RENDER_PASSES.SILHOUETTE_HIGHLIGHTED;
         } else if (xrayed) {
-            f1 = RENDER_PASSES.SILHOUETTE_XRAYED;
+            silhouetteFlag = RENDER_PASSES.SILHOUETTE_XRAYED;
         } else {
-            f1 = RENDER_PASSES.NOT_RENDERED;
+            silhouetteFlag = RENDER_PASSES.NOT_RENDERED;
         }
 
-        // Edges
-
-        let f2 = 0;
+        let edgeFlag = 0;
         if (!visible || culled) {
-            f2 = RENDER_PASSES.NOT_RENDERED;
+            edgeFlag = RENDER_PASSES.NOT_RENDERED;
         } else if (selected) {
-            f2 = RENDER_PASSES.EDGES_SELECTED;
+            edgeFlag = RENDER_PASSES.EDGES_SELECTED;
         } else if (highlighted) {
-            f2 = RENDER_PASSES.EDGES_HIGHLIGHTED;
+            edgeFlag = RENDER_PASSES.EDGES_HIGHLIGHTED;
         } else if (xrayed) {
-            f2 = RENDER_PASSES.EDGES_XRAYED;
+            edgeFlag = RENDER_PASSES.EDGES_XRAYED;
         } else if (edges) {
             if (meshTransparent) {
-                f2 = RENDER_PASSES.EDGES_COLOR_TRANSPARENT;
+                edgeFlag = RENDER_PASSES.EDGES_COLOR_TRANSPARENT;
             } else {
-                f2 = RENDER_PASSES.EDGES_COLOR_OPAQUE;
+                edgeFlag = RENDER_PASSES.EDGES_COLOR_OPAQUE;
             }
         } else {
-            f2 = RENDER_PASSES.NOT_RENDERED;
+            edgeFlag = RENDER_PASSES.NOT_RENDERED;
         }
 
-        // Pick
+        let pickFlag = (visible && !culled && pickable) ? RENDER_PASSES.PICK : RENDER_PASSES.NOT_RENDERED;
 
-        let f3 = (visible && !culled && pickable) ? RENDER_PASSES.PICK : RENDER_PASSES.NOT_RENDERED;
+        const clippableFlag = !!(flags & ENTITY_FLAGS.CLIPPABLE) ? 255 : 0;
 
-        tempUint8Vec4[0] = f0; // x - normal fill
-        tempUint8Vec4[1] = f1; // y - emphasis fill
-        tempUint8Vec4[2] = f2; // z - edges
-        tempUint8Vec4[3] = f3; // w - pick
+        let vertFlag = 0;
+        vertFlag |= colorFlag;
+        vertFlag |= silhouetteFlag << 4;
+        vertFlag |= edgeFlag << 8;
+        vertFlag |= pickFlag << 12;
+        vertFlag |= clippableFlag << 16;
 
-        this._state.flagsBuf.setData(tempUint8Vec4, portionId * 4, 4);
-    }
+        tempFloat32[0] = vertFlag;
 
-    _setFlags2(portionId, flags) {
-
-        if (!this._finalized) {
-            throw "Not finalized";
-        }
-
-        const clippable = !!(flags & ENTITY_FLAGS.CLIPPABLE) ? 255 : 0;
-        tempUint8Vec4[0] = clippable;
-
-        this._state.flags2Buf.setData(tempUint8Vec4, portionId * 4, 4);
+        this._state.flagsBuf.setData(tempFloat32, portionId);
     }
 
     setOffset(portionId, offset) {
@@ -646,10 +630,6 @@ class LinesInstancingLayer {
         if (state.flagsBuf) {
             state.flagsBuf.destroy();
             state.flagsBuf = null;
-        }
-        if (state.flags2Buf) {
-            state.flags2Buf.destroy();
-            state.flags2Buf = null;
         }
         if (state.offsetsBuf) {
             state.offsetsBuf.destroy();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/linesInstancing/LinesInstancingLayer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/linesInstancing/LinesInstancingLayer.js
@@ -431,6 +431,9 @@ class LinesInstancingLayer {
         this._setFlags(portionId, flags, transparent);
     }
 
+    /**
+     * flags are 4bits values encoded on a 32bit base. color flag on the first 4 bits, silhouette flag on the next 4 bits and so on for edge, pick and clippable.
+     */
     _setFlags(portionId, flags, meshTransparent) {
 
         if (!this._finalized) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/linesInstancing/renderers/LinesInstancingColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/linesInstancing/renderers/LinesInstancingColorRenderer.js
@@ -94,11 +94,6 @@ class LinesInstancingColorRenderer {
         this._aFlags.bindArrayBuffer(state.flagsBuf);
         gl.vertexAttribDivisor(this._aFlags.location, 1);
 
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf);
-            gl.vertexAttribDivisor(this._aFlags2.location, 1);
-        }
-
         if (this._aOffset) {
             this._aOffset.bindArrayBuffer(state.offsetsBuf);
             gl.vertexAttribDivisor(this._aOffset.location, 1);
@@ -116,10 +111,6 @@ class LinesInstancingColorRenderer {
 
         gl.vertexAttribDivisor(this._aColor.location, 0);
         gl.vertexAttribDivisor(this._aFlags.location, 0);
-
-        if (this._aFlags2) { // Won't be in shader when not clipping
-            gl.vertexAttribDivisor(this._aFlags2.location, 0);
-        }
 
         if (this._aOffset) {
             gl.vertexAttribDivisor(this._aOffset.location, 0);
@@ -162,7 +153,6 @@ class LinesInstancingColorRenderer {
         this._aPosition = program.getAttribute("position");
         this._aColor = program.getAttribute("color");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
         this._aOffset = program.getAttribute("offset");
 
         this._aModelMatrixCol0 = program.getAttribute("modelMatrixCol0");
@@ -206,8 +196,7 @@ class LinesInstancingColorRenderer {
 
         src.push("in vec3 position;");
         src.push("in vec4 color;");
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
 
         if (scene.entityOffsetsEnabled) {
             src.push("in vec3 offset;");
@@ -231,16 +220,17 @@ class LinesInstancingColorRenderer {
 
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
         src.push("out vec4 vColor;");
 
         src.push("void main(void) {");
 
-        // flags.x = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
+        // colorFlag = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
         // renderPass = COLOR_OPAQUE | COLOR_TRANSPARENT
 
-        src.push(`if (int(flags.x) != renderPass) {`);
+        src.push(`int colorFlag = int(flags) & 0xF;`);
+        src.push(`if (colorFlag != renderPass) {`);
         src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
 
         src.push("} else {");
@@ -257,7 +247,7 @@ class LinesInstancingColorRenderer {
 
         if (clipping) {
             src.push("vWorldPosition = worldPosition;");
-            src.push("vFlags2 = flags2;");
+            src.push("vFlags = flags;");
         }
         src.push("vec4 clipPos = projMatrix * viewPosition;");
         if (scene.logarithmicDepthBufferEnabled) {
@@ -291,7 +281,7 @@ class LinesInstancingColorRenderer {
         }
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -302,7 +292,7 @@ class LinesInstancingColorRenderer {
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/linesInstancing/renderers/LinesInstancingSilhouetteRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/linesInstancing/renderers/LinesInstancingSilhouetteRenderer.js
@@ -114,11 +114,6 @@ class LinesInstancingSilhouetteRenderer {
         this._aFlags.bindArrayBuffer(state.flagsBuf, gl.UNSIGNED_BYTE, true);
         gl.vertexAttribDivisor(this._aFlags.location, 1);
 
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf, gl.UNSIGNED_BYTE, true);
-            gl.vertexAttribDivisor(this._aFlags2.location, 1);
-        }
-
         if (this._aOffset) {
             this._aOffset.bindArrayBuffer(state.offsetsBuf);
             gl.vertexAttribDivisor(this._aOffset.location, 1);
@@ -133,9 +128,6 @@ class LinesInstancingSilhouetteRenderer {
         gl.vertexAttribDivisor(this._aModelMatrixCol2.location, 0);
 
         gl.vertexAttribDivisor(this._aFlags.location, 0);
-        if (this._aFlags2) {
-            gl.vertexAttribDivisor(this._aFlags2.location, 0);
-        }
         if (this._aOffset) {
             gl.vertexAttribDivisor(this._aOffset.location, 0);
         }
@@ -176,7 +168,6 @@ class LinesInstancingSilhouetteRenderer {
         this._aPosition = program.getAttribute("position");
         this._aOffset = program.getAttribute("offset");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
         this._aModelMatrixCol0 = program.getAttribute("modelMatrixCol0");
         this._aModelMatrixCol1 = program.getAttribute("modelMatrixCol1");
         this._aModelMatrixCol2 = program.getAttribute("modelMatrixCol2");
@@ -222,8 +213,7 @@ class LinesInstancingSilhouetteRenderer {
         if (scene.entityOffsetsEnabled) {
             src.push("in vec3 offset;");
         }
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
 
         src.push("in vec4 modelMatrixCol0;"); // Modeling matrix
         src.push("in vec4 modelMatrixCol1;");
@@ -243,15 +233,16 @@ class LinesInstancingSilhouetteRenderer {
 
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
 
         src.push("void main(void) {");
 
-        // flags.y = NOT_RENDERED | SILHOUETTE_HIGHLIGHTED | SILHOUETTE_SELECTED | | SILHOUETTE_XRAYED
+        // silhouetteFlag = NOT_RENDERED | SILHOUETTE_HIGHLIGHTED | SILHOUETTE_SELECTED | | SILHOUETTE_XRAYED
         // renderPass = SILHOUETTE_HIGHLIGHTED | SILHOUETTE_SELECTED | | SILHOUETTE_XRAYED
 
-        src.push(`if (int(flags.y) != renderPass) {`);
+        src.push(`int silhouetteFlag = int(flags) >> 4 & 0xF;`);
+        src.push(`if (silhouetteFlag != renderPass) {`);
         src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
 
         src.push("} else {");
@@ -265,7 +256,7 @@ class LinesInstancingSilhouetteRenderer {
 
         if (clipping) {
             src.push("vWorldPosition = worldPosition;");
-            src.push("vFlags2 = flags2;");
+            src.push("vFlags = flags;");
         }
         src.push("vec4 clipPos = projMatrix * viewPosition;");
         if (scene.logarithmicDepthBufferEnabled) {
@@ -297,7 +288,7 @@ class LinesInstancingSilhouetteRenderer {
         }
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -308,7 +299,7 @@ class LinesInstancingSilhouetteRenderer {
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsBatching/PointsBatchingLayer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsBatching/PointsBatchingLayer.js
@@ -542,6 +542,9 @@ class PointsBatchingLayer {
         this._setFlags(portionId, flags, transparent);
     }
 
+    /**
+     * flags are 4bits values encoded on a 32bit base. color flag on the first 4 bits, silhouette flag on the next 4 bits and so on for edge, pick and clippable.
+     */
     _setFlags(portionId, flags, transparent) {
 
         if (!this._finalized) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsBatching/renderers/PointsBatchingColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsBatching/renderers/PointsBatchingColorRenderer.js
@@ -1,7 +1,6 @@
 import {Program} from "../../../../../../webgl/Program.js";
 import {math} from "../../../../../../math/math.js";
 import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
-import {WEBGL_INFO} from "../../../../../../webglInfo.js";
 
 const tempVec3a = math.vec3();
 
@@ -91,10 +90,6 @@ class PointsBatchingColorRenderer {
             this._aFlags.bindArrayBuffer(state.flagsBuf);
         }
 
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf);
-        }
-
         if (this._aOffset) {
             this._aOffset.bindArrayBuffer(state.offsetsBuf);
         }
@@ -143,7 +138,6 @@ class PointsBatchingColorRenderer {
         this._aOffset = program.getAttribute("offset");
         this._aColor = program.getAttribute("color");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
 
         this._uPointSize = program.getLocation("pointSize");
         this._uNearPlaneHeight = program.getLocation("nearPlaneHeight");
@@ -195,8 +189,7 @@ class PointsBatchingColorRenderer {
 
         src.push("in vec3 position;");
         src.push("in vec4 color;");
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
 
         if (scene.entityOffsetsEnabled) {
             src.push("in vec3 offset;");
@@ -224,16 +217,17 @@ class PointsBatchingColorRenderer {
 
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
         src.push("out vec4 vColor;");
 
         src.push("void main(void) {");
 
-        // flags.x = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
+        // colorFlag = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
         // renderPass = COLOR_OPAQUE
 
-        src.push(`if (int(flags.x) != renderPass) {`);
+        src.push(`int colorFlag = int(flags) & 0xF;`);
+        src.push(`if (colorFlag != renderPass) {`);
         src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
 
         src.push("} else {");
@@ -255,7 +249,7 @@ class PointsBatchingColorRenderer {
 
         if (clipping) {
             src.push("vWorldPosition = worldPosition;");
-            src.push("vFlags2 = flags2;");
+            src.push("vFlags = flags;");
         }
         src.push("vec4 clipPos = projMatrix * viewPosition;");
         if (scene.logarithmicDepthBufferEnabled) {
@@ -299,7 +293,7 @@ class PointsBatchingColorRenderer {
         }
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -317,7 +311,7 @@ class PointsBatchingColorRenderer {
             src.push("  }");
         }
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsBatching/renderers/PointsBatchingOcclusionRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsBatching/renderers/PointsBatchingOcclusionRenderer.js
@@ -1,7 +1,6 @@
 import {Program} from "../../../../../../webgl/Program.js";
 import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
 import {math} from "../../../../../../math/math.js";
-import {WEBGL_INFO} from "../../../../../../webglInfo.js";
 
 const tempVec3a = math.vec3();
 
@@ -85,10 +84,6 @@ class PointsBatchingOcclusionRenderer {
 
         this._aFlags.bindArrayBuffer(state.flagsBuf);
 
-        if (this._aFlags2) { // Won't be in shader when not clipping
-            this._aFlags2.bindArrayBuffer(state.flags2Buf);
-        }
-
         gl.uniform1f(this._uPointSize, pointsMaterial.pointSize);
         const nearPlaneHeight = (scene.camera.projection === "ortho") ? 1.0 : (gl.drawingBufferHeight / (2 * Math.tan(0.5 * scene.camera.perspective.fov * Math.PI / 180.0)));
         gl.uniform1f(this._uNearPlaneHeight, nearPlaneHeight);
@@ -128,7 +123,6 @@ class PointsBatchingOcclusionRenderer {
         this._aPosition = program.getAttribute("position");
         this._aOffset = program.getAttribute("offset");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
 
         this._uPointSize = program.getLocation("pointSize");
         this._uNearPlaneHeight = program.getLocation("nearPlaneHeight");
@@ -173,8 +167,7 @@ class PointsBatchingOcclusionRenderer {
         if (scene.entityOffsetsEnabled) {
             src.push("in vec3 offset;");
         }
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
 
         src.push("uniform mat4 worldMatrix;");
         src.push("uniform mat4 viewMatrix;");
@@ -192,15 +185,16 @@ class PointsBatchingOcclusionRenderer {
         }
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
         src.push("void main(void) {");
 
-        // flags.x = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
+        // colorFlag = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
         // renderPass = COLOR_OPAQUE
         // Only opaque objects can be occluders
 
-        src.push(`if (int(flags.x) != renderPass) {`);
+        src.push(`int colorFlag = int(flags) & 0xF;`);
+        src.push(`if (colorFlag != renderPass) {`);
         src.push("      gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
 
         src.push("  } else {");
@@ -212,7 +206,7 @@ class PointsBatchingOcclusionRenderer {
         src.push("      vec4 viewPosition  = viewMatrix * worldPosition; ");
         if (clipping) {
             src.push("      vWorldPosition = worldPosition;");
-            src.push("      vFlags2 = flags2;");
+            src.push("      vFlags = flags;");
         }
         src.push("vec4 clipPos = projMatrix * viewPosition;");
         if (scene.logarithmicDepthBufferEnabled) {
@@ -251,7 +245,7 @@ class PointsBatchingOcclusionRenderer {
         }
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -268,7 +262,7 @@ class PointsBatchingOcclusionRenderer {
             src.push("  }");
         }
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("      float dist = 0.0;");
             for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsBatching/renderers/PointsBatchingPickDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsBatching/renderers/PointsBatchingPickDepthRenderer.js
@@ -102,10 +102,6 @@ class PointsBatchingPickDepthRenderer {
             this._aFlags.bindArrayBuffer(state.flagsBuf);
         }
 
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf);
-        }
-
         gl.uniform1f(this._uPointSize, pointsMaterial.pointSize);
         const nearPlaneHeight = (scene.camera.projection === "ortho") ? 1.0 : (gl.drawingBufferHeight / (2 * Math.tan(0.5 * scene.camera.perspective.fov * Math.PI / 180.0)));
         gl.uniform1f(this._uNearPlaneHeight, nearPlaneHeight);
@@ -146,7 +142,6 @@ class PointsBatchingPickDepthRenderer {
         this._aPosition = program.getAttribute("position");
         this._aOffset = program.getAttribute("offset");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
         this._uPickZNear = program.getLocation("pickZNear");
         this._uPickZFar = program.getLocation("pickZFar");
 
@@ -182,8 +177,7 @@ class PointsBatchingPickDepthRenderer {
         if (scene.entityOffsetsEnabled) {
             src.push("in vec3 offset;");
         }
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
 
         src.push("uniform bool pickInvisible;");
 
@@ -204,15 +198,16 @@ class PointsBatchingPickDepthRenderer {
 
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
         src.push("out vec4 vViewPosition;");
         src.push("void main(void) {");
 
-        // flags.w = NOT_RENDERED | PICK
+        // pickFlag = NOT_RENDERED | PICK
         // renderPass = PICK
 
-        src.push(`if (int(flags.w) != renderPass) {`);
+        src.push(`int pickFlag = int(flags) >> 12 & 0xF;`);
+        src.push(`if (pickFlag != renderPass) {`);
         src.push("      gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
         src.push("  } else {");
         src.push("      vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
@@ -222,7 +217,7 @@ class PointsBatchingPickDepthRenderer {
         src.push("      vec4 viewPosition  = viewMatrix * worldPosition; ");
         if (clipping) {
             src.push("      vWorldPosition = worldPosition;");
-            src.push("      vFlags2 = flags2;");
+            src.push("      vFlags = flags;");
         }
         src.push("vViewPosition = viewPosition;");
         src.push("vec4 clipPos = projMatrix * viewPosition;");
@@ -269,7 +264,7 @@ class PointsBatchingPickDepthRenderer {
 
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -294,7 +289,7 @@ class PointsBatchingPickDepthRenderer {
             src.push("  }");
         }
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("      float dist = 0.0;");
             for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsBatching/renderers/PointsBatchingSilhouetteRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsBatching/renderers/PointsBatchingSilhouetteRenderer.js
@@ -113,10 +113,6 @@ class PointsBatchingSilhouetteRenderer {
             this._aFlags.bindArrayBuffer(state.flagsBuf);
         }
 
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf);
-        }
-
         gl.uniform1f(this._uPointSize, pointsMaterial.pointSize);
         const nearPlaneHeight = (scene.camera.projection === "ortho") ? 1.0 : (gl.drawingBufferHeight / (2 * Math.tan(0.5 * scene.camera.perspective.fov * Math.PI / 180.0)));
         gl.uniform1f(this._uNearPlaneHeight, nearPlaneHeight);
@@ -157,7 +153,6 @@ class PointsBatchingSilhouetteRenderer {
         this._aPosition = program.getAttribute("position");
         this._aOffset = program.getAttribute("offset");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
 
         this._uPointSize = program.getLocation("pointSize");
         this._uNearPlaneHeight = program.getLocation("nearPlaneHeight");
@@ -205,8 +200,7 @@ class PointsBatchingSilhouetteRenderer {
         if (scene.entityOffsetsEnabled) {
             src.push("in vec3 offset;");
         }
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
         src.push("uniform mat4 worldMatrix;");
         src.push("uniform mat4 viewMatrix;");
         src.push("uniform mat4 projMatrix;");
@@ -225,15 +219,16 @@ class PointsBatchingSilhouetteRenderer {
 
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
 
         src.push("void main(void) {");
 
-        // flags.y = NOT_RENDERED | SILHOUETTE_HIGHLIGHTED | SILHOUETTE_SELECTED | SILHOUETTE_XRAYED
+        // silhouetteFlag = NOT_RENDERED | SILHOUETTE_HIGHLIGHTED | SILHOUETTE_SELECTED | SILHOUETTE_XRAYED
         // renderPass = SILHOUETTE_HIGHLIGHTED | SILHOUETTE_SELECTED | | SILHOUETTE_XRAYED
 
-        src.push(`if (int(flags.y) != renderPass) {`);
+        src.push(`int silhouetteFlag = int(flags) >> 4 & 0xF;`);
+        src.push(`if (silhouetteFlag != renderPass) {`);
         src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
         src.push("} else {");
 
@@ -244,7 +239,7 @@ class PointsBatchingSilhouetteRenderer {
         src.push("vec4 viewPosition  = viewMatrix * worldPosition; ");
         if (clipping) {
             src.push("vWorldPosition = worldPosition;");
-            src.push("vFlags2 = flags2;");
+            src.push("vFlags = flags;");
         }
         src.push("vec4 clipPos = projMatrix * viewPosition;");
         if (scene.logarithmicDepthBufferEnabled) {
@@ -285,7 +280,7 @@ class PointsBatchingSilhouetteRenderer {
         }
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -303,7 +298,7 @@ class PointsBatchingSilhouetteRenderer {
             src.push("  }");
         }
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/PointsInstancingLayer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/PointsInstancingLayer.js
@@ -444,6 +444,9 @@ class PointsInstancingLayer {
     //     this._state.modelMatrixCol2Buf.setData(tempFloat32Vec4, offset);
     // }
 
+    /**
+     * flags are 4bits values encoded on a 32bit base. color flag on the first 4 bits, silhouette flag on the next 4 bits and so on for edge, pick and clippable.
+     */
     _setFlags(portionId, flags, meshTransparent) {
 
         if (!this._finalized) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/PointsInstancingLayer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/PointsInstancingLayer.js
@@ -7,6 +7,7 @@ import {ArrayBuf} from "../../../../../webgl/ArrayBuf.js";
 import {getPointsInstancingRenderers} from "./PointsInstancingRenderers.js";
 
 const tempUint8Vec4 = new Uint8Array(4);
+const tempFloat32 = new Float32Array(1);
 const tempVec4a = math.vec4([0, 0, 0, 1]);
 const tempVec4b = math.vec4([0, 0, 0, 1]);
 const tempVec4c = math.vec4([0, 0, 0, 1]);
@@ -200,14 +201,12 @@ class PointsInstancingLayer {
             throw "Already finalized";
         }
         const gl = this.model.scene.canvas.gl;
-        const flagsLength = this._pickColors.length;
+        const flagsLength = this._pickColors.length / 4;
         if (flagsLength > 0) {
             // Because we only build flags arrays here, 
             // get their length from the colors array
             let notNormalized = false;
-            let normalized = true;
-            this._state.flagsBuf = new ArrayBuf(gl, gl.ARRAY_BUFFER, new Uint8Array(flagsLength), flagsLength, 4, gl.DYNAMIC_DRAW, notNormalized);
-            this._state.flags2Buf = new ArrayBuf(gl, gl.ARRAY_BUFFER, new Uint8Array(flagsLength), flagsLength, 4, gl.DYNAMIC_DRAW, normalized);
+            this._state.flagsBuf = new ArrayBuf(gl, gl.ARRAY_BUFFER, new Float32Array(flagsLength), flagsLength, 1, gl.DYNAMIC_DRAW, notNormalized);
         }
         if (this.model.scene.entityOffsetsEnabled) {
             if (this._offsets.length > 0) {
@@ -274,7 +273,6 @@ class PointsInstancingLayer {
             this.model.numTransparentLayerPortions++;
         }
         this._setFlags(portionId, flags, meshTransparent);
-        this._setFlags2(portionId, flags);
     }
 
     setVisible(portionId, flags, meshTransparent) {
@@ -358,7 +356,7 @@ class PointsInstancingLayer {
             this._numClippableLayerPortions--;
             this.model.numClippableLayerPortions--;
         }
-        this._setFlags2(portionId, flags);
+        this._setFlags(portionId, flags);
     }
 
     setCollidable(portionId, flags) {
@@ -378,7 +376,7 @@ class PointsInstancingLayer {
             this._numPickableLayerPortions--;
             this.model.numPickableLayerPortions--;
         }
-        this._setFlags2(portionId, flags, meshTransparent);
+        this._setFlags(portionId, flags, meshTransparent);
     }
 
     setCulled(portionId, flags, meshTransparent) {
@@ -402,7 +400,7 @@ class PointsInstancingLayer {
         tempUint8Vec4[0] = color[0];
         tempUint8Vec4[1] = color[1];
         tempUint8Vec4[2] = color[2];
-        this._state.colorsBuf.setData(tempUint8Vec4, portionId * 3, 3);
+        this._state.colorsBuf.setData(tempUint8Vec4, portionId * 3);
     }
 
     setTransparent(portionId, flags, transparent) {
@@ -429,21 +427,21 @@ class PointsInstancingLayer {
     //     tempFloat32Vec4[2] = matrix[8];
     //     tempFloat32Vec4[3] = matrix[12];
     //
-    //     this._state.modelMatrixCol0Buf.setData(tempFloat32Vec4, offset, 4);
+    //     this._state.modelMatrixCol0Buf.setData(tempFloat32Vec4, offset);
     //
     //     tempFloat32Vec4[0] = matrix[1];
     //     tempFloat32Vec4[1] = matrix[5];
     //     tempFloat32Vec4[2] = matrix[9];
     //     tempFloat32Vec4[3] = matrix[13];
     //
-    //     this._state.modelMatrixCol1Buf.setData(tempFloat32Vec4, offset, 4);
+    //     this._state.modelMatrixCol1Buf.setData(tempFloat32Vec4, offset);
     //
     //     tempFloat32Vec4[0] = matrix[2];
     //     tempFloat32Vec4[1] = matrix[6];
     //     tempFloat32Vec4[2] = matrix[10];
     //     tempFloat32Vec4[3] = matrix[14];
     //
-    //     this._state.modelMatrixCol2Buf.setData(tempFloat32Vec4, offset, 4);
+    //     this._state.modelMatrixCol2Buf.setData(tempFloat32Vec4, offset);
     // }
 
     _setFlags(portionId, flags, meshTransparent) {
@@ -460,79 +458,65 @@ class PointsInstancingLayer {
         const pickable = !!(flags & ENTITY_FLAGS.PICKABLE);
         const culled = !!(flags & ENTITY_FLAGS.CULLED);
 
-        // Normal fill
-
-        let f0;
+        let colorFlag;
         if (!visible || culled || xrayed
             || (highlighted && !this.model.scene.highlightMaterial.glowThrough)
             || (selected && !this.model.scene.selectedMaterial.glowThrough) ) {
-            f0 = RENDER_PASSES.NOT_RENDERED;
+            colorFlag = RENDER_PASSES.NOT_RENDERED;
         } else {
             if (meshTransparent) {
-                f0 = RENDER_PASSES.COLOR_TRANSPARENT;
+                colorFlag = RENDER_PASSES.COLOR_TRANSPARENT;
             } else {
-                f0 = RENDER_PASSES.COLOR_OPAQUE;
+                colorFlag = RENDER_PASSES.COLOR_OPAQUE;
             }
         }
 
-        // Emphasis fill
-
-        let f1;
+        let silhouetteFlag;
         if (!visible || culled) {
-            f1 = RENDER_PASSES.NOT_RENDERED;
+            silhouetteFlag = RENDER_PASSES.NOT_RENDERED;
         } else if (selected) {
-            f1 = RENDER_PASSES.SILHOUETTE_SELECTED;
+            silhouetteFlag = RENDER_PASSES.SILHOUETTE_SELECTED;
         } else if (highlighted) {
-            f1 = RENDER_PASSES.SILHOUETTE_HIGHLIGHTED;
+            silhouetteFlag = RENDER_PASSES.SILHOUETTE_HIGHLIGHTED;
         } else if (xrayed) {
-            f1 = RENDER_PASSES.SILHOUETTE_XRAYED;
+            silhouetteFlag = RENDER_PASSES.SILHOUETTE_XRAYED;
         } else {
-            f1 = RENDER_PASSES.NOT_RENDERED;
+            silhouetteFlag = RENDER_PASSES.NOT_RENDERED;
         }
 
-        // Edges
-
-        let f2 = 0;
+        let edgeFlag = 0;
         if (!visible || culled) {
-            f2 = RENDER_PASSES.NOT_RENDERED;
+            edgeFlag = RENDER_PASSES.NOT_RENDERED;
         } else if (selected) {
-            f2 = RENDER_PASSES.EDGES_SELECTED;
+            edgeFlag = RENDER_PASSES.EDGES_SELECTED;
         } else if (highlighted) {
-            f2 = RENDER_PASSES.EDGES_HIGHLIGHTED;
+            edgeFlag = RENDER_PASSES.EDGES_HIGHLIGHTED;
         } else if (xrayed) {
-            f2 = RENDER_PASSES.EDGES_XRAYED;
+            edgeFlag = RENDER_PASSES.EDGES_XRAYED;
         } else if (edges) {
             if (meshTransparent) {
-                f2 = RENDER_PASSES.EDGES_COLOR_TRANSPARENT;
+                edgeFlag = RENDER_PASSES.EDGES_COLOR_TRANSPARENT;
             } else {
-                f2 = RENDER_PASSES.EDGES_COLOR_OPAQUE;
+                edgeFlag = RENDER_PASSES.EDGES_COLOR_OPAQUE;
             }
         } else {
-            f2 = RENDER_PASSES.NOT_RENDERED;
+            edgeFlag = RENDER_PASSES.NOT_RENDERED;
         }
 
-        // Pick
+        let pickFlag = (visible && !culled && pickable) ? RENDER_PASSES.PICK : RENDER_PASSES.NOT_RENDERED;
 
-        let f3 = (visible && !culled && pickable) ? RENDER_PASSES.PICK : RENDER_PASSES.NOT_RENDERED;
+        const clippableFlag = !!(flags & ENTITY_FLAGS.CLIPPABLE) ? 255 : 0;
 
-        tempUint8Vec4[0] = f0; // x - normal fill
-        tempUint8Vec4[1] = f1; // y - emphasis fill
-        tempUint8Vec4[2] = f2; // z - edges
-        tempUint8Vec4[3] = f3; // w - pick
+        let vertFlag = 0;
+        vertFlag |= colorFlag;
+        vertFlag |= silhouetteFlag << 4;
+        vertFlag |= edgeFlag << 8;
+        vertFlag |= pickFlag << 12;
+        vertFlag |= clippableFlag << 16;
 
-        this._state.flagsBuf.setData(tempUint8Vec4, portionId * 4, 4);
-    }
+        tempFloat32[0] = vertFlag;
 
-    _setFlags2(portionId, flags) {
-
-        if (!this._finalized) {
-            throw "Not finalized";
-        }
-
-        const clippable = !!(flags & ENTITY_FLAGS.CLIPPABLE) ? 255 : 0;
-        tempUint8Vec4[0] = clippable;
-
-        this._state.flags2Buf.setData(tempUint8Vec4, portionId * 4, 4);
+        this._state.flagsBuf.setData(tempFloat32, portionId);
     }
 
     setOffset(portionId, offset) {
@@ -546,7 +530,7 @@ class PointsInstancingLayer {
         tempVec3fa[0] = offset[0];
         tempVec3fa[1] = offset[1];
         tempVec3fa[2] = offset[2];
-        this._state.offsetsBuf.setData(tempVec3fa, portionId * 3, 3);
+        this._state.offsetsBuf.setData(tempVec3fa, portionId * 3);
     }
 
     // ---------------------- NORMAL RENDERING -----------------------------------
@@ -672,10 +656,6 @@ class PointsInstancingLayer {
         if (state.flagsBuf) {
             state.flagsBuf.destroy();
             state.flagsBuf = null;
-        }
-        if (state.flags2Buf) {
-            state.flags2Buf.destroy();
-            state.flags2Buf = null;
         }
         if (state.offsetsBuf) {
             state.offsetsBuf.destroy();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/renderers/PointsInstancingColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/renderers/PointsInstancingColorRenderer.js
@@ -95,11 +95,6 @@ class PointsInstancingColorRenderer {
         this._aFlags.bindArrayBuffer(state.flagsBuf);
         gl.vertexAttribDivisor(this._aFlags.location, 1);
 
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf);
-            gl.vertexAttribDivisor(this._aFlags2.location, 1);
-        }
-
         if (this._aOffset) {
             this._aOffset.bindArrayBuffer(state.offsetsBuf);
             gl.vertexAttribDivisor(this._aOffset.location, 1);
@@ -118,10 +113,6 @@ class PointsInstancingColorRenderer {
         gl.vertexAttribDivisor(this._aModelMatrixCol2.location, 0);
 
         gl.vertexAttribDivisor(this._aFlags.location, 0);
-
-        if (this._aFlags2) { // Won't be in shader when not clipping
-            gl.vertexAttribDivisor(this._aFlags2.location, 0);
-        }
 
         if (this._aOffset) {
             gl.vertexAttribDivisor(this._aOffset.location, 0);
@@ -164,7 +155,6 @@ class PointsInstancingColorRenderer {
         this._aPosition = program.getAttribute("position");
         this._aColor = program.getAttribute("color");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
         this._aOffset = program.getAttribute("offset");
 
         this._aModelMatrixCol0 = program.getAttribute("modelMatrixCol0");
@@ -221,8 +211,7 @@ class PointsInstancingColorRenderer {
 
         src.push("in vec3 position;");
         src.push("in vec4 color;");
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
 
         if (scene.entityOffsetsEnabled) {
             src.push("in vec3 offset;");
@@ -253,16 +242,17 @@ class PointsInstancingColorRenderer {
 
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
         src.push("out vec4 vColor;");
 
         src.push("void main(void) {");
 
-        // flags.x = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
-        // renderPass = COLOR_OPAQUE | COLOR_TRANSPARENT
+        // colorFlag = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
+        // renderPass = COLOR_OPAQUE
 
-        src.push(`if (int(flags.x) != renderPass) {`);
+        src.push(`int colorFlag = int(flags) & 0xF;`);
+        src.push(`if (colorFlag != renderPass) {`);
         src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
 
         src.push("} else {");
@@ -286,7 +276,7 @@ class PointsInstancingColorRenderer {
 
         if (clipping) {
             src.push("vWorldPosition = worldPosition;");
-            src.push("vFlags2 = flags2;");
+            src.push("vFlags = flags;");
         }
 
         src.push("vec4 clipPos = projMatrix * viewPosition;");
@@ -332,7 +322,7 @@ class PointsInstancingColorRenderer {
         }
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -350,7 +340,7 @@ class PointsInstancingColorRenderer {
             src.push("  }");
         }
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/renderers/PointsInstancingDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/renderers/PointsInstancingDepthRenderer.js
@@ -95,11 +95,6 @@ class PointsInstancingDepthRenderer {
         this._aFlags.bindArrayBuffer(state.flagsBuf);
         gl.vertexAttribDivisor(this._aFlags.location, 1);
 
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf);
-            gl.vertexAttribDivisor(this._aFlags2.location, 1);
-        }
-
         gl.uniform1f(this._uPointSize, pointsMaterial.pointSize);
         const nearPlaneHeight = (scene.camera.projection === "ortho") ? 1.0 : (gl.drawingBufferHeight / (2 * Math.tan(0.5 * scene.camera.perspective.fov * Math.PI / 180.0)));
         gl.uniform1f(this._uNearPlaneHeight, nearPlaneHeight);
@@ -110,10 +105,6 @@ class PointsInstancingDepthRenderer {
         gl.vertexAttribDivisor(this._aModelMatrixCol1.location, 0);
         gl.vertexAttribDivisor(this._aModelMatrixCol2.location, 0);
         gl.vertexAttribDivisor(this._aFlags.location, 0);
-
-        if (this._aFlags2) { // Won't be in shader when not clipping
-            gl.vertexAttribDivisor(this._aFlags2.location, 0);
-        }
 
         if (this._aOffset) {
             gl.vertexAttribDivisor(this._aOffset.location, 0);
@@ -154,7 +145,6 @@ class PointsInstancingDepthRenderer {
         this._aPosition = program.getAttribute("position");
         this._aOffset = program.getAttribute("offset");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
         this._aModelMatrixCol0 = program.getAttribute("modelMatrixCol0");
         this._aModelMatrixCol1 = program.getAttribute("modelMatrixCol1");
         this._aModelMatrixCol2 = program.getAttribute("modelMatrixCol2");
@@ -203,8 +193,7 @@ class PointsInstancingDepthRenderer {
         if (scene.entityOffsetsEnabled) {
             src.push("in vec3 offset;");
         }
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
         src.push("in vec4 modelMatrixCol0;");
         src.push("in vec4 modelMatrixCol1;");
         src.push("in vec4 modelMatrixCol2;");
@@ -224,14 +213,15 @@ class PointsInstancingDepthRenderer {
         }
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
         src.push("void main(void) {");
 
-        // flags.x = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
+        // colorFlag = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
         // renderPass = COLOR_OPAQUE
 
-        src.push(`if (int(flags.x) != renderPass) {`);
+        src.push(`int colorFlag = int(flags) & 0xF;`);
+        src.push(`if (colorFlag != renderPass) {`);
         src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
 
         src.push("} else {");
@@ -244,7 +234,7 @@ class PointsInstancingDepthRenderer {
 
         if (clipping) {
             src.push("vWorldPosition = worldPosition;");
-            src.push("vFlags2 = flags2;");
+            src.push("vFlags = flags;");
         }
         src.push("vec4 clipPos = projMatrix * viewPosition;");
         if (scene.logarithmicDepthBufferEnabled) {
@@ -285,7 +275,7 @@ class PointsInstancingDepthRenderer {
         }
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -317,7 +307,7 @@ class PointsInstancingDepthRenderer {
         }
 
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/renderers/PointsInstancingPickDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/renderers/PointsInstancingPickDepthRenderer.js
@@ -106,11 +106,6 @@ class PointsInstancingPickDepthRenderer {
         this._aFlags.bindArrayBuffer(state.flagsBuf);
         gl.vertexAttribDivisor(this._aFlags.location, 1);
 
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf);
-            gl.vertexAttribDivisor(this._aFlags2.location, 1);
-        }
-
         if (this._aOffset) {
             this._aOffset.bindArrayBuffer(state.offsetsBuf);
             gl.vertexAttribDivisor(this._aOffset.location, 1);
@@ -129,9 +124,6 @@ class PointsInstancingPickDepthRenderer {
         gl.vertexAttribDivisor(this._aModelMatrixCol2.location, 0);
 
         gl.vertexAttribDivisor(this._aFlags.location, 0);
-        if (this._aFlags2) { // Won't be in shader when not clipping
-            gl.vertexAttribDivisor(this._aFlags2.location, 0);
-        }
 
         if (this._aOffset) {
             gl.vertexAttribDivisor(this._aOffset.location, 0);
@@ -171,7 +163,6 @@ class PointsInstancingPickDepthRenderer {
         this._aPosition = program.getAttribute("position");
         this._aOffset = program.getAttribute("offset");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
         this._aModelMatrixCol0 = program.getAttribute("modelMatrixCol0");
         this._aModelMatrixCol1 = program.getAttribute("modelMatrixCol1");
         this._aModelMatrixCol2 = program.getAttribute("modelMatrixCol2");
@@ -217,8 +208,7 @@ class PointsInstancingPickDepthRenderer {
             src.push("in vec3 offset;");
         }
 
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
         src.push("in vec4 modelMatrixCol0;"); // Modeling matrix
         src.push("in vec4 modelMatrixCol1;");
         src.push("in vec4 modelMatrixCol2;");
@@ -241,16 +231,17 @@ class PointsInstancingPickDepthRenderer {
 
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
 
         src.push("out vec4 vViewPosition;");
         src.push("void main(void) {");
 
-        // flags.w = NOT_RENDERED | PICK
+        // pickFlag = NOT_RENDERED | PICK
         // renderPass = PICK
 
-        src.push(`if (int(flags.w) != renderPass) {`);
+        src.push(`int pickFlag = int(flags) >> 12 & 0xF;`);
+        src.push(`if (pickFlag != renderPass) {`);
         src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
 
         src.push("} else {");
@@ -263,7 +254,7 @@ class PointsInstancingPickDepthRenderer {
         src.push("  vec4 viewPosition  = viewMatrix * worldPosition; ");
         if (clipping) {
             src.push("  vWorldPosition = worldPosition;");
-            src.push("  vFlags2 = flags2;");
+            src.push("  vFlags = flags;");
         }
         src.push("  vViewPosition = viewPosition;");
         src.push("vec4 clipPos = projMatrix * viewPosition;");
@@ -309,7 +300,7 @@ class PointsInstancingPickDepthRenderer {
 
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -336,7 +327,7 @@ class PointsInstancingPickDepthRenderer {
         }
 
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/renderers/PointsInstancingPickMeshRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/renderers/PointsInstancingPickMeshRenderer.js
@@ -81,11 +81,6 @@ class PointsInstancingPickMeshRenderer {
         this._aFlags.bindArrayBuffer(state.flagsBuf);
         gl.vertexAttribDivisor(this._aFlags.location, 1);
 
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf);
-            gl.vertexAttribDivisor(this._aFlags2.location, 1);
-        }
-
         if (this._aOffset) {
             this._aOffset.bindArrayBuffer(state.offsetsBuf);
             gl.vertexAttribDivisor(this._aOffset.location, 1);
@@ -129,10 +124,6 @@ class PointsInstancingPickMeshRenderer {
         gl.vertexAttribDivisor(this._aPickColor.location, 0);
         gl.vertexAttribDivisor(this._aFlags.location, 0);
 
-        if (this._aFlags2) { // Won't be in shader when not clipping
-            gl.vertexAttribDivisor(this._aFlags2.location, 0);
-        }
-
         if (this._aOffset) {
             gl.vertexAttribDivisor(this._aOffset.location, 0);
         }
@@ -175,7 +166,6 @@ class PointsInstancingPickMeshRenderer {
         this._aOffset = program.getAttribute("offset");
         this._aPickColor = program.getAttribute("pickColor");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
         this._aModelMatrixCol0 = program.getAttribute("modelMatrixCol0");
         this._aModelMatrixCol1 = program.getAttribute("modelMatrixCol1");
         this._aModelMatrixCol2 = program.getAttribute("modelMatrixCol2");
@@ -219,8 +209,7 @@ class PointsInstancingPickMeshRenderer {
         if (scene.entityOffsetsEnabled) {
             src.push("in vec3 offset;");
         }
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
         src.push("in vec4 pickColor;");
 
         src.push("in vec4 modelMatrixCol0;"); // Modeling matrix
@@ -245,15 +234,16 @@ class PointsInstancingPickMeshRenderer {
 
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
         src.push("out vec4 vPickColor;");
         src.push("void main(void) {");
 
-        // flags.w = NOT_RENDERED | PICK
+        // pickFlag = NOT_RENDERED | PICK
         // renderPass = PICK
 
-        src.push(`if (int(flags.w) != renderPass) {`);
+        src.push(`int pickFlag = int(flags) >> 12 & 0xF;`);
+        src.push(`if (pickFlag != renderPass) {`);
         src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
 
         src.push("} else {");
@@ -270,7 +260,7 @@ class PointsInstancingPickMeshRenderer {
         src.push("  vPickColor = vec4(float(pickColor.r) / 255.0, float(pickColor.g) / 255.0, float(pickColor.b) / 255.0, float(pickColor.a) / 255.0);");
         if (clipping) {
             src.push("  vWorldPosition = worldPosition;");
-            src.push("  vFlags2 = flags2;");
+            src.push("  vFlags = flags;");
         }
         src.push("vec4 clipPos = projMatrix * viewPosition;");
         if (scene.logarithmicDepthBufferEnabled) {
@@ -308,7 +298,7 @@ class PointsInstancingPickMeshRenderer {
         }
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -328,7 +318,7 @@ class PointsInstancingPickMeshRenderer {
         }
 
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/renderers/PointsInstancingSilhouetteRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/renderers/PointsInstancingSilhouetteRenderer.js
@@ -113,11 +113,6 @@ class PointsInstancingSilhouetteRenderer {
         this._aFlags.bindArrayBuffer(state.flagsBuf, gl.UNSIGNED_BYTE, true);
         gl.vertexAttribDivisor(this._aFlags.location, 1);
 
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf, gl.UNSIGNED_BYTE, true);
-            gl.vertexAttribDivisor(this._aFlags2.location, 1);
-        }
-
         if (this._aOffset) {
             this._aOffset.bindArrayBuffer(state.offsetsBuf);
             gl.vertexAttribDivisor(this._aOffset.location, 1);
@@ -134,9 +129,6 @@ class PointsInstancingSilhouetteRenderer {
         gl.vertexAttribDivisor(this._aModelMatrixCol2.location, 0);
 
         gl.vertexAttribDivisor(this._aFlags.location, 0);
-        if (this._aFlags2) {
-            gl.vertexAttribDivisor(this._aFlags2.location, 0);
-        }
         if (this._aOffset) {
             gl.vertexAttribDivisor(this._aOffset.location, 0);
         }
@@ -177,7 +169,6 @@ class PointsInstancingSilhouetteRenderer {
         this._aPosition = program.getAttribute("position");
         this._aOffset = program.getAttribute("offset");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
         this._aModelMatrixCol0 = program.getAttribute("modelMatrixCol0");
         this._aModelMatrixCol1 = program.getAttribute("modelMatrixCol1");
         this._aModelMatrixCol2 = program.getAttribute("modelMatrixCol2");
@@ -229,8 +220,7 @@ class PointsInstancingSilhouetteRenderer {
         if (scene.entityOffsetsEnabled) {
             src.push("in vec3 offset;");
         }
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
         src.push("in vec4 color;");
 
         src.push("in vec4 modelMatrixCol0;"); // Modeling matrix
@@ -256,16 +246,17 @@ class PointsInstancingSilhouetteRenderer {
 
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
         src.push("out vec4 vColor;");
 
         src.push("void main(void) {");
 
-        // flags.y = NOT_RENDERED | SILHOUETTE_HIGHLIGHTED | SILHOUETTE_SELECTED | | SILHOUETTE_XRAYED
+        // silhouetteFlag = NOT_RENDERED | SILHOUETTE_HIGHLIGHTED | SILHOUETTE_SELECTED | | SILHOUETTE_XRAYED
         // renderPass = SILHOUETTE_HIGHLIGHTED | SILHOUETTE_SELECTED | | SILHOUETTE_XRAYED
 
-        src.push(`if (int(flags.y) != renderPass) {`);
+        src.push(`int silhouetteFlag = int(flags) >> 4 & 0xF;`);
+        src.push(`if (silhouetteFlag != renderPass) {`);
         src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
 
         src.push("} else {");
@@ -279,7 +270,7 @@ class PointsInstancingSilhouetteRenderer {
 
         if (clipping) {
             src.push("vWorldPosition = worldPosition;");
-            src.push("vFlags2 = flags2;");
+            src.push("vFlags = flags;");
         }
         src.push("vec4 clipPos = projMatrix * viewPosition;");
         if (scene.logarithmicDepthBufferEnabled) {
@@ -319,7 +310,7 @@ class PointsInstancingSilhouetteRenderer {
         }
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -337,7 +328,7 @@ class PointsInstancingSilhouetteRenderer {
             src.push("  }");
         }
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/TrianglesBatchingLayer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/TrianglesBatchingLayer.js
@@ -743,6 +743,9 @@ class TrianglesBatchingLayer {
         this._setFlags(portionId, flags, transparent);
     }
 
+    /**
+     * flags are 4bits values encoded on a 32bit base. color flag on the first 4 bits, silhouette flag on the next 4 bits and so on for edge, pick and clippable.
+     */
     _setFlags(portionId, flags, transparent, deferred = false) {
 
         if (!this._finalized) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/TrianglesBatchingLayer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/TrianglesBatchingLayer.js
@@ -82,7 +82,6 @@ class TrianglesBatchingLayer {
             uvBuf: null,
             metallicRoughnessBuf: null,
             flagsBuf: null,
-            flags2Buf: null,
             indicesBuf: null,
             edgeIndicesBuf: null,
             positionsDecodeMatrix: math.mat4(),
@@ -495,13 +494,10 @@ class TrianglesBatchingLayer {
         }
 
         if (buffer.positions.length > 0) { // Because we build flags arrays here, get their length from the positions array
-            const flagsLength = (buffer.positions.length / 3) * 4;
-            const flags = new Uint8Array(flagsLength);
-            const flags2 = new Uint8Array(flagsLength);
-            let notNormalized = false;
-            let normalized = true;
-            state.flagsBuf = new ArrayBuf(gl, gl.ARRAY_BUFFER, flags, flags.length, 4, gl.DYNAMIC_DRAW, notNormalized);
-            state.flags2Buf = new ArrayBuf(gl, gl.ARRAY_BUFFER, flags2, flags2.length, 4, gl.DYNAMIC_DRAW, normalized);
+            const flagsLength = (buffer.positions.length / 3);
+            const flags = new Float32Array(flagsLength);
+            const notNormalized = false;
+            state.flagsBuf = new ArrayBuf(gl, gl.ARRAY_BUFFER, flags, flags.length, 1, gl.DYNAMIC_DRAW, notNormalized);
         }
 
         if (buffer.pickColors.length > 0) {
@@ -586,12 +582,10 @@ class TrianglesBatchingLayer {
         }
         const deferred = true;
         this._setFlags(portionId, flags, meshTransparent, deferred);
-        this._setFlags2(portionId, flags, deferred);
     }
 
     flushInitFlags() {
         this._setDeferredFlags();
-        this._setDeferredFlags2();
     }
 
     setVisible(portionId, flags, transparent) {
@@ -675,7 +669,7 @@ class TrianglesBatchingLayer {
             this._numClippableLayerPortions--;
             this.model.numClippableLayerPortions--;
         }
-        this._setFlags2(portionId, flags);
+        this._setFlags(portionId, flags);
     }
 
     setCulled(portionId, flags, transparent) {
@@ -759,8 +753,8 @@ class TrianglesBatchingLayer {
         const portion = this._portions[portionsIdx];
         const vertsBaseIndex = portion.vertsBaseIndex;
         const numVerts = portion.numVerts;
-        const firstFlag = vertsBaseIndex * 4;
-        const lenFlags = numVerts * 4;
+        const firstFlag = vertsBaseIndex;
+        const lenFlags = numVerts;
 
         const visible = !!(flags & ENTITY_FLAGS.VISIBLE);
         const xrayed = !!(flags & ENTITY_FLAGS.XRAYED);
@@ -770,79 +764,81 @@ class TrianglesBatchingLayer {
         const pickable = !!(flags & ENTITY_FLAGS.PICKABLE);
         const culled = !!(flags & ENTITY_FLAGS.CULLED);
 
-        // Color
-
-        let f0;
+        let colorFlag;
         if (!visible || culled || xrayed
             || (highlighted && !this.model.scene.highlightMaterial.glowThrough)
             || (selected && !this.model.scene.selectedMaterial.glowThrough)) {
-            f0 = RENDER_PASSES.NOT_RENDERED;
+            colorFlag = RENDER_PASSES.NOT_RENDERED;
         } else {
             if (transparent) {
-                f0 = RENDER_PASSES.COLOR_TRANSPARENT;
+                colorFlag = RENDER_PASSES.COLOR_TRANSPARENT;
             } else {
-                f0 = RENDER_PASSES.COLOR_OPAQUE;
+                colorFlag = RENDER_PASSES.COLOR_OPAQUE;
             }
         }
 
-        // Silhouette
-
-        let f1;
+        let silhouetteFlag;
         if (!visible || culled) {
-            f1 = RENDER_PASSES.NOT_RENDERED;
+            silhouetteFlag = RENDER_PASSES.NOT_RENDERED;
         } else if (selected) {
-            f1 = RENDER_PASSES.SILHOUETTE_SELECTED;
+            silhouetteFlag = RENDER_PASSES.SILHOUETTE_SELECTED;
         } else if (highlighted) {
-            f1 = RENDER_PASSES.SILHOUETTE_HIGHLIGHTED;
+            silhouetteFlag = RENDER_PASSES.SILHOUETTE_HIGHLIGHTED;
         } else if (xrayed) {
-            f1 = RENDER_PASSES.SILHOUETTE_XRAYED;
+            silhouetteFlag = RENDER_PASSES.SILHOUETTE_XRAYED;
         } else {
-            f1 = RENDER_PASSES.NOT_RENDERED;
+            silhouetteFlag = RENDER_PASSES.NOT_RENDERED;
         }
 
-        // Edges
-
-        let f2 = 0;
+        let edgeFlag = 0;
         if (!visible || culled) {
-            f2 = RENDER_PASSES.NOT_RENDERED;
+            edgeFlag = RENDER_PASSES.NOT_RENDERED;
         } else if (selected) {
-            f2 = RENDER_PASSES.EDGES_SELECTED;
+            edgeFlag = RENDER_PASSES.EDGES_SELECTED;
         } else if (highlighted) {
-            f2 = RENDER_PASSES.EDGES_HIGHLIGHTED;
+            edgeFlag = RENDER_PASSES.EDGES_HIGHLIGHTED;
         } else if (xrayed) {
-            f2 = RENDER_PASSES.EDGES_XRAYED;
+            edgeFlag = RENDER_PASSES.EDGES_XRAYED;
         } else if (edges) {
             if (transparent) {
-                f2 = RENDER_PASSES.EDGES_COLOR_TRANSPARENT;
+                edgeFlag = RENDER_PASSES.EDGES_COLOR_TRANSPARENT;
             } else {
-                f2 = RENDER_PASSES.EDGES_COLOR_OPAQUE;
+                edgeFlag = RENDER_PASSES.EDGES_COLOR_OPAQUE;
             }
         } else {
-            f2 = RENDER_PASSES.NOT_RENDERED;
+            edgeFlag = RENDER_PASSES.NOT_RENDERED;
         }
 
-        // Pick
+        let pickFlag = (visible && !culled && pickable) ? RENDER_PASSES.PICK : RENDER_PASSES.NOT_RENDERED;
 
-        let f3 = (visible && !culled && pickable) ? RENDER_PASSES.PICK : RENDER_PASSES.NOT_RENDERED;
+        const clippableFlag = !!(flags & ENTITY_FLAGS.CLIPPABLE) ? 1 : 0;
 
         if (deferred) {
             // Avoid zillions of individual WebGL bufferSubData calls - buffer them to apply in one shot
             if (!this._deferredFlagValues) {
-                this._deferredFlagValues = new Uint8Array(this._numVerts * 4);
+                this._deferredFlagValues = new Float32Array(this._numVerts);
             }
-            for (let i = firstFlag, len = (firstFlag + lenFlags); i < len; i += 4) {
-                this._deferredFlagValues[i + 0] = f0;
-                this._deferredFlagValues[i + 1] = f1;
-                this._deferredFlagValues[i + 2] = f2;
-                this._deferredFlagValues[i + 3] = f3;
+            for (let i = firstFlag, len = (firstFlag + lenFlags); i < len; i++) {
+                let vertFlag = 0;
+                vertFlag |= colorFlag;
+                vertFlag |= silhouetteFlag << 4;
+                vertFlag |= edgeFlag << 8;
+                vertFlag |= pickFlag << 12;
+                vertFlag |= clippableFlag << 16;
+
+                this._deferredFlagValues[i] = vertFlag;
             }
         } else if (this._state.flagsBuf) {
-            const tempArray = this._scratchMemory.getUInt8Array(lenFlags);
-            for (let i = 0; i < lenFlags; i += 4) {
-                tempArray[i + 0] = f0; // x - normal fill
-                tempArray[i + 1] = f1; // y - emphasis fill
-                tempArray[i + 2] = f2; // z - edges
-                tempArray[i + 3] = f3; // w - pick
+            const tempArray = this._scratchMemory.getFloat32Array(lenFlags);
+            for (let i = 0; i < lenFlags; i++) {
+                let vertFlag = 0;
+                vertFlag |= colorFlag;
+                vertFlag |= silhouetteFlag << 4;
+                vertFlag |= edgeFlag << 8;
+                vertFlag |= pickFlag << 12;
+                vertFlag |= clippableFlag << 16;
+
+                tempArray[i] = vertFlag;
             }
             this._state.flagsBuf.setData(tempArray, firstFlag, lenFlags);
         }
@@ -852,43 +848,6 @@ class TrianglesBatchingLayer {
         if (this._deferredFlagValues) {
             this._state.flagsBuf.setData(this._deferredFlagValues);
             this._deferredFlagValues = null;
-        }
-    }
-
-    _setFlags2(portionId, flags, deferred = false) {
-
-        if (!this._finalized) {
-            throw "Not finalized";
-        }
-
-        const portionsIdx = portionId;
-        const portion = this._portions[portionsIdx];
-        const vertsBaseIndex = portion.vertsBaseIndex;
-        const numVerts = portion.numVerts;
-        const firstFlag = vertsBaseIndex * 4;
-        const lenFlags = numVerts * 4;
-        const clippable = !!(flags & ENTITY_FLAGS.CLIPPABLE) ? 255 : 0;
-
-        if (deferred) {
-            if (!this._setDeferredFlag2Values) {
-                this._setDeferredFlag2Values = new Uint8Array(this._numVerts * 4);
-            }
-            for (let i = firstFlag, len = (firstFlag + lenFlags); i < len; i += 4) {
-                this._setDeferredFlag2Values[i] = clippable;
-            }
-        } else if (this._state.flags2Buf) {
-            const tempArray = this._scratchMemory.getUInt8Array(lenFlags);
-            for (let i = 0; i < lenFlags; i += 4) {
-                tempArray[i + 0] = clippable;
-            }
-            this._state.flags2Buf.setData(tempArray, firstFlag, lenFlags);
-        }
-    }
-
-    _setDeferredFlags2() {
-        if (this._setDeferredFlag2Values) {
-            this._state.flags2Buf.setData(this._setDeferredFlag2Values);
-            this._setDeferredFlag2Values = null;
         }
     }
 
@@ -1298,10 +1257,6 @@ class TrianglesBatchingLayer {
         if (state.flagsBuf) {
             state.flagsBuf.destroy();
             state.flagsBuf = null;
-        }
-        if (state.flags2Buf) {
-            state.flags2Buf.destroy();
-            state.flags2Buf = null;
         }
         if (state.pickColorsBuf) {
             state.pickColorsBuf.destroy();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingColorRenderer.js
@@ -95,10 +95,6 @@ class TrianglesBatchingColorRenderer {
             this._aFlags.bindArrayBuffer(state.flagsBuf);
         }
 
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf);
-        }
-
         if (this._aOffset) {
             this._aOffset.bindArrayBuffer(state.offsetsBuf);
         }
@@ -180,7 +176,6 @@ class TrianglesBatchingColorRenderer {
         this._aNormal = program.getAttribute("normal");
         this._aColor = program.getAttribute("color");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
 
         if (this._withSAO) {
             this._uOcclusionTexture = "uOcclusionTexture";
@@ -269,8 +264,7 @@ class TrianglesBatchingColorRenderer {
         src.push("in vec3 position;");
         src.push("in vec3 normal;");
         src.push("in vec4 color;");
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
 
         if (scene.entityOffsetsEnabled) {
             src.push("in vec3 offset;");
@@ -323,16 +317,17 @@ class TrianglesBatchingColorRenderer {
 
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
         src.push("out vec4 vColor;");
 
         src.push("void main(void) {");
 
-        // flags.x = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
+        // colorFlag = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
         // renderPass = COLOR_OPAQUE
 
-        src.push(`if (int(flags.x) != renderPass) {`);
+        src.push(`int colorFlag = int(flags) & 0xF;`);
+        src.push(`if (colorFlag != renderPass) {`);
         src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
 
         src.push("} else {");
@@ -391,7 +386,7 @@ class TrianglesBatchingColorRenderer {
         }
         if (clipping) {
             src.push("vWorldPosition = worldPosition;");
-            src.push("vFlags2 = flags2;");
+            src.push("vFlags = flags;");
         }
         src.push("gl_Position = clipPos;");
         src.push("}");
@@ -435,7 +430,7 @@ class TrianglesBatchingColorRenderer {
         }
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -447,7 +442,7 @@ class TrianglesBatchingColorRenderer {
         src.push("void main(void) {");
 
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingEdgesColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingEdgesColorRenderer.js
@@ -83,9 +83,6 @@ class TrianglesBatchingEdgesColorRenderer {
         if (this._aFlags) {
             this._aFlags.bindArrayBuffer(state.flagsBuf);
         }
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf);
-        }
         state.edgeIndicesBuf.bind();
 
         gl.drawElements(gl.LINES, state.edgeIndicesBuf.numItems, state.edgeIndicesBuf.itemType, 0);
@@ -124,7 +121,6 @@ class TrianglesBatchingEdgesColorRenderer {
         this._aColor = program.getAttribute("color");
         this._aOffset = program.getAttribute("offset");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
 
         if (scene.logarithmicDepthBufferEnabled) {
             this._uLogDepthBufFC = program.getLocation("logDepthBufFC");
@@ -170,8 +166,7 @@ class TrianglesBatchingEdgesColorRenderer {
         if (scene.entityOffsetsEnabled) {
             src.push("in vec3 offset;");
         }
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
 
         src.push("uniform mat4 worldMatrix;");
         src.push("uniform mat4 viewMatrix;");
@@ -189,16 +184,17 @@ class TrianglesBatchingEdgesColorRenderer {
 
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
 
         src.push("out vec4 vColor;");
         src.push("void main(void) {");
 
-        // flags.z = NOT_RENDERED | EDGES_COLOR_OPAQUE | EDGES_COLOR_TRANSPARENT | EDGES_HIGHLIGHTED | EDGES_XRAYED | EDGES_SELECTED
+        // edgeFlag = NOT_RENDERED | EDGES_COLOR_OPAQUE | EDGES_COLOR_TRANSPARENT | EDGES_HIGHLIGHTED | EDGES_XRAYED | EDGES_SELECTED
         // renderPass = EDGES_COLOR_OPAQUE | EDGES_COLOR_TRANSPARENT
 
-        src.push(`if (int(flags.z) != renderPass) {`);
+        src.push(`int edgeFlag = int(flags) >> 8 & 0xF;`);
+        src.push(`if (edgeFlag != renderPass) {`);
         src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
 
         src.push("} else {");
@@ -211,7 +207,7 @@ class TrianglesBatchingEdgesColorRenderer {
 
         if (clipping) {
             src.push("  vWorldPosition = worldPosition;");
-            src.push("  vFlags2 = flags2;");
+            src.push("  vFlags = flags;");
         }
 
         src.push("vec4 clipPos = projMatrix * viewPosition;");
@@ -248,7 +244,7 @@ class TrianglesBatchingEdgesColorRenderer {
         }
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -259,7 +255,7 @@ class TrianglesBatchingEdgesColorRenderer {
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingPBRRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingPBRRenderer.js
@@ -117,10 +117,6 @@ class TrianglesBatchingPBRRenderer {
             this._aFlags.bindArrayBuffer(state.flagsBuf);
         }
 
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf);
-        }
-
         if (this._aOffset) {
             this._aOffset.bindArrayBuffer(state.offsetsBuf);
         }
@@ -255,7 +251,6 @@ class TrianglesBatchingPBRRenderer {
         this._aColor = program.getAttribute("color");
         this._aMetallicRoughness = program.getAttribute("metallicRoughness");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
 
         this._uBaseColorMap = "uBaseColorMap";
         this._uMetallicRoughMap = "uMetallicRoughMap";
@@ -360,8 +355,7 @@ class TrianglesBatchingPBRRenderer {
         src.push("in vec4 color;");
         src.push("in vec2 uv;");
         src.push("in vec2 metallicRoughness;");
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
 
         if (scene.entityOffsetsEnabled) {
             src.push("in vec3 offset;");
@@ -405,7 +399,7 @@ class TrianglesBatchingPBRRenderer {
 
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
             if (clippingCaps) {
                 src.push("out vec4 vClipPosition;");
             }
@@ -413,10 +407,11 @@ class TrianglesBatchingPBRRenderer {
 
         src.push("void main(void) {");
 
-        // flags.x = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
+        // colorFlag = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
         // renderPass = COLOR_OPAQUE
 
-        src.push(`if (int(flags.x) != renderPass) {`);
+        src.push(`int colorFlag = int(flags) & 0xF;`);
+        src.push(`if (colorFlag != renderPass) {`);
         src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
 
         src.push("} else {");
@@ -437,7 +432,7 @@ class TrianglesBatchingPBRRenderer {
 
         if (clipping) {
             src.push("vWorldPosition = worldPosition;");
-            src.push("vFlags2 = flags2;");
+            src.push("vFlags = flags;");
             if (clippingCaps) {
                 src.push("vClipPosition = clipPos;");
             }
@@ -566,7 +561,7 @@ class TrianglesBatchingPBRRenderer {
 
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             if (clippingCaps) {
                 src.push("in vec4 vClipPosition;");
             }
@@ -740,7 +735,7 @@ class TrianglesBatchingPBRRenderer {
         src.push("void main(void) {");
 
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingShadowRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingShadowRenderer.js
@@ -47,9 +47,6 @@ class TrianglesBatchingShadowRenderer {
         if (this._aFlags) {
             this._aFlags.bindArrayBuffer(state.flagsBuf);
         }
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf);
-        }
         if (this._aOffset) {
             this._aOffset.bindArrayBuffer(state.offsetsBuf);
         }
@@ -114,7 +111,6 @@ class TrianglesBatchingShadowRenderer {
         this._aOffset = program.getAttribute("offset");
         this._aColor = program.getAttribute("color");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
     }
 
     _bindProgram(frameCtx) {
@@ -146,19 +142,19 @@ class TrianglesBatchingShadowRenderer {
             src.push("in vec3 offset;");
         }
         src.push("in vec4 color;");
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
         src.push("uniform mat4 shadowViewMatrix;");
         src.push("uniform mat4 shadowProjMatrix;");
         src.push("uniform mat4 positionsDecodeMatrix;");
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
         src.push("out vec4 vViewPosition;");
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
-        src.push("  bool visible        = (float(flags.x) > 0.0);");
+        src.push(`  int colorFlag = int(flags) & 0xF;`);
+        src.push("  bool visible        = (colorFlag > 0);");
         src.push("  bool transparent    = ((float(color.a) / 255.0) < 1.0);");
         src.push("  if (!visible || transparent) {");
         src.push("      gl_Position = vec4(0.0, 0.0, 0.0, 0.0);");
@@ -170,7 +166,7 @@ class TrianglesBatchingShadowRenderer {
         src.push("      vec4 viewPosition  = shadowViewMatrix * worldPosition; ");
         if (clipping) {
             src.push("      vWorldPosition = worldPosition;");
-            src.push("      vFlags2 = flags2;");
+            src.push("      vFlags = flags;");
         }
         src.push("      vViewPosition = viewPosition;");
         src.push("      gl_Position = shadowProjMatrix * viewPosition;");
@@ -195,7 +191,7 @@ class TrianglesBatchingShadowRenderer {
         src.push("#endif");
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -214,7 +210,7 @@ class TrianglesBatchingShadowRenderer {
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("      float dist = 0.0;");
             for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingSilhouetteRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingSilhouetteRenderer.js
@@ -111,10 +111,6 @@ class TrianglesBatchingSilhouetteRenderer {
             this._aFlags.bindArrayBuffer(state.flagsBuf);
         }
 
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf);
-        }
-
         if (this._aColor) {
             this._aColor.bindArrayBuffer(state.colorsBuf);
         }
@@ -157,7 +153,6 @@ class TrianglesBatchingSilhouetteRenderer {
         this._aPosition = program.getAttribute("position");
         this._aOffset = program.getAttribute("offset");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
         this._aColor = program.getAttribute("color");
 
         if (scene.logarithmicDepthBufferEnabled) {
@@ -204,8 +199,7 @@ class TrianglesBatchingSilhouetteRenderer {
         if (scene.entityOffsetsEnabled) {
             src.push("in vec3 offset;");
         }
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
         src.push("in vec4 color;");
         src.push("uniform mat4 worldMatrix;");
         src.push("uniform mat4 viewMatrix;");
@@ -224,17 +218,18 @@ class TrianglesBatchingSilhouetteRenderer {
 
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
 
         src.push("out vec4 vColor;");
 
         src.push("void main(void) {");
 
-        // flags.y = NOT_RENDERED | SILHOUETTE_HIGHLIGHTED | SILHOUETTE_SELECTED | SILHOUETTE_XRAYED
+        // silhouetteFlag = NOT_RENDERED | SILHOUETTE_HIGHLIGHTED | SILHOUETTE_SELECTED | SILHOUETTE_XRAYED
         // renderPass = SILHOUETTE_HIGHLIGHTED | SILHOUETTE_SELECTED | | SILHOUETTE_XRAYED
 
-        src.push(`if (int(flags.y) != renderPass) {`);
+        src.push(`int silhouetteFlag = int(flags) >> 4 & 0xF;`);
+        src.push(`if (silhouetteFlag != renderPass) {`);
         src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
         src.push("} else {");
 
@@ -245,7 +240,7 @@ class TrianglesBatchingSilhouetteRenderer {
         src.push("vec4 viewPosition  = viewMatrix * worldPosition; ");
         if (clipping) {
             src.push("vWorldPosition = worldPosition;");
-            src.push("vFlags2 = flags2;");
+            src.push("vFlags = flags;");
         }
         src.push("vColor = vec4(silhouetteColor.r, silhouetteColor.g, silhouetteColor.b, min(silhouetteColor.a, float(color.a) / 255.0));");
         src.push("vec4 clipPos = projMatrix * viewPosition;");
@@ -283,7 +278,7 @@ class TrianglesBatchingSilhouetteRenderer {
         }
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -294,7 +289,7 @@ class TrianglesBatchingSilhouetteRenderer {
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/TrianglesInstancingLayer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/TrianglesInstancingLayer.js
@@ -1,4 +1,3 @@
-import {WEBGL_INFO} from "../../../../../webglInfo.js";
 import {ENTITY_FLAGS} from '../../ENTITY_FLAGS.js';
 import {RENDER_PASSES} from '../../RENDER_PASSES.js';
 
@@ -8,6 +7,7 @@ import {ArrayBuf} from "../../../../../webgl/ArrayBuf.js";
 import {getInstancingRenderers} from "./TrianglesInstancingRenderers.js";
 
 const tempUint8Vec4 = new Uint8Array(4);
+const tempFloat32 = new Float32Array(1);
 const tempVec4a = math.vec4([0, 0, 0, 1]);
 const tempVec4b = math.vec4([0, 0, 0, 1]);
 const tempVec4c = math.vec4([0, 0, 0, 1]);
@@ -279,7 +279,7 @@ class TrianglesInstancingLayer {
         const textureSet = state.textureSet;
         const gl = this.model.scene.canvas.gl;
         const colorsLength = this._colors.length;
-        const flagsLength = colorsLength;
+        const flagsLength = colorsLength / 4;
         if (colorsLength > 0) {
             let notNormalized = false;
             this._state.colorsBuf = new ArrayBuf(gl, gl.ARRAY_BUFFER, new Uint8Array(this._colors), this._colors.length, 4, gl.DYNAMIC_DRAW, notNormalized);
@@ -294,9 +294,7 @@ class TrianglesInstancingLayer {
             // Because we only build flags arrays here,
             // get their length from the colors array
             let notNormalized = false;
-            let normalized = true;
-            this._state.flagsBuf = new ArrayBuf(gl, gl.ARRAY_BUFFER, new Uint8Array(flagsLength), flagsLength, 4, gl.DYNAMIC_DRAW, notNormalized);
-            this._state.flags2Buf = new ArrayBuf(gl, gl.ARRAY_BUFFER, new Uint8Array(flagsLength), flagsLength, 4, gl.DYNAMIC_DRAW, normalized);
+            this._state.flagsBuf = new ArrayBuf(gl, gl.ARRAY_BUFFER, new Float32Array(flagsLength), flagsLength, 1, gl.DYNAMIC_DRAW, notNormalized);
         }
         if (this.model.scene.entityOffsetsEnabled) {
             if (this._offsets.length > 0) {
@@ -388,7 +386,6 @@ class TrianglesInstancingLayer {
             this.model.numTransparentLayerPortions++;
         }
         this._setFlags(portionId, flags, meshTransparent);
-        this._setFlags2(portionId, flags);
     }
 
     setVisible(portionId, flags, meshTransparent) {
@@ -472,7 +469,7 @@ class TrianglesInstancingLayer {
             this._numClippableLayerPortions--;
             this.model.numClippableLayerPortions--;
         }
-        this._setFlags2(portionId, flags);
+        this._setFlags(portionId, flags);
     }
 
     setCollidable(portionId, flags) {
@@ -518,7 +515,7 @@ class TrianglesInstancingLayer {
         tempUint8Vec4[2] = color[2];
         tempUint8Vec4[3] = color[3];
         if (this._state.colorsBuf) {
-            this._state.colorsBuf.setData(tempUint8Vec4, portionId * 4, 4);
+            this._state.colorsBuf.setData(tempUint8Vec4, portionId * 4);
         }
     }
 
@@ -546,21 +543,21 @@ class TrianglesInstancingLayer {
     //     tempFloat32Vec4[2] = matrix[8];
     //     tempFloat32Vec4[3] = matrix[12];
     //
-    //     this._state.modelMatrixCol0Buf.setData(tempFloat32Vec4, offset, 4);
+    //     this._state.modelMatrixCol0Buf.setData(tempFloat32Vec4, offset);
     //
     //     tempFloat32Vec4[0] = matrix[1];
     //     tempFloat32Vec4[1] = matrix[5];
     //     tempFloat32Vec4[2] = matrix[9];
     //     tempFloat32Vec4[3] = matrix[13];
     //
-    //     this._state.modelMatrixCol1Buf.setData(tempFloat32Vec4, offset, 4);
+    //     this._state.modelMatrixCol1Buf.setData(tempFloat32Vec4, offset);
     //
     //     tempFloat32Vec4[0] = matrix[2];
     //     tempFloat32Vec4[1] = matrix[6];
     //     tempFloat32Vec4[2] = matrix[10];
     //     tempFloat32Vec4[3] = matrix[14];
     //
-    //     this._state.modelMatrixCol2Buf.setData(tempFloat32Vec4, offset, 4);
+    //     this._state.modelMatrixCol2Buf.setData(tempFloat32Vec4, offset);
     // }
 
     _setFlags(portionId, flags, meshTransparent) {
@@ -577,82 +574,66 @@ class TrianglesInstancingLayer {
         const pickable = !!(flags & ENTITY_FLAGS.PICKABLE);
         const culled = !!(flags & ENTITY_FLAGS.CULLED);
 
-        // Normal fill
-
-        let f0;
+        let colorFlag;
         if (!visible || culled || xrayed
             || (highlighted && !this.model.scene.highlightMaterial.glowThrough)
             || (selected && !this.model.scene.selectedMaterial.glowThrough) ) {
-            f0 = RENDER_PASSES.NOT_RENDERED;
+            colorFlag = RENDER_PASSES.NOT_RENDERED;
         } else {
             if (meshTransparent) {
-                f0 = RENDER_PASSES.COLOR_TRANSPARENT;
+                colorFlag = RENDER_PASSES.COLOR_TRANSPARENT;
             } else {
-                f0 = RENDER_PASSES.COLOR_OPAQUE;
+                colorFlag = RENDER_PASSES.COLOR_OPAQUE;
             }
         }
 
-        // Emphasis fill
-
-        let f1;
+        let silhouetteFlag;
         if (!visible || culled) {
-            f1 = RENDER_PASSES.NOT_RENDERED;
+            silhouetteFlag = RENDER_PASSES.NOT_RENDERED;
         } else if (selected) {
-            f1 = RENDER_PASSES.SILHOUETTE_SELECTED;
+            silhouetteFlag = RENDER_PASSES.SILHOUETTE_SELECTED;
         } else if (highlighted) {
-            f1 = RENDER_PASSES.SILHOUETTE_HIGHLIGHTED;
+            silhouetteFlag = RENDER_PASSES.SILHOUETTE_HIGHLIGHTED;
         } else if (xrayed) {
-            f1 = RENDER_PASSES.SILHOUETTE_XRAYED;
+            silhouetteFlag = RENDER_PASSES.SILHOUETTE_XRAYED;
         } else {
-            f1 = RENDER_PASSES.NOT_RENDERED;
+            silhouetteFlag = RENDER_PASSES.NOT_RENDERED;
         }
 
-        // Edges
-
-        let f2 = 0;
+        let edgeFlag = 0;
         if (!visible || culled) {
-            f2 = RENDER_PASSES.NOT_RENDERED;
+            edgeFlag = RENDER_PASSES.NOT_RENDERED;
         } else if (selected) {
-            f2 = RENDER_PASSES.EDGES_SELECTED;
+            edgeFlag = RENDER_PASSES.EDGES_SELECTED;
         } else if (highlighted) {
-            f2 = RENDER_PASSES.EDGES_HIGHLIGHTED;
+            edgeFlag = RENDER_PASSES.EDGES_HIGHLIGHTED;
         } else if (xrayed) {
-            f2 = RENDER_PASSES.EDGES_XRAYED;
+            edgeFlag = RENDER_PASSES.EDGES_XRAYED;
         } else if (edges) {
             if (meshTransparent) {
-                f2 = RENDER_PASSES.EDGES_COLOR_TRANSPARENT;
+                edgeFlag = RENDER_PASSES.EDGES_COLOR_TRANSPARENT;
             } else {
-                f2 = RENDER_PASSES.EDGES_COLOR_OPAQUE;
+                edgeFlag = RENDER_PASSES.EDGES_COLOR_OPAQUE;
             }
         } else {
-            f2 = RENDER_PASSES.NOT_RENDERED;
+            edgeFlag = RENDER_PASSES.NOT_RENDERED;
         }
 
-        // Pick
+        const pickFlag = (visible && !culled && pickable) ? RENDER_PASSES.PICK : RENDER_PASSES.NOT_RENDERED;
 
-        let f3 = (visible && !culled && pickable) ? RENDER_PASSES.PICK : RENDER_PASSES.NOT_RENDERED;
+        const clippableFlag = !!(flags & ENTITY_FLAGS.CLIPPABLE) ? 1 : 0;
 
-        tempUint8Vec4[0] = f0; // x - normal fill
-        tempUint8Vec4[1] = f1; // y - emphasis fill
-        tempUint8Vec4[2] = f2; // z - edges
-        tempUint8Vec4[3] = f3; // w - pick
+        let vertFlag = 0;
+        vertFlag |= colorFlag;
+        vertFlag |= silhouetteFlag << 4;
+        vertFlag |= edgeFlag << 8;
+        vertFlag |= pickFlag << 12;
+        vertFlag |= clippableFlag << 16;
+
+        tempFloat32[0] = vertFlag;
 
         if (this._state.flagsBuf) {
-            this._state.flagsBuf.setData(tempUint8Vec4, portionId * 4, 4);
-        }
-    }
-
-    _setFlags2(portionId, flags) {
-
-        if (!this._finalized) {
-            throw "Not finalized";
-        }
-
-        const clippable = !!(flags & ENTITY_FLAGS.CLIPPABLE) ? 255 : 0;
-        tempUint8Vec4[0] = clippable;
-
-        if (this._state.flags2Buf) {
-            this._state.flags2Buf.setData(tempUint8Vec4, portionId * 4, 4);
+            this._state.flagsBuf.setData(tempFloat32, portionId);
         }
     }
 
@@ -668,7 +649,7 @@ class TrianglesInstancingLayer {
         tempVec3fa[1] = offset[1];
         tempVec3fa[2] = offset[2];
         if (this._state.offsetsBuf) {
-            this._state.offsetsBuf.setData(tempVec3fa, portionId * 3, 3);
+            this._state.offsetsBuf.setData(tempVec3fa, portionId * 3);
         }
     }
 
@@ -1035,10 +1016,6 @@ class TrianglesInstancingLayer {
         if (state.flagsBuf) {
             state.flagsBuf.destroy();
             state.flagsBuf = null;
-        }
-        if (state.flags2Buf) {
-            state.flags2Buf.destroy();
-            state.flags2Buf = null;
         }
         if (state.offsetsBuf) {
             state.offsetsBuf.destroy();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/TrianglesInstancingLayer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/TrianglesInstancingLayer.js
@@ -560,6 +560,9 @@ class TrianglesInstancingLayer {
     //     this._state.modelMatrixCol2Buf.setData(tempFloat32Vec4, offset);
     // }
 
+    /**
+     * flags are 4bits values encoded on a 32bit base. color flag on the first 4 bits, silhouette flag on the next 4 bits and so on for edge, pick and clippable.
+     */
     _setFlags(portionId, flags, meshTransparent) {
 
         if (!this._finalized) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingColorRenderer.js
@@ -107,11 +107,6 @@ class TrianglesInstancingColorRenderer {
         this._aFlags.bindArrayBuffer(state.flagsBuf);
         gl.vertexAttribDivisor(this._aFlags.location, 1);
 
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf);
-            gl.vertexAttribDivisor(this._aFlags2.location, 1);
-        }
-
         if (this._aOffset) {
             this._aOffset.bindArrayBuffer(state.offsetsBuf);
             gl.vertexAttribDivisor(this._aOffset.location, 1);
@@ -131,10 +126,6 @@ class TrianglesInstancingColorRenderer {
         gl.vertexAttribDivisor(this._aModelNormalMatrixCol2.location, 0);
         gl.vertexAttribDivisor(this._aColor.location, 0);
         gl.vertexAttribDivisor(this._aFlags.location, 0);
-
-        if (this._aFlags2) { // Won't be in shader when not clipping
-            gl.vertexAttribDivisor(this._aFlags2.location, 0);
-        }
 
         if (this._aOffset) {
             gl.vertexAttribDivisor(this._aOffset.location, 0);
@@ -213,7 +204,6 @@ class TrianglesInstancingColorRenderer {
         this._aNormal = program.getAttribute("normal");
         this._aColor = program.getAttribute("color");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
         this._aOffset = program.getAttribute("offset");
 
         this._aModelMatrixCol0 = program.getAttribute("modelMatrixCol0");
@@ -309,8 +299,7 @@ class TrianglesInstancingColorRenderer {
         src.push("in vec3 position;");
         src.push("in vec2 normal;");
         src.push("in vec4 color;");
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
 
         if (scene.entityOffsetsEnabled) {
             src.push("in vec3 offset;");
@@ -370,16 +359,17 @@ class TrianglesInstancingColorRenderer {
 
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
         src.push("out vec4 vColor;");
 
         src.push("void main(void) {");
 
-        // flags.x = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
+        // colorFlag = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
         // renderPass = COLOR_OPAQUE | COLOR_TRANSPARENT
 
-        src.push(`if (int(flags.x) != renderPass) {`);
+        src.push(`int colorFlag = int(flags) & 0xF;`);
+        src.push(`if (colorFlag != renderPass) {`);
         src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
 
         src.push("} else {");
@@ -441,7 +431,7 @@ class TrianglesInstancingColorRenderer {
 
         if (clipping) {
             src.push("vWorldPosition = worldPosition;");
-            src.push("vFlags2 = flags2;");
+            src.push("vFlags = flags;");
         }
 
         src.push("gl_Position = clipPos;");
@@ -487,7 +477,7 @@ class TrianglesInstancingColorRenderer {
 
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -499,7 +489,7 @@ class TrianglesInstancingColorRenderer {
         src.push("void main(void) {");
 
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingDepthRenderer.js
@@ -94,11 +94,6 @@ class TrianglesInstancingDepthRenderer {
         this._aFlags.bindArrayBuffer(state.flagsBuf);
         gl.vertexAttribDivisor(this._aFlags.location, 1);
 
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf);
-            gl.vertexAttribDivisor(this._aFlags2.location, 1);
-        }
-
         geometry.indicesBuf.bind();
 
         gl.drawElementsInstanced(gl.TRIANGLES, geometry.indicesBuf.numItems, geometry.indicesBuf.itemType, 0, state.numInstances);
@@ -107,10 +102,6 @@ class TrianglesInstancingDepthRenderer {
         gl.vertexAttribDivisor(this._aModelMatrixCol1.location, 0);
         gl.vertexAttribDivisor(this._aModelMatrixCol2.location, 0);
         gl.vertexAttribDivisor(this._aFlags.location, 0);
-
-        if (this._aFlags2) { // Won't be in shader when not clipping
-            gl.vertexAttribDivisor(this._aFlags2.location, 0);
-        }
 
         if (this._aOffset) {
             gl.vertexAttribDivisor(this._aOffset.location, 0);
@@ -151,7 +142,6 @@ class TrianglesInstancingDepthRenderer {
         this._aPosition = program.getAttribute("position");
         this._aOffset = program.getAttribute("offset");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
         this._aModelMatrixCol0 = program.getAttribute("modelMatrixCol0");
         this._aModelMatrixCol1 = program.getAttribute("modelMatrixCol1");
         this._aModelMatrixCol2 = program.getAttribute("modelMatrixCol2");
@@ -197,8 +187,7 @@ class TrianglesInstancingDepthRenderer {
         if (scene.entityOffsetsEnabled) {
             src.push("in vec3 offset;");
         }
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
         src.push("in vec4 modelMatrixCol0;");
         src.push("in vec4 modelMatrixCol1;");
         src.push("in vec4 modelMatrixCol2;");
@@ -216,15 +205,16 @@ class TrianglesInstancingDepthRenderer {
         }
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
         src.push("out vec2 vHighPrecisionZW;");
         src.push("void main(void) {");
 
-        // flags.x = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
+        // colorFlag = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
         // renderPass = COLOR_OPAQUE
 
-        src.push(`if (int(flags.x) != renderPass) {`);
+        src.push(`int colorFlag = int(flags) & 0xF;`);
+        src.push(`if (colorFlag != renderPass) {`);
         src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
 
         src.push("} else {");
@@ -237,7 +227,7 @@ class TrianglesInstancingDepthRenderer {
 
         if (clipping) {
             src.push("vWorldPosition = worldPosition;");
-            src.push("vFlags2 = flags2;");
+            src.push("vFlags = flags;");
         }
         src.push("vec4 clipPos = projMatrix * viewPosition;");
         if (scene.logarithmicDepthBufferEnabled) {
@@ -270,7 +260,7 @@ class TrianglesInstancingDepthRenderer {
         }
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -281,7 +271,7 @@ class TrianglesInstancingDepthRenderer {
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingEdgesColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingEdgesColorRenderer.js
@@ -95,11 +95,6 @@ class TrianglesInstancingEdgesColorRenderer {
             gl.vertexAttribDivisor(this._aFlags.location, 1);
         }
 
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf, gl.UNSIGNED_BYTE, true);
-            gl.vertexAttribDivisor(this._aFlags2.location, 1);
-        }
-
         if (this._aOffset) {
             this._aOffset.bindArrayBuffer(state.offsetsBuf);
             gl.vertexAttribDivisor(this._aOffset.location, 1);
@@ -120,10 +115,6 @@ class TrianglesInstancingEdgesColorRenderer {
 
         if (this._aFlags) {
             gl.vertexAttribDivisor(this._aFlags.location, 0);
-        }
-
-        if (this._aFlags2) {
-            gl.vertexAttribDivisor(this._aFlags2.location, 0);
         }
     }
 
@@ -161,7 +152,6 @@ class TrianglesInstancingEdgesColorRenderer {
         this._aColor = program.getAttribute("color");
         this._aOffset = program.getAttribute("offset");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
         this._aModelMatrixCol0 = program.getAttribute("modelMatrixCol0");
         this._aModelMatrixCol1 = program.getAttribute("modelMatrixCol1");
         this._aModelMatrixCol2 = program.getAttribute("modelMatrixCol2");
@@ -208,8 +198,7 @@ class TrianglesInstancingEdgesColorRenderer {
         if (scene.entityOffsetsEnabled) {
             src.push("in vec3 offset;");
         }
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
         src.push("in vec4 modelMatrixCol0;"); // Modeling matrix
         src.push("in vec4 modelMatrixCol1;");
         src.push("in vec4 modelMatrixCol2;");
@@ -229,17 +218,18 @@ class TrianglesInstancingEdgesColorRenderer {
 
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
 
         src.push("out vec4 vColor;");
 
         src.push("void main(void) {");
 
-        // flags.z = NOT_RENDERED | EDGES_COLOR_OPAQUE | EDGES_HIGHLIGHTED | EDGES_XRAYED | EDGES_SELECTED
+        // edgeFlag = NOT_RENDERED | EDGES_COLOR_OPAQUE | EDGES_HIGHLIGHTED | EDGES_XRAYED | EDGES_SELECTED
         // renderPass = EDGES_HIGHLIGHTED | EDGES_XRAYED | EDGES_SELECTED
 
-        src.push(`if (int(flags.z) != renderPass) {`);
+        src.push(`int edgeFlag = int(flags) >> 8 & 0xF;`);
+        src.push(`if (edgeFlag != renderPass) {`);
         src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
 
         src.push("} else {");
@@ -251,7 +241,7 @@ class TrianglesInstancingEdgesColorRenderer {
         src.push("vec4 viewPosition  = viewMatrix * worldPosition; ");
         if (clipping) {
             src.push("vWorldPosition = worldPosition;");
-            src.push("vFlags2 = flags2;");
+            src.push("vFlags = flags;");
         }
         src.push("vec4 clipPos = projMatrix * viewPosition;");
         if (scene.logarithmicDepthBufferEnabled) {
@@ -288,7 +278,7 @@ class TrianglesInstancingEdgesColorRenderer {
         }
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -299,7 +289,7 @@ class TrianglesInstancingEdgesColorRenderer {
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingFlatColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingFlatColorRenderer.js
@@ -93,11 +93,6 @@ class TrianglesInstancingFlatColorRenderer {
         this._aFlags.bindArrayBuffer(state.flagsBuf);
         gl.vertexAttribDivisor(this._aFlags.location, 1);
 
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf);
-            gl.vertexAttribDivisor(this._aFlags2.location, 1);
-        }
-
         if (this._aOffset) {
             this._aOffset.bindArrayBuffer(state.offsetsBuf);
             gl.vertexAttribDivisor(this._aOffset.location, 1);
@@ -112,10 +107,6 @@ class TrianglesInstancingFlatColorRenderer {
         gl.vertexAttribDivisor(this._aModelMatrixCol2.location, 0);
         gl.vertexAttribDivisor(this._aColor.location, 0);
         gl.vertexAttribDivisor(this._aFlags.location, 0);
-
-        if (this._aFlags2) { // Won't be in shader when not clipping
-            gl.vertexAttribDivisor(this._aFlags2.location, 0);
-        }
 
         if (this._aOffset) {
             gl.vertexAttribDivisor(this._aOffset.location, 0);
@@ -191,7 +182,6 @@ class TrianglesInstancingFlatColorRenderer {
         this._aPosition = program.getAttribute("position");
         this._aColor = program.getAttribute("color");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
         this._aOffset = program.getAttribute("offset");
 
         this._aModelMatrixCol0 = program.getAttribute("modelMatrixCol0");
@@ -278,8 +268,7 @@ class TrianglesInstancingFlatColorRenderer {
 
         src.push("in vec3 position;");
         src.push("in vec4 color;");
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
 
         if (scene.entityOffsetsEnabled) {
             src.push("in vec3 offset;");
@@ -305,7 +294,7 @@ class TrianglesInstancingFlatColorRenderer {
         
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
 
         src.push("out vec4 vViewPosition;");
@@ -313,10 +302,11 @@ class TrianglesInstancingFlatColorRenderer {
 
         src.push("void main(void) {");
 
-        // flags.x = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
+        // colorFlag = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
         // renderPass = COLOR_OPAQUE | COLOR_TRANSPARENT
 
-        src.push(`if (int(flags.x) != renderPass) {`);
+        src.push(`int colorFlag = int(flags) & 0xF;`);
+        src.push(`if (colorFlag != renderPass) {`);
         src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
 
         src.push("} else {");
@@ -339,7 +329,7 @@ class TrianglesInstancingFlatColorRenderer {
 
         if (clipping) {
             src.push("vWorldPosition = worldPosition;");
-            src.push("vFlags2 = flags2;");
+            src.push("vFlags = flags;");
         }
 
         src.push("gl_Position = clipPos;");
@@ -386,7 +376,7 @@ class TrianglesInstancingFlatColorRenderer {
 
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -423,7 +413,7 @@ class TrianglesInstancingFlatColorRenderer {
         src.push("void main(void) {");
 
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingFlatNormalsRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingFlatNormalsRenderer.js
@@ -95,11 +95,6 @@ class TrianglesInstancingFlatNormalsRenderer {
         this._aFlags.bindArrayBuffer(state.flagsBuf);
         gl.vertexAttribDivisor(this._aFlags.location, 1);
 
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf);
-            gl.vertexAttribDivisor(this._aFlags2.location, 1);
-        }
-
         geometry.indicesBuf.bind();
 
         gl.drawElementsInstanced(gl.TRIANGLES, geometry.indicesBuf.numItems, geometry.indicesBuf.itemType, 0, state.numInstances);
@@ -109,10 +104,6 @@ class TrianglesInstancingFlatNormalsRenderer {
         gl.vertexAttribDivisor(this._aModelMatrixCol2.location, 0);
         gl.vertexAttribDivisor(this._aColor.location, 0);
         gl.vertexAttribDivisor(this._aFlags.location, 0);
-
-        if (this._aFlags2) { // Won't be in shader when not clipping
-            gl.vertexAttribDivisor(this._aFlags2.location, 0);
-        }
 
         if (this._aOffset) {
             gl.vertexAttribDivisor(this._aOffset.location, 0);
@@ -154,10 +145,6 @@ class TrianglesInstancingFlatNormalsRenderer {
         this._aOffset = program.getAttribute("offset");
         this._aColor = program.getAttribute("color");
         this._aFlags = program.getAttribute("flags");
-
-        if (this._aFlags2) {
-            this._aFlags2 = program.getAttribute("flags2");
-        }
 
         this._aModelMatrixCol0 = program.getAttribute("modelMatrixCol0");
         this._aModelMatrixCol1 = program.getAttribute("modelMatrixCol1");
@@ -205,8 +192,7 @@ class TrianglesInstancingFlatNormalsRenderer {
             src.push("in vec3 offset;");
         }
         src.push("in vec4 color;");
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
         src.push("in vec4 modelMatrixCol0;");
         src.push("in vec4 modelMatrixCol1;");
         src.push("in vec4 modelMatrixCol2;");
@@ -224,12 +210,14 @@ class TrianglesInstancingFlatNormalsRenderer {
         }
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
         src.push("void main(void) {");
-        // flags.x = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
+        // colorFlag = NOT_RENDERED | COLOR_OPAQUE | COLOR_TRANSPARENT
         // renderPass = COLOR_OPAQUE
-        src.push(`if (int(flags.x) != renderPass) {`);
+
+        src.push(`int colorFlag = int(flags) & 0xF;`);
+        src.push(`if (colorFlag != renderPass) {`);
         src.push("      gl_Position = vec4(0.0, 0.0, 0.0, 0.0);");
         src.push("} else {");
         src.push("  vec4 worldPosition = positionsDecodeMatrix * vec4(position, 1.0); ");
@@ -240,7 +228,7 @@ class TrianglesInstancingFlatNormalsRenderer {
         src.push("  vec4 viewPosition  = viewMatrix * worldPosition; ");
         if (clipping) {
             src.push("vWorldPosition = worldPosition;");
-            src.push("vFlags2 = flags2;");
+            src.push("vFlags = flags;");
         }
         src.push("  vViewPosition = viewPosition;");
         src.push("vec4 clipPos = projMatrix * viewPosition;");
@@ -276,7 +264,7 @@ class TrianglesInstancingFlatNormalsRenderer {
         }
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -290,7 +278,7 @@ class TrianglesInstancingFlatNormalsRenderer {
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingPickDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingPickDepthRenderer.js
@@ -105,11 +105,6 @@ class TrianglesInstancingPickDepthRenderer {
         this._aFlags.bindArrayBuffer(state.flagsBuf);
         gl.vertexAttribDivisor(this._aFlags.location, 1);
 
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf);
-            gl.vertexAttribDivisor(this._aFlags2.location, 1);
-        }
-
         if (this._aOffset) {
             this._aOffset.bindArrayBuffer(state.offsetsBuf);
             gl.vertexAttribDivisor(this._aOffset.location, 1);
@@ -126,9 +121,6 @@ class TrianglesInstancingPickDepthRenderer {
         gl.vertexAttribDivisor(this._aModelMatrixCol2.location, 0);
 
         gl.vertexAttribDivisor(this._aFlags.location, 0);
-        if (this._aFlags2) { // Won't be in shader when not clipping
-            gl.vertexAttribDivisor(this._aFlags2.location, 0);
-        }
 
         if (this._aOffset) {
             gl.vertexAttribDivisor(this._aOffset.location, 0);
@@ -168,7 +160,6 @@ class TrianglesInstancingPickDepthRenderer {
         this._aPosition = program.getAttribute("position");
         this._aOffset = program.getAttribute("offset");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
         this._aModelMatrixCol0 = program.getAttribute("modelMatrixCol0");
         this._aModelMatrixCol1 = program.getAttribute("modelMatrixCol1");
         this._aModelMatrixCol2 = program.getAttribute("modelMatrixCol2");
@@ -210,8 +201,7 @@ class TrianglesInstancingPickDepthRenderer {
             src.push("in vec3 offset;");
         }
 
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
         src.push("in vec4 modelMatrixCol0;"); // Modeling matrix
         src.push("in vec4 modelMatrixCol1;");
         src.push("in vec4 modelMatrixCol2;");
@@ -233,16 +223,17 @@ class TrianglesInstancingPickDepthRenderer {
 
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
 
         src.push("out vec4 vViewPosition;");
         src.push("void main(void) {");
 
-        // flags.w = NOT_RENDERED | PICK
+        // pickFlag = NOT_RENDERED | PICK
         // renderPass = PICK
 
-        src.push(`if (int(flags.w) != renderPass) {`);
+        src.push(`int pickFlag = int(flags) >> 12 & 0xF;`);
+        src.push(`if (pickFlag != renderPass) {`);
         src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
 
         src.push("} else {");
@@ -255,7 +246,7 @@ class TrianglesInstancingPickDepthRenderer {
         src.push("  vec4 viewPosition  = viewMatrix * worldPosition; ");
         if (clipping) {
             src.push("  vWorldPosition = worldPosition;");
-            src.push("  vFlags2 = flags2;");
+            src.push("  vFlags = flags;");
         }
         src.push("  vViewPosition = viewPosition;");
         src.push("vec4 clipPos = projMatrix * viewPosition;");
@@ -297,7 +288,7 @@ class TrianglesInstancingPickDepthRenderer {
 
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -315,7 +306,7 @@ class TrianglesInstancingPickDepthRenderer {
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingPickMeshRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingPickMeshRenderer.js
@@ -80,11 +80,6 @@ class TrianglesInstancingPickMeshRenderer {
         this._aFlags.bindArrayBuffer(state.flagsBuf);
         gl.vertexAttribDivisor(this._aFlags.location, 1);
 
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf);
-            gl.vertexAttribDivisor(this._aFlags2.location, 1);
-        }
-
         if (this._aOffset) {
             this._aOffset.bindArrayBuffer(state.offsetsBuf);
             gl.vertexAttribDivisor(this._aOffset.location, 1);
@@ -125,10 +120,6 @@ class TrianglesInstancingPickMeshRenderer {
         gl.vertexAttribDivisor(this._aModelMatrixCol2.location, 0);
         gl.vertexAttribDivisor(this._aPickColor.location, 0);
         gl.vertexAttribDivisor(this._aFlags.location, 0);
-
-        if (this._aFlags2) { // Won't be in shader when not clipping
-            gl.vertexAttribDivisor(this._aFlags2.location, 0);
-        }
 
         if (this._aOffset) {
             gl.vertexAttribDivisor(this._aOffset.location, 0);
@@ -172,7 +163,6 @@ class TrianglesInstancingPickMeshRenderer {
         this._aOffset = program.getAttribute("offset");
         this._aPickColor = program.getAttribute("pickColor");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
         this._aModelMatrixCol0 = program.getAttribute("modelMatrixCol0");
         this._aModelMatrixCol1 = program.getAttribute("modelMatrixCol1");
         this._aModelMatrixCol2 = program.getAttribute("modelMatrixCol2");
@@ -213,8 +203,7 @@ class TrianglesInstancingPickMeshRenderer {
         if (scene.entityOffsetsEnabled) {
             src.push("in vec3 offset;");
         }
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
         src.push("in vec4 pickColor;");
 
         src.push("in vec4 modelMatrixCol0;"); // Modeling matrix
@@ -238,15 +227,16 @@ class TrianglesInstancingPickMeshRenderer {
 
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
         src.push("out vec4 vPickColor;");
         src.push("void main(void) {");
 
-        // flags.w = NOT_RENDERED | PICK
+        // pickFlag = NOT_RENDERED | PICK
         // renderPass = PICK
 
-        src.push(`if (int(flags.w) != renderPass) {`);
+        src.push(`int pickFlag = int(flags) >> 12 & 0xF;`);
+        src.push(`if (pickFlag != renderPass) {`);
         src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
 
         src.push("} else {");
@@ -263,7 +253,7 @@ class TrianglesInstancingPickMeshRenderer {
         src.push("  vPickColor = vec4(float(pickColor.r) / 255.0, float(pickColor.g) / 255.0, float(pickColor.b) / 255.0, float(pickColor.a) / 255.0);");
         if (clipping) {
             src.push("  vWorldPosition = worldPosition;");
-            src.push("  vFlags2 = flags2;");
+            src.push("  vFlags = flags;");
         }
         src.push("vec4 clipPos = projMatrix * viewPosition;");
         if (scene.logarithmicDepthBufferEnabled) {
@@ -298,7 +288,7 @@ class TrianglesInstancingPickMeshRenderer {
         }
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -309,7 +299,7 @@ class TrianglesInstancingPickMeshRenderer {
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingPickNormalsFlatRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingPickNormalsFlatRenderer.js
@@ -102,11 +102,6 @@ class TrianglesInstancingPickNormalsFlatRenderer {
         this._aFlags.bindArrayBuffer(state.flagsBuf);
         gl.vertexAttribDivisor(this._aFlags.location, 1);
 
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf);
-            gl.vertexAttribDivisor(this._aFlags2.location, 1);
-        }
-
         if (this._aOffset) {
             this._aOffset.bindArrayBuffer(state.offsetsBuf);
             gl.vertexAttribDivisor(this._aOffset.location, 1);
@@ -120,10 +115,6 @@ class TrianglesInstancingPickNormalsFlatRenderer {
         gl.vertexAttribDivisor(this._aModelMatrixCol1.location, 0);
         gl.vertexAttribDivisor(this._aModelMatrixCol2.location, 0);
         gl.vertexAttribDivisor(this._aFlags.location, 0);
-
-        if (this._aFlags2) { // Won't be in shader when not clipping
-            gl.vertexAttribDivisor(this._aFlags2.location, 0);
-        }
 
         if (this._aOffset) {
             gl.vertexAttribDivisor(this._aOffset.location, 0);
@@ -165,7 +156,6 @@ class TrianglesInstancingPickNormalsFlatRenderer {
         this._aPosition = program.getAttribute("position");
         this._aOffset = program.getAttribute("offset");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
 
         this._aModelMatrixCol0 = program.getAttribute("modelMatrixCol0");
         this._aModelMatrixCol1 = program.getAttribute("modelMatrixCol1");
@@ -200,8 +190,7 @@ class TrianglesInstancingPickNormalsFlatRenderer {
         if (scene.entityOffsetsEnabled) {
             src.push("in vec3 offset;");
         }
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
         src.push("in vec4 modelMatrixCol0;"); // Modeling matrix
         src.push("in vec4 modelMatrixCol1;");
         src.push("in vec4 modelMatrixCol2;");
@@ -219,15 +208,16 @@ class TrianglesInstancingPickNormalsFlatRenderer {
             src.push("out float isPerspective;");
         }
         if (clipping) {
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
         src.push("out vec4 vWorldPosition;");
         src.push("void main(void) {");
 
-        // flags.w = NOT_RENDERED | PICK
+        // pickFlag = NOT_RENDERED | PICK
         // renderPass = PICK
 
-        src.push(`if (int(flags.w) != renderPass) {`);
+        src.push(`int pickFlag = int(flags) >> 12 & 0xF;`);
+        src.push(`if (pickFlag != renderPass) {`);
         src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
         src.push("} else {");
         src.push("  vec4 worldPosition = positionsDecodeMatrix * vec4(position, 1.0); ");
@@ -242,6 +232,11 @@ class TrianglesInstancingPickNormalsFlatRenderer {
            src.push("vFragDepth = 1.0 + clipPos.w;");
             src.push("isPerspective = float (isPerspectiveMatrix(projMatrix));");
         }
+
+        if (clipping) {
+            src.push("vFlags = flags;");
+        }
+
         src.push("gl_Position = clipPos;");
         src.push("}");
         src.push("}");
@@ -271,7 +266,7 @@ class TrianglesInstancingPickNormalsFlatRenderer {
         }
         src.push("in vec4 vWorldPosition;");
         if (clipping) {
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -282,7 +277,7 @@ class TrianglesInstancingPickNormalsFlatRenderer {
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingPickNormalsRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingPickNormalsRenderer.js
@@ -114,11 +114,6 @@ class TrianglesInstancingPickNormalsRenderer {
         this._aFlags.bindArrayBuffer(state.flagsBuf);
         gl.vertexAttribDivisor(this._aFlags.location, 1);
 
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf);
-            gl.vertexAttribDivisor(this._aFlags2.location, 1);
-        }
-
         if (this._aOffset) {
             this._aOffset.bindArrayBuffer(state.offsetsBuf);
             gl.vertexAttribDivisor(this._aOffset.location, 1);
@@ -135,10 +130,6 @@ class TrianglesInstancingPickNormalsRenderer {
         gl.vertexAttribDivisor(this._aModelNormalMatrixCol1.location, 0);
         gl.vertexAttribDivisor(this._aModelNormalMatrixCol2.location, 0);
         gl.vertexAttribDivisor(this._aFlags.location, 0);
-
-        if (this._aFlags2) { // Won't be in shader when not clipping
-            gl.vertexAttribDivisor(this._aFlags2.location, 0);
-        }
 
         if (this._aOffset) {
             gl.vertexAttribDivisor(this._aOffset.location, 0);
@@ -183,7 +174,6 @@ class TrianglesInstancingPickNormalsRenderer {
         this._aOffset = program.getAttribute("offset");
         this._aNormal = program.getAttribute("normal");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
 
         this._aModelMatrixCol0 = program.getAttribute("modelMatrixCol0");
         this._aModelMatrixCol1 = program.getAttribute("modelMatrixCol1");
@@ -223,8 +213,7 @@ class TrianglesInstancingPickNormalsRenderer {
             src.push("in vec3 offset;");
         }
         src.push("in vec2 normal;");
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
         src.push("in vec4 modelMatrixCol0;"); // Modeling matrix
         src.push("in vec4 modelMatrixCol1;");
         src.push("in vec4 modelMatrixCol2;");
@@ -253,15 +242,16 @@ class TrianglesInstancingPickNormalsRenderer {
         src.push("}");
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
         src.push("out vec3 vWorldNormal;");
         src.push("void main(void) {");
 
-        // flags.w = NOT_RENDERED | PICK
+        // pickFlag = NOT_RENDERED | PICK
         // renderPass = PICK
 
-        src.push(`if (int(flags.w) != renderPass) {`);
+        src.push(`int pickFlag = int(flags) >> 12 & 0xF;`);
+        src.push(`if (pickFlag != renderPass) {`);
         src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
 
         src.push("} else {");
@@ -276,6 +266,7 @@ class TrianglesInstancingPickNormalsRenderer {
         src.push("  vWorldNormal = worldNormal;");
         if (clipping) {
             src.push("  vWorldPosition = worldPosition;");
+            src.push("vFlags = flags;");
         }
         src.push("vec4 clipPos = projMatrix * viewPosition;");
         if (scene.logarithmicDepthBufferEnabled) {
@@ -314,7 +305,7 @@ class TrianglesInstancingPickNormalsRenderer {
 
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -325,7 +316,7 @@ class TrianglesInstancingPickNormalsRenderer {
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingShadowRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingShadowRenderer.js
@@ -68,11 +68,6 @@ class TrianglesInstancingShadowRenderer {
         this._aFlags.bindArrayBuffer(state.flagsBuf);
         gl.vertexAttribDivisor(this._aFlags.location, 1);
 
-        if (this._aFlags2) {
-            this._aFlags2.bindArrayBuffer(state.flags2Buf);
-            gl.vertexAttribDivisor(this._aFlags2.location, 1);
-        }
-
         // TODO: Section planes need to be set if RTC center has changed since last RTC center recorded on frameCtx
 
         const numSectionPlanes = scene._sectionPlanesState.sectionPlanes.length;
@@ -110,10 +105,6 @@ class TrianglesInstancingShadowRenderer {
         gl.vertexAttribDivisor(this._aColor.location, 0);
         gl.vertexAttribDivisor(this._aFlags.location, 0);
 
-        if (this._aFlags2) { // Won't be in shader when not clipping
-            gl.vertexAttribDivisor(this._aFlags2.location, 0);
-        }
-
         if (this._aOffset) {
             gl.vertexAttribDivisor(this._aOffset.location, 0);
         }
@@ -145,7 +136,6 @@ class TrianglesInstancingShadowRenderer {
         this._aOffset = program.getAttribute("offset");
         this._aColor = program.getAttribute("color");
         this._aFlags = program.getAttribute("flags");
-        this._aFlags2 = program.getAttribute("flags2");
         this._aModelMatrixCol0 = program.getAttribute("modelMatrixCol0");
         this._aModelMatrixCol1 = program.getAttribute("modelMatrixCol1");
         this._aModelMatrixCol2 = program.getAttribute("modelMatrixCol2");
@@ -180,8 +170,7 @@ class TrianglesInstancingShadowRenderer {
             src.push("in vec3 offset;");
         }
         src.push("in vec4 color;");
-        src.push("in vec4 flags;");
-        src.push("in vec4 flags2;");
+        src.push("in float flags;");
         src.push("in vec4 modelMatrixCol0;");
         src.push("in vec4 modelMatrixCol1;");
         src.push("in vec4 modelMatrixCol2;");
@@ -190,10 +179,11 @@ class TrianglesInstancingShadowRenderer {
         src.push("uniform mat4 positionsDecodeMatrix;");
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("out float vFlags;");
         }
         src.push("void main(void) {");
-        src.push("bool visible      = (float(flags.x) > 0.0);");
+        src.push(`int colorFlag = int(flags) & 0xF;`);
+        src.push("bool visible = (colorFlag > 0);");
         src.push("bool transparent  = ((float(color.a) / 255.0) < 1.0);");
         src.push(`if (!visible || transparent) {`);
         src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
@@ -207,7 +197,7 @@ class TrianglesInstancingShadowRenderer {
 
         if (clipping) {
             src.push("vWorldPosition = worldPosition;");
-            src.push("vFlags2 = flags2;");
+            src.push("vFlags = flags;");
         }
         src.push("  gl_Position = shadowProjMatrix * viewPosition;");
         src.push("}");
@@ -236,7 +226,7 @@ class TrianglesInstancingShadowRenderer {
         }
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("in float vFlags;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -250,7 +240,7 @@ class TrianglesInstancingShadowRenderer {
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {


### PR DESCRIPTION
VBOSceneModel renderers shader flags are two `vec4` (`flags` & `flags2`).
They handle [RENDER_PASSES](https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/scene/models/VBOSceneModel/lib/RENDER_PASSES.js#L4) for color silhouette edge pick (for flags) and clippable (for flags2).

However each flag can be encoded in 4 bits because RENDER_PASSES is [0-11] and clippable is a simple boolean. (if encoded on 4 bits, there is 4 remaining RENDER_PASSES possible values for potential futur addition).

In layers, flagsBuf is changed from `UInt8Array` with 4 elements per vertex, to `Float32Array` with one element per vertex.
flags2Buf is removed as with 4 bits per flags and with 5 flags ( color, silhouette, edge, pick & clippable), flagsBuf can handle it and can still handle 3 potentials futur flags (32 bit - 5 * 4bit = 12 bits remaining => 4 bits per flags = 3 possible flags :P )

So from the javacript side, the memory gain is removing flags2 = 32bits per vertex.
From the WebGL side, two `vec4` => one `float`. However, as we set Float32Array instead of UInt8Array on glBuffers, not sure if the gain is by 8. (does two vec4 means 8 x 32bits in GPU memory even if we used javascript UInt8Array to set the data for the vec4 ?)
