### PR TITLE
Stats `fps` field

### DIFF
--- a/src/viewer/scene/core.js
+++ b/src/viewer/scene/core.js
@@ -138,8 +138,8 @@ const core = new Core();
 
 const frame = function () {
     let time = Date.now();
-    if (lastTime > 0) { // Log FPS stats
-        elapsedTime = time - lastTime;
+    elapsedTime = time - lastTime;
+    if (lastTime > 0 && elapsedTime > 0) { // Log FPS stats
         var newFPS = 1000 / elapsedTime; // Moving average of FPS
         totalFPS += newFPS;
         fpsSamples.push(newFPS);


### PR DESCRIPTION
The [stats.frame.fps](https://github.com/xeokit/xeokit-sdk/blob/a2bf178671392f0703b2f56918d8ccf9c914ed2c/src/viewer/scene/stats.js#L33) field becomes null/NaN whenever requestAnimationFrame calls are sparse.
Checking for elapsedTime fixes it.
