### PR TITLE
fix & clean VBOSceneModel renderers

### DIFF
--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/linesBatching/renderers/LinesBatchingColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/linesBatching/renderers/LinesBatchingColorRenderer.js
@@ -17,7 +17,7 @@ class LinesBatchingColorRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();
@@ -31,7 +31,6 @@ class LinesBatchingColorRenderer {
         const gl = scene.canvas.gl;
         const state = batchingLayer._state;
         const origin = batchingLayer._state.origin;
-        const geometry = batchingLayer.geometry;
 
         if (!this._program) {
             this._allocate();
@@ -139,7 +138,7 @@ class LinesBatchingColorRenderer {
         }
     }
 
-    _bindProgram(frameCtx) {
+    _bindProgram() {
 
         const scene = this._scene;
         const gl = scene.canvas.gl;

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/linesBatching/renderers/LinesBatchingSilhouetteRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/linesBatching/renderers/LinesBatchingSilhouetteRenderer.js
@@ -2,7 +2,6 @@ import {Program} from "../../../../../../webgl/Program.js";
 import {RENDER_PASSES} from "../../../RENDER_PASSES.js";
 import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
 import {math} from "../../../../../../math/math.js";
-import {WEBGL_INFO} from "../../../../../../webglInfo.js";
 
 const defaultColor = new Float32Array([1, 1, 1]);
 const tempVec3a = math.vec3();
@@ -12,7 +11,7 @@ const tempVec3a = math.vec3();
  */
 class LinesBatchingSilhouetteRenderer {
 
-    constructor(scene, primitiveType) {
+    constructor(scene) {
         this._scene = scene;
         this._hash = this._getHash();
         this._allocate();
@@ -20,7 +19,7 @@ class LinesBatchingSilhouetteRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();
@@ -34,7 +33,6 @@ class LinesBatchingSilhouetteRenderer {
         const gl = scene.canvas.gl;
         const state = batchingLayer._state;
         const origin = batchingLayer._state.origin;
-        const geometry = batchingLayer.geometry;
 
         if (!this._program) {
             this._allocate();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/linesInstancing/renderers/LinesInstancingColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/linesInstancing/renderers/LinesInstancingColorRenderer.js
@@ -17,7 +17,7 @@ class LinesInstancingColorRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/linesInstancing/renderers/LinesInstancingSilhouetteRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/linesInstancing/renderers/LinesInstancingSilhouetteRenderer.js
@@ -18,7 +18,7 @@ class LinesInstancingSilhouetteRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsBatching/renderers/PointsBatchingOcclusionRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsBatching/renderers/PointsBatchingOcclusionRenderer.js
@@ -17,7 +17,7 @@ class PointsBatchingOcclusionRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash() + (this._scene.pointsMaterial.hash);

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsBatching/renderers/PointsBatchingPickDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsBatching/renderers/PointsBatchingPickDepthRenderer.js
@@ -1,7 +1,6 @@
 import {Program} from "../../../../../../webgl/Program.js";
 import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
 import {math} from "../../../../../../math/math.js";
-import {WEBGL_INFO} from "../../../../../../webglInfo.js";
 
 const tempVec3a = math.vec3();
 
@@ -18,7 +17,7 @@ class PointsBatchingPickDepthRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash() + (this._scene.pointsMaterial.hash);

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsBatching/renderers/PointsBatchingPickMeshRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsBatching/renderers/PointsBatchingPickMeshRenderer.js
@@ -1,7 +1,6 @@
 import {Program} from "../../../../../../webgl/Program.js";
 import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
 import {math} from "../../../../../../math/math.js";
-import {WEBGL_INFO} from "../../../../../../webglInfo.js";
 
 const tempVec3a = math.vec3();
 
@@ -18,7 +17,7 @@ class PointsBatchingPickMeshRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash() + (this._scene.pointsMaterial.hash);
@@ -282,7 +281,7 @@ class PointsBatchingPickMeshRenderer {
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("      float dist = 0.0;");
-            for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
+            for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
                 src.push("      if (sectionPlaneActive" + i + ") {");
                 src.push("          dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
                 src.push("      }");

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsBatching/renderers/PointsBatchingShadowRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsBatching/renderers/PointsBatchingShadowRenderer.js
@@ -19,7 +19,7 @@ class PointsBatchingShadowRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();
@@ -29,7 +29,7 @@ class PointsBatchingShadowRenderer {
         const scene = this._scene;
         const gl = scene.canvas.gl;
         const state = pointsBatchingLayer._state;
-        const pointsMaterial = scene.pointsMaterial._state;
+
         if (!this._program) {
             this._allocate();
         }
@@ -58,7 +58,7 @@ class PointsBatchingShadowRenderer {
         if (numSectionPlanes > 0) {
             const sectionPlanes = scene._sectionPlanesState.sectionPlanes;
             const baseIndex = pointsBatchingLayer.layerIndex * numSectionPlanes;
-            const renderFlags = model.renderFlags;
+            const renderFlags = pointsBatchingLayer.model.renderFlags;
             const origin = pointsBatchingLayer._state.origin;
             for (let sectionPlaneIndex = 0; sectionPlaneIndex < numSectionPlanes; sectionPlaneIndex++) {
                 const sectionPlaneUniforms = this._uSectionPlanes[sectionPlaneIndex];

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsBatching/renderers/PointsBatchingSilhouetteRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsBatching/renderers/PointsBatchingSilhouetteRenderer.js
@@ -2,7 +2,6 @@ import {Program} from "../../../../../../webgl/Program.js";
 import {RENDER_PASSES} from "../../../RENDER_PASSES.js";
 import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
 import {math} from "../../../../../../math/math.js";
-import {WEBGL_INFO} from "../../../../../../webglInfo.js";
 
 const defaultColor = new Float32Array([1, 1, 1]);
 const tempVec3a = math.vec3();
@@ -20,7 +19,7 @@ class PointsBatchingSilhouetteRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash() + this._scene.pointsMaterial.hash;

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/renderers/PointsInstancingDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/renderers/PointsInstancingDepthRenderer.js
@@ -17,7 +17,7 @@ class PointsInstancingDepthRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash() + this._scene.pointsMaterial.hash;

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/renderers/PointsInstancingOcclusionRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/renderers/PointsInstancingOcclusionRenderer.js
@@ -17,7 +17,7 @@ class PointsInstancingOcclusionRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash() + this._scene.pointsMaterial.hash;

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/renderers/PointsInstancingPickDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/renderers/PointsInstancingPickDepthRenderer.js
@@ -17,7 +17,7 @@ class PointsInstancingPickDepthRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash() + this._scene.pointsMaterial.hash;

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/renderers/PointsInstancingPickMeshRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/renderers/PointsInstancingPickMeshRenderer.js
@@ -19,7 +19,7 @@ class PointsInstancingPickMeshRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash() + this._scene.pointsMaterial.hash;

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/renderers/PointsInstancingShadowRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/renderers/PointsInstancingShadowRenderer.js
@@ -20,7 +20,7 @@ class PointsInstancingShadowRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();
@@ -45,7 +45,7 @@ class PointsInstancingShadowRenderer {
             this._bindProgram(frameCtx, instancingLayer);
         }
 
-        gl.uniformMatrix4fv(this._uPositionsDecodeMatrix, false, geometry.positionsDecodeMatrix); // TODO geometry is undefined
+        gl.uniformMatrix4fv(this._uPositionsDecodeMatrix, false, state.geometry.positionsDecodeMatrix);
 
         this._aModelMatrixCol0.bindArrayBuffer(state.modelMatrixCol0Buf);
         this._aModelMatrixCol1.bindArrayBuffer(state.modelMatrixCol1Buf);
@@ -142,7 +142,7 @@ class PointsInstancingShadowRenderer {
         this._uPointSize = program.getLocation("pointSize");
     }
 
-    _bindProgram(frameCtx, instancingLayer) {
+    _bindProgram(frameCtx) {
         const scene = this._scene;
         const gl = scene.canvas.gl;
         const program = this._program;

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/renderers/PointsInstancingSilhouetteRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/pointsInstancing/renderers/PointsInstancingSilhouetteRenderer.js
@@ -18,7 +18,7 @@ class PointsInstancingSilhouetteRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash() + this._scene.pointsMaterial.hash;

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingColorRenderer.js
@@ -19,7 +19,7 @@ class TrianglesBatchingColorRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         const scene = this._scene;

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingColorTextureRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingColorTextureRenderer.js
@@ -20,7 +20,7 @@ class TrianglesBatchingColorTextureRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         const scene = this._scene;
@@ -219,9 +219,8 @@ class TrianglesBatchingColorTextureRenderer {
         }
     }
 
-    _bindProgram(frameCtx) {
+    _bindProgram() {
 
-        const maxTextureUnits = WEBGL_INFO.MAX_TEXTURE_IMAGE_UNITS;
         const scene = this._scene;
         const gl = scene.canvas.gl;
         const program = this._program;

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingDepthRenderer.js
@@ -18,7 +18,7 @@ class TrianglesBatchingDepthRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingEdgesColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingEdgesColorRenderer.js
@@ -17,7 +17,7 @@ class TrianglesBatchingEdgesColorRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingEdgesRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingEdgesRenderer.js
@@ -19,7 +19,7 @@ class TrianglesBatchingEdgesRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingFlatColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingFlatColorRenderer.js
@@ -19,7 +19,7 @@ class TrianglesBatchingFlatColorRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         const scene = this._scene;

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingNormalsRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingNormalsRenderer.js
@@ -17,7 +17,7 @@ class TrianglesBatchingNormalsRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingOcclusionRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingOcclusionRenderer.js
@@ -17,7 +17,7 @@ class TrianglesBatchingOcclusionRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingPBRRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingPBRRenderer.js
@@ -2,7 +2,6 @@ import {Program} from "../../../../../../webgl/Program.js";
 import {math} from "../../../../../../math/math.js";
 import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
 import {WEBGL_INFO} from "../../../../../../webglInfo.js";
-import {LinearEncoding, sRGBEncoding} from "../../../../../../constants/constants.js";
 
 const tempVec4 = math.vec4();
 const tempVec3a = math.vec3();
@@ -25,7 +24,7 @@ class TrianglesBatchingPBRRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         const scene = this._scene;
@@ -268,9 +267,8 @@ class TrianglesBatchingPBRRenderer {
         }
     }
 
-    _bindProgram(frameCtx) {
+    _bindProgram() {
 
-        const maxTextureUnits = WEBGL_INFO.MAX_TEXTURE_IMAGE_UNITS;
         const scene = this._scene;
         const gl = scene.canvas.gl;
         const program = this._program;

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingPickDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingPickDepthRenderer.js
@@ -17,7 +17,7 @@ class TrianglesBatchingPickDepthRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();
@@ -277,7 +277,7 @@ class TrianglesBatchingPickDepthRenderer {
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("      float dist = 0.0;");
-            for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
+            for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
                 src.push("      if (sectionPlaneActive" + i + ") {");
                 src.push("          dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
                 src.push("      }");

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingPickMeshRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingPickMeshRenderer.js
@@ -17,7 +17,7 @@ class TrianglesBatchingPickMeshRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();
@@ -265,7 +265,7 @@ class TrianglesBatchingPickMeshRenderer {
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("      float dist = 0.0;");
-            for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
+            for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
                 src.push("      if (sectionPlaneActive" + i + ") {");
                 src.push("          dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
                 src.push("      }");

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingPickNormalsFlatRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingPickNormalsFlatRenderer.js
@@ -17,7 +17,7 @@ class TrianglesBatchingPickNormalsFlatRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();
@@ -242,7 +242,7 @@ class TrianglesBatchingPickNormalsFlatRenderer {
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("      float dist = 0.0;");
-            for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
+            for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
                 src.push("      if (sectionPlaneActive" + i + ") {");
                 src.push("          dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
                 src.push("      }");

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingPickNormalsRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingPickNormalsRenderer.js
@@ -17,7 +17,7 @@ class TrianglesBatchingPickNormalsRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();
@@ -262,7 +262,7 @@ class TrianglesBatchingPickNormalsRenderer {
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("      float dist = 0.0;");
-            for (var i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
+            for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
                 src.push("      if (sectionPlaneActive" + i + ") {");
                 src.push("          dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
                 src.push("      }");

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingShadowRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingShadowRenderer.js
@@ -19,7 +19,7 @@ class TrianglesBatchingShadowRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();
@@ -58,7 +58,7 @@ class TrianglesBatchingShadowRenderer {
         if (numSectionPlanes > 0) {
             const sectionPlanes = scene._sectionPlanesState.sectionPlanes;
             const baseIndex = batchingLayer.layerIndex * numSectionPlanes;
-            const renderFlags = model.renderFlags;
+            const renderFlags = batchingLayer.model.renderFlags;
             const origin = batchingLayer._state.origin;
             for (let sectionPlaneIndex = 0; sectionPlaneIndex < numSectionPlanes; sectionPlaneIndex++) {
                 const sectionPlaneUniforms = this._uSectionPlanes[sectionPlaneIndex];

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingSilhouetteRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingSilhouetteRenderer.js
@@ -11,7 +11,7 @@ const tempVec3a = math.vec3();
  */
 class TrianglesBatchingSilhouetteRenderer {
 
-    constructor(scene, primitiveType) {
+    constructor(scene) {
         this._scene = scene;
         this._hash = this._getHash();
         this._allocate();
@@ -19,7 +19,7 @@ class TrianglesBatchingSilhouetteRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/TrianglesInstancingLayer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/TrianglesInstancingLayer.js
@@ -21,8 +21,6 @@ const tempVec3e = math.vec3();
 const tempVec3f = math.vec3();
 const tempVec3g = math.vec3();
 
-const tempVec2a = math.vec2([0, 0]);
-
 /**
  * @private
  */

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingColorRenderer.js
@@ -19,7 +19,7 @@ class TrianglesInstancingColorRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         const scene = this._scene;
@@ -443,8 +443,6 @@ class TrianglesInstancingColorRenderer {
     _buildFragmentShader() {
         const scene = this._scene;
         const sectionPlanesState = scene._sectionPlanesState;
-        let i;
-        let len;
         const clipping = sectionPlanesState.sectionPlanes.length > 0;
         const src = [];
         src.push("#version 300 es");

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingColorTextureRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingColorTextureRenderer.js
@@ -20,7 +20,7 @@ class TrianglesInstancingColorTextureRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         const scene = this._scene;
@@ -236,7 +236,7 @@ class TrianglesInstancingColorTextureRenderer {
         }
     }
 
-    _bindProgram(frameCtx) {
+    _bindProgram() {
 
         const scene = this._scene;
         const gl = scene.canvas.gl;

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingDepthRenderer.js
@@ -17,7 +17,7 @@ class TrianglesInstancingDepthRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingEdgesColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingEdgesColorRenderer.js
@@ -1,5 +1,4 @@
 import {Program} from "../../../../../../webgl/Program.js";
-import {RENDER_PASSES} from "../../../RENDER_PASSES.js";
 import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
 import {math} from "../../../../../../math/math.js";
 
@@ -18,7 +17,7 @@ class TrianglesInstancingEdgesColorRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingEdgesRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingEdgesRenderer.js
@@ -19,7 +19,7 @@ class TrianglesInstancingEdgesRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingFlatColorRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingFlatColorRenderer.js
@@ -19,7 +19,7 @@ class TrianglesInstancingFlatColorRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         const scene = this._scene;

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingFlatNormalsRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingFlatNormalsRenderer.js
@@ -17,7 +17,7 @@ class TrianglesInstancingFlatNormalsRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingNormalsRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingNormalsRenderer.js
@@ -17,7 +17,7 @@ class TrianglesInstancingNormalsRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingOcclusionRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingOcclusionRenderer.js
@@ -17,7 +17,7 @@ class TrianglesInstancingOcclusionRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingPBRRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingPBRRenderer.js
@@ -25,7 +25,7 @@ class TrianglesInstancingPBRRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         const scene = this._scene;
@@ -300,9 +300,8 @@ class TrianglesInstancingPBRRenderer {
         }
     }
 
-    _bindProgram(frameCtx) {
+    _bindProgram() {
 
-        const maxTextureUnits = WEBGL_INFO.MAX_TEXTURE_IMAGE_UNITS;
         const scene = this._scene;
         const gl = scene.canvas.gl;
         const lightsState = scene._lightsState;

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingPickDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingPickDepthRenderer.js
@@ -17,7 +17,7 @@ class TrianglesInstancingPickDepthRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingPickMeshRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingPickMeshRenderer.js
@@ -19,7 +19,7 @@ class TrianglesInstancingPickMeshRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingPickNormalsFlatRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingPickNormalsFlatRenderer.js
@@ -17,7 +17,7 @@ class TrianglesInstancingPickNormalsFlatRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingPickNormalsRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingPickNormalsRenderer.js
@@ -17,7 +17,7 @@ class TrianglesInstancingPickNormalsRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingShadowRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingShadowRenderer.js
@@ -1,5 +1,5 @@
 import {Program} from "../../../../../../webgl/Program.js";
-import {createRTCViewMat, getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
+import {getPlaneRTCPos} from "../../../../../../math/rtcCoords.js";
 import {math} from "../../../../../../math/math.js";
 
 const tempVec3a = math.vec3();
@@ -20,7 +20,7 @@ class TrianglesInstancingShadowRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();
@@ -141,7 +141,7 @@ class TrianglesInstancingShadowRenderer {
         this._aModelMatrixCol2 = program.getAttribute("modelMatrixCol2");
     }
 
-    _bindProgram(frameCtx, instancingLayer) {
+    _bindProgram(frameCtx) {
         const scene = this._scene;
         const gl = scene.canvas.gl;
         const program = this._program;

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingSilhouetteRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesInstancing/renderers/TrianglesInstancingSilhouetteRenderer.js
@@ -18,7 +18,7 @@ class TrianglesInstancingSilhouetteRenderer {
 
     getValid() {
         return this._hash === this._getHash();
-    };
+    }
 
     _getHash() {
         return this._scene._sectionPlanesState.getHash();


### PR DESCRIPTION
fixes:
- fix triangle batching shadow renderer -> model was `undefined`
- fix point batching shadow renderer -> model was `undefined`
- fix point instancing shadow renderer -> geometry was `undefined`

cleans:
- remove unused import & variables
- remove useless semicolon
- replace `var` by `let` in shader for loop