### PR TITLE
Add stats typings

### DIFF
--- a/types/viewer/scene/index.d.ts
+++ b/types/viewer/scene/index.d.ts
@@ -14,5 +14,6 @@ export * from "./nodes";
 export * from "./models";
 export * from "./scene/Scene";
 export * from "./sectionPlane";
+export * from "./stats";
 export * from "./viewport";
 export * from "./webgl";

--- a/types/viewer/scene/stats.d.ts
+++ b/types/viewer/scene/stats.d.ts
@@ -1,0 +1,40 @@
+declare const stats: {
+    build: {
+        version: string;
+    };
+    client: {
+        browser: string;
+    };
+
+    components: {
+        scenes: number;
+        models: number;
+        meshes: number;
+        objects: number;
+    };
+    memory: {
+        meshes: number;
+        positions: number;
+        colors: number;
+        normals: number;
+        uvs: number;
+        indices: number;
+        textures: number;
+        transforms: number;
+        materials: number;
+        programs: number;
+    };
+    frame: {
+        frameCount: number;
+        fps: number;
+        useProgram: number;
+        bindTexture: number;
+        bindArray: number;
+        drawElements: number;
+        drawArrays: number;
+        tasksRun: number;
+        tasksScheduled: number;
+    };
+};
+
+export { stats };


### PR DESCRIPTION
Hi, I noticed the [stats](https://github.com/xeokit/xeokit-sdk/blob/a2bf178671392f0703b2f56918d8ccf9c914ed2c/src/viewer/scene/stats.js) object was missing typings, which prevent correct Typescript import.