### PR TITLE
Remove useless Renderer picking commented code

### DIFF
--- a/src/viewer/scene/webgl/Renderer.js
+++ b/src/viewer/scene/webgl/Renderer.js
@@ -1039,10 +1039,6 @@ const Renderer = function (scene, options) {
                             pickResult.worldNormal = worldSurfaceNormal;
                         }
 
-                        // if (params.pickSurfaceNormal !== false) {
-                        //     gpuPickWorldNormal(pickBuffer, pickable, canvasPos, pickViewMatrix, pickProjMatrix, pickResult);
-                        // }
-
                         pickResult.pickSurfacePrecision = true;
                     }
 


### PR DESCRIPTION
The commented code is the code for the GPU pick surface (not precise) part, but it is in the JS pick surface (precise) part. I assume it needs to be deleted.