### PR TITLE
VBOSceneModel - TriangleBatching - Only draw pick depth & normals of the picked mesh

### DIFF
--- a/src/viewer/scene/models/VBOSceneModel/VBOSceneModel.js
+++ b/src/viewer/scene/models/VBOSceneModel/VBOSceneModel.js
@@ -2716,6 +2716,12 @@ ${cfg.uv && cfg.uv.length > 0 ? 1 : 0}-${cfg.uvCompressed && cfg.uvCompressed.le
         mesh._portionId = portionId;
         mesh.aabb = aabb;
 
+        if (layer.getElementsCountAndOffset) {
+            const { count, offset } = layer.getElementsCountAndOffset(portionId);
+            mesh.pickElementsCount = count;
+            mesh.pickElementsOffset = offset
+        }
+
         this._meshes[id] = mesh;
     }
 

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/TrianglesBatchingLayer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/TrianglesBatchingLayer.js
@@ -370,11 +370,11 @@ class TrianglesBatchingLayer {
             }
         }
 
-        if (indices) {
-            for (let i = 0, len = indices.length; i < len; i++) {
-                buffer.indices.push(vertsBaseIndex + indices[i]);
-            }
+
+        for (let i = 0, len = indices.length; i < len; i++) {
+            buffer.indices.push(vertsBaseIndex + indices[i]);
         }
+
 
         if (edgeIndices) {
             for (let i = 0, len = edgeIndices.length; i < len; i++) {
@@ -405,14 +405,16 @@ class TrianglesBatchingLayer {
 
         const portion = {
             vertsBaseIndex: vertsBaseIndex,
-            numVerts: numVerts
+            numVerts: numVerts,
+            indicesBaseIndex: buffer.indices.length - indices.length,
+            numIndices: indices.length,
         };
 
         if (scene.pickSurfacePrecisionEnabled) {
             // Quantized in-memory positions are initialized in finalize()
-            if (indices) {
-                portion.indices = indices;
-            }
+
+            portion.indices = indices;
+
             if (scene.entityOffsetsEnabled) {
                 portion.offset = new Float32Array(3);
             }
@@ -917,6 +919,19 @@ class TrianglesBatchingLayer {
             worldPos[2] += offsetZ;
             callback(worldPos);
         }
+    }
+
+    getElementsCountAndOffset(portionId) {
+        let count = null;
+        let offset = null;
+        const portion = this._portions[portionId];
+
+        if (portion) {
+            count = portion.numIndices;
+            offset = portion.indicesBaseIndex;
+        }
+
+        return { count, offset }
     }
 
     // ---------------------- COLOR RENDERING -----------------------------------

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingPickDepthRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingPickDepthRenderer.js
@@ -84,10 +84,6 @@ class TrianglesBatchingPickDepthRenderer {
             }
         }
 
-        //=============================================================
-        // TODO: Use drawElements count and offset to draw only one entity
-        //=============================================================
-
         gl.uniformMatrix4fv(this._uPositionsDecodeMatrix, false, batchingLayer._state.positionsDecodeMatrix);
 
         this._aPosition.bindArrayBuffer(state.positionsBuf);
@@ -102,7 +98,10 @@ class TrianglesBatchingPickDepthRenderer {
 
         state.indicesBuf.bind();
 
-        gl.drawElements(gl.TRIANGLES, state.indicesBuf.numItems, state.indicesBuf.itemType, 0);
+        const count = frameCtx.pickElementsCount || state.indicesBuf.numItems;
+        const offset = frameCtx.pickElementsOffset ? frameCtx.pickElementsOffset * state.indicesBuf.itemByteSize : 0;
+
+        gl.drawElements(gl.TRIANGLES, count, state.indicesBuf.itemType, offset);
     }
 
     _allocate() {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingPickNormalsFlatRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingPickNormalsFlatRenderer.js
@@ -79,10 +79,6 @@ class TrianglesBatchingPickNormalsFlatRenderer {
             }
         }
 
-        //=============================================================
-        // TODO: Use drawElements count and offset to draw only one entity
-        //=============================================================
-
         gl.uniformMatrix4fv(this._uPositionsDecodeMatrix, false, batchingLayer._state.positionsDecodeMatrix);
 
         this._aPosition.bindArrayBuffer(state.positionsBuf);
@@ -97,7 +93,10 @@ class TrianglesBatchingPickNormalsFlatRenderer {
 
         state.indicesBuf.bind();
 
-        gl.drawElements(gl.TRIANGLES, state.indicesBuf.numItems, state.indicesBuf.itemType, 0);
+        const count = frameCtx.pickElementsCount || state.indicesBuf.numItems;
+        const offset = frameCtx.pickElementsOffset ? frameCtx.pickElementsOffset * state.indicesBuf.itemByteSize : 0;
+
+        gl.drawElements(gl.TRIANGLES, count, state.indicesBuf.itemType, offset);
     }
 
     _allocate() {

--- a/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingPickNormalsRenderer.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/layers/trianglesBatching/renderers/TrianglesBatchingPickNormalsRenderer.js
@@ -81,10 +81,6 @@ class TrianglesBatchingPickNormalsRenderer {
             }
         }
 
-        //=============================================================
-        // TODO: Use drawElements count and offset to draw only one entity
-        //=============================================================
-
         gl.uniformMatrix4fv(this._uPositionsDecodeMatrix, false, batchingLayer._state.positionsDecodeMatrix);
 
         this._aPosition.bindArrayBuffer(state.positionsBuf);
@@ -103,7 +99,10 @@ class TrianglesBatchingPickNormalsRenderer {
 
         state.indicesBuf.bind();
 
-        gl.drawElements(gl.TRIANGLES, state.indicesBuf.numItems, state.indicesBuf.itemType, 0);
+        const count = frameCtx.pickElementsCount || state.indicesBuf.numItems;
+        const offset = frameCtx.pickElementsOffset ? frameCtx.pickElementsOffset * state.indicesBuf.itemByteSize : 0;
+
+        gl.drawElements(gl.TRIANGLES, count, state.indicesBuf.itemType, offset);
     }
 
     _allocate() {

--- a/src/viewer/scene/webgl/FrameContext.js
+++ b/src/viewer/scene/webgl/FrameContext.js
@@ -219,6 +219,22 @@ class FrameContext {
          */
         this.pickInvisible = false;
 
+        /**
+         * Used to draw only requested elements / indices.
+         *
+         * @property pickElementsCount
+         * @type {Number}
+         */
+        this.pickElementsCount = null;
+
+        /**
+         * Used to draw only requested elements / indices.
+         *
+         * @property pickElementsOffset
+         * @type {Number}
+         */
+        this.pickElementsOffset = null;
+
         /** The current line width.
          *
          * @property lineWidth

--- a/src/viewer/scene/webgl/Renderer.js
+++ b/src/viewer/scene/webgl/Renderer.js
@@ -1198,6 +1198,8 @@ const Renderer = function (scene, options) {
             frameCtx.pickProjMatrix = pickProjMatrix;
             frameCtx.pickZNear = nearAndFar[0];
             frameCtx.pickZFar = nearAndFar[1];
+            frameCtx.pickElementsCount = pickable.pickElementsCount;
+            frameCtx.pickElementsOffset = pickable.pickElementsOffset;
 
             gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
 


### PR DESCRIPTION
This PR adresses the

```js
//=============================================================
// TODO: Use drawElements count and offset to draw only one entity
//=============================================================
```
of the triangle batching renderers (pick depth, pick normals & pick normals flat).

API update:
- add FrameContext `pickElementsCount` & `pickElementsOffset` nullable number properties.
- add VBOSceneModelMesh `pickElementsCount` & `pickElementsOffset` nullable number properties.
- add TriangleBatchingLayer `getElementsCountAndOffset` method.
```js
getElementsCountAndOffset(portionId: number): { count?: number offset?: number }
```
- TriangleBatchingLayer portions get extra `indicesBaseIndex` & `numIndices` number properties.

Also remove the TriangleBatchingLayer `if` tests on the `indices` as they are mandatory for triangle primitives.