### PR TITLE
Fix metaObject leaks

### DIFF
--- a/src/viewer/metadata/MetaScene.js
+++ b/src/viewer/metadata/MetaScene.js
@@ -315,6 +315,7 @@ class MetaScene {
                 delete this.propertySets[propertySetId];
             }
         }
+        delete this.rootMetaObjects[metaModel.rootMetaObject.id]
         delete this.metaModels[metaModel.id];
     }
 


### PR DESCRIPTION
I noticed the [destroyMetaModel](https://github.com/xeokit/xeokit-sdk/blob/802b63bf6c5992f50ae2f2d4018c2f1d024b6a73/src/viewer/metadata/MetaScene.js#L282) function did not properly release metaModels, because of a dangling reference in [MetaScene.rootMetaObjects](https://github.com/xeokit/xeokit-sdk/blob/802b63bf6c5992f50ae2f2d4018c2f1d024b6a73/src/viewer/metadata/MetaScene.js#L67).

The following pictures show my heap state before and after my fix is applied, after loading a model, destroying it and destroying its metamodel.

### Before
![before_meta](https://github.com/xeokit/xeokit-sdk/assets/112864474/1c5f83a1-8af3-4af0-833f-cf9e09ed7c27)


### After
![after_meta](https://github.com/xeokit/xeokit-sdk/assets/112864474/9a24ac1c-de9e-45cd-8d94-feb21cafbedb)

