### PR TITLE
data-tex: use 12 instead of 16 floats to store entity matrices

### DIFF
--- a/src/viewer/scene/models/DataTextureSceneModel/lib/layers/DataTextureState.js
+++ b/src/viewer/scene/models/DataTextureSceneModel/lib/layers/DataTextureState.js
@@ -919,8 +919,8 @@ class DataTextureGenerator
         }
 
         // in one row we can fit 512 matrices        
-        const textureWidth = 512 * 4;
-        const textureHeight =  Math.ceil (numMatrices / (textureWidth / 4));
+        const textureWidth = 512 * 3;
+        const textureHeight =  Math.ceil (numMatrices / (textureWidth / 3));
 
         var texArray = new Float32Array(4 * textureWidth * textureHeight);
 
@@ -928,17 +928,21 @@ class DataTextureGenerator
         dataTextureRamStats.numberOfTextures++;
 
         const tmpMatrix = math.mat4();
+        const tmpMatrix2 = math.mat4();
 
         for (var i = 0; i < positionDecodeMatrices.length; i++)
         {
             // 4x4 values
             texArray.set (
-                math.mulMat4(
-                    instanceMatrices[i],
-                    positionDecodeMatrices[i],
-                    tmpMatrix
-                ),
-                i * 16
+                math.transposeMat4(
+                    math.mulMat4(
+                        instanceMatrices[i],
+                        positionDecodeMatrices[i],
+                        tmpMatrix
+                    ),
+                    tmpMatrix2
+                ).slice(0, 12),
+                i * 12
             );
         }
 

--- a/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
+++ b/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureColorRenderer.js
@@ -411,7 +411,7 @@ class TrianglesDataTextureColorRenderer {
         src.push("ivec3 indexPositionH = uniqueVertexIndexes & 4095;")
         src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 12;")
 
-        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+2, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+3, objectIndexCoords.y), 0));")
+        src.push("mat4 positionsDecodeMatrix = transpose(mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+2, objectIndexCoords.y), 0), vec4(0, 0, 0, 1)));")
         
         src.push("uint solid = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+7, objectIndexCoords.y), 0).r;"); // chipmunk
 

--- a/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureDepthRenderer.js
+++ b/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureDepthRenderer.js
@@ -319,7 +319,7 @@ class TrianglesDataTextureDepthRenderer {
         src.push("ivec3 indexPositionH = uniqueVertexIndexes & 4095;")
         src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 12;")
 
-        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+2, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+3, objectIndexCoords.y), 0));")
+        src.push("mat4 positionsDecodeMatrix = transpose(mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+2, objectIndexCoords.y), 0), vec4(0, 0, 0, 1)));")
 
         src.push("uint solid = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+7, objectIndexCoords.y), 0).r;"); // chipmunk
 

--- a/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
+++ b/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesColorRenderer.js
@@ -290,7 +290,7 @@ class TrianglesDataTextureEdgesColorRenderer {
         src.push("int indexPositionH = uniqueVertexIndexes[gl_VertexID % 2] & 4095;")
         src.push("int indexPositionV = uniqueVertexIndexes[gl_VertexID % 2] >> 12;")
 
-        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+2, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+3, objectIndexCoords.y), 0));")
+        src.push("mat4 positionsDecodeMatrix = transpose(mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+2, objectIndexCoords.y), 0), vec4(0, 0, 0, 1)));")
 
         // get flags & flags2
         src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+2, objectIndexCoords.y), 0);"); // chipmunk

--- a/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesRenderer.js
+++ b/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureEdgesRenderer.js
@@ -319,7 +319,7 @@ class TrianglesDataTextureEdgesRenderer {
         src.push("int indexPositionH = uniqueVertexIndexes[gl_VertexID % 2] & 4095;")
         src.push("int indexPositionV = uniqueVertexIndexes[gl_VertexID % 2] >> 12;")
 
-        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+2, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+3, objectIndexCoords.y), 0));")
+        src.push("mat4 positionsDecodeMatrix = transpose(mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+2, objectIndexCoords.y), 0), vec4(0, 0, 0, 1)));")
 
         // get flags & flags2
         src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+2, objectIndexCoords.y), 0);"); // chipmunk

--- a/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
+++ b/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickDepthRenderer.js
@@ -308,7 +308,7 @@ class TrianglesDataTexturePickDepthRenderer {
         src.push("ivec3 indexPositionH = uniqueVertexIndexes & 4095;")
         src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 12;")
 
-        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+2, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+3, objectIndexCoords.y), 0));")
+        src.push("mat4 positionsDecodeMatrix = transpose(mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+2, objectIndexCoords.y), 0), vec4(0, 0, 0, 1)));")
         
         src.push("uint solid = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+7, objectIndexCoords.y), 0).r;"); // chipmunk
 

