### PR TITLE
Fix full precision picking in triangle instancing layer

### DIFF
--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/TrianglesInstancingLayer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/TrianglesInstancingLayer.js
@@ -1003,9 +1003,11 @@ class TrianglesInstancingLayer {
             c[1] = quantizedPositions[ic + 1];
             c[2] = quantizedPositions[ic + 2];
 
-            math.decompressPosition(a, state.positionsDecodeMatrix);
-            math.decompressPosition(b, state.positionsDecodeMatrix);
-            math.decompressPosition(c, state.positionsDecodeMatrix);
+            const { positionsDecodeMatrix } = state.geometry;
+
+            math.decompressPosition(a, positionsDecodeMatrix);
+            math.decompressPosition(b, positionsDecodeMatrix);
+            math.decompressPosition(c, positionsDecodeMatrix);
 
             if (math.rayTriangleIntersect(rtcRayOrigin, rtcRayDir, a, b, c, closestIntersectPos)) {
 


### PR DESCRIPTION
Full precision is broken on [triangle instancing layer](https://xeokit.github.io/xeokit-sdk/examples/#picking_pickSurfacePrecision_VBOSceneModel_instancing).

`positionsDecodeMatrix` is not directly available on the layer `state` but must be obtained [from the state `geometry`](https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/TrianglesInstancingLayer.js#L681). The error should result by copying and pasting the code of the [triangleBatchingLayer](https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/TrianglesBatchingLayer.js#L1231) that gets the `positionsDecodeMatrix` directly from the layer `state`.