--- a/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
+++ b/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickMeshRenderer.js
@@ -312,7 +312,7 @@ class TrianglesDataTexturePickMeshRenderer {
         src.push("ivec3 indexPositionH = uniqueVertexIndexes & 4095;")
         src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 12;")
 
-        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+2, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+3, objectIndexCoords.y), 0));")
+        src.push("mat4 positionsDecodeMatrix = transpose(mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+2, objectIndexCoords.y), 0), vec4(0, 0, 0, 1)));")
         
         src.push("uint solid = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+7, objectIndexCoords.y), 0).r;"); // chipmunk
 

--- a/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsFlatRenderer.js
+++ b/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsFlatRenderer.js
@@ -387,7 +387,7 @@ class TrianglesDataTexturePickNormalsFlatRenderer {
         src.push("ivec3 indexPositionH = uniqueVertexIndexes & 4095;")
         src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 12;")
 
-        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+2, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+3, objectIndexCoords.y), 0));")
+        src.push("mat4 positionsDecodeMatrix = transpose(mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+2, objectIndexCoords.y), 0), vec4(0, 0, 0, 1)));")
 
         // get flags & flags2
         src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+2, objectIndexCoords.y), 0);"); // chipmunk

--- a/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
+++ b/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTexturePickNormalsRenderer.js
@@ -302,7 +302,7 @@ class TrianglesDataTexturePickNormalsRenderer {
         src.push("ivec3 indexPositionH = uniqueVertexIndexes & 4095;")
         src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 12;")
 
-        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+2, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+3, objectIndexCoords.y), 0));")
+        src.push("mat4 positionsDecodeMatrix = transpose(mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+2, objectIndexCoords.y), 0), vec4(0, 0, 0, 1)));")
         
         src.push("uint solid = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+7, objectIndexCoords.y), 0).r;"); // chipmunk
 

--- a/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureSilhouetteRenderer.js
+++ b/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureSilhouetteRenderer.js
@@ -339,7 +339,7 @@ class TrianglesDataTextureSilhouetteRenderer {
         src.push("ivec3 indexPositionH = uniqueVertexIndexes & 4095;")
         src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 12;")
 
-        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+2, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+3, objectIndexCoords.y), 0));")
+        src.push("mat4 positionsDecodeMatrix = transpose(mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+2, objectIndexCoords.y), 0), vec4(0, 0, 0, 1)));")
         
         src.push("uint solid = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+7, objectIndexCoords.y), 0).r;"); // chipmunk
 

--- a/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureSnapPickZBufferInitializer.js
+++ b/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureSnapPickZBufferInitializer.js
@@ -362,7 +362,7 @@ class TrianglesDataTextureSnapPickZBufferInitializer {
         src.push("ivec3 indexPositionH = uniqueVertexIndexes & 4095;")
         src.push("ivec3 indexPositionV = uniqueVertexIndexes >> 12;")
 
-        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+2, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+3, objectIndexCoords.y), 0));")
+        src.push("mat4 positionsDecodeMatrix = transpose(mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+2, objectIndexCoords.y), 0), vec4(0, 0, 0, 1)));")
         
         src.push("uint solid = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+7, objectIndexCoords.y), 0).r;"); // chipmunk
 

--- a/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureVertexDepthRenderer.js
+++ b/src/viewer/scene/models/DataTextureSceneModel/lib/layers/trianglesDataTexture/renderers/TrianglesDataTextureVertexDepthRenderer.js
@@ -360,7 +360,7 @@ class TrianglesDataTextureVertexDepthRenderer {
         src.push("int indexPositionH = uniqueVertexIndexes[gl_VertexID % 2] & 4095;")
         src.push("int indexPositionV = uniqueVertexIndexes[gl_VertexID % 2] >> 12;")
 
-        src.push("mat4 positionsDecodeMatrix = mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+2, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*4+3, objectIndexCoords.y), 0));")
+        src.push("mat4 positionsDecodeMatrix = transpose(mat4 (texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+0, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+1, objectIndexCoords.y), 0), texelFetch (uTexturePerObjectIdPositionsDecodeMatrix, ivec2(objectIndexCoords.x*3+2, objectIndexCoords.y), 0), vec4(0, 0, 0, 1)));")
 
         // get flags & flags2
         src.push("uvec4 flags = texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+2, objectIndexCoords.y), 0);"); // chipmunk


### PR DESCRIPTION
A 4x4 matrix has this form:

```
| a | b | c | d |
+---+---+---+---+
| e | f | g | h |
+---+---+---+---+
| i | j | k | l |
+---+---+---+---+
| m | n | o | p |
```

In case of entity instancing matrices, if the instancing matrix is not projective, can be simplified to:

```
| a | b | c | 0 |
+---+---+---+---+
| e | f | g | 0 |
+---+---+---+---+
| i | j | k | 0 |
+---+---+---+---+
| m | n | o | 1 |
```

This allows to simplify the storage of the entity matrices by just storing the 1st three columns, knowing that the last column will be a `vec4(0, 0, 0, 1)` .

In my tests, a model with around 50k objects and 19.28 M triangles moves from using 33.25 MB VRAM to 31.20 MB, so 6.2% less VRAM!