### PR TITLE
Fix entity `.destroy()` memory leaks linked to Scene.*Updated functions

### DIFF
--- a/src/viewer/scene/mesh/Mesh.js
+++ b/src/viewer/scene/mesh/Mesh.js
@@ -720,7 +720,7 @@ class Mesh extends Component {
         visible = visible !== false;
         this._state.visible = visible;
         if (this._isObject) {
-            this.scene._objectVisibilityUpdated(this);
+            this.scene._objectVisibilityUpdated(this, visible);
         }
         this.glRedraw();
     }
@@ -756,7 +756,7 @@ class Mesh extends Component {
         }
         this._state.xrayed = xrayed;
         if (this._isObject) {
-            this.scene._objectXRayedUpdated(this);
+            this.scene._objectXRayedUpdated(this, xrayed);
         }
         this.glRedraw();
     }
@@ -792,7 +792,7 @@ class Mesh extends Component {
         }
         this._state.highlighted = highlighted;
         if (this._isObject) {
-            this.scene._objectHighlightedUpdated(this);
+            this.scene._objectHighlightedUpdated(this, highlighted);
         }
         this.glRedraw();
     }
@@ -828,7 +828,7 @@ class Mesh extends Component {
         }
         this._state.selected = selected;
         if (this._isObject) {
-            this.scene._objectSelectedUpdated(this);
+            this.scene._objectSelectedUpdated(this, selected);
         }
         this.glRedraw();
     }
@@ -1925,16 +1925,16 @@ class Mesh extends Component {
         if (this._isObject) {
             this.scene._deregisterObject(this);
             if (this._visible) {
-                this.scene._objectVisibilityUpdated(this, false);
+                this.scene._objectVisibilityUpdated(this, false, false);
             }
             if (this._xrayed) {
-                this.scene._objectXRayedUpdated(this, false);
+                this.scene._objectXRayedUpdated(this, false, false);
             }
             if (this._selected) {
-                this.scene._objectSelectedUpdated(this, false);
+                this.scene._objectSelectedUpdated(this, false, false);
             }
             if (this._highlighted) {
-                this.scene._objectHighlightedUpdated(this, false);
+                this.scene._objectHighlightedUpdated(this, false, false);
             }
             this.scene._objectColorizeUpdated(this, false);
             this.scene._objectOpacityUpdated(this, false);

--- a/src/viewer/scene/mesh/Mesh.js
+++ b/src/viewer/scene/mesh/Mesh.js
@@ -1938,7 +1938,8 @@ class Mesh extends Component {
             }
             this.scene._objectColorizeUpdated(this, false);
             this.scene._objectOpacityUpdated(this, false);
-            this.scene._objectOffsetUpdated(this, false);
+            if (this.offset.some((v) => v !== 0))
+                this.scene._objectOffsetUpdated(this, false);
         }
         if (this._isModel) {
             this.scene._deregisterModel(this);

--- a/src/viewer/scene/models/DataTextureSceneModel/lib/DataTextureSceneModelNode.js
+++ b/src/viewer/scene/models/DataTextureSceneModel/lib/DataTextureSceneModelNode.js
@@ -720,11 +720,10 @@ class DataTextureSceneModelNode {
             }
             if (this._opacityUpdated) {
                 this.scene._objectColorizeUpdated(this, false);
-            }
-            if (this._opacityUpdated) {
                 this.scene._objectOpacityUpdated(this, false);
             }
-            this.scene._objectOffsetUpdated(this, false);
+            if (this.offset.some((v) => v !== 0))
+                this.scene._objectOffsetUpdated(this, false);
         }
         for (let i = 0, len = this.meshes.length; i < len; i++) {
             this.meshes[i]._destroy();

--- a/src/viewer/scene/models/DataTextureSceneModel/lib/DataTextureSceneModelNode.js
+++ b/src/viewer/scene/models/DataTextureSceneModel/lib/DataTextureSceneModelNode.js
@@ -174,7 +174,7 @@ class DataTextureSceneModelNode {
             this.meshes[i]._setVisible(this._flags);
         }
         if (this._isObject) {
-            this.model.scene._objectVisibilityUpdated(this);
+            this.model.scene._objectVisibilityUpdated(this, visible);
         }
         this.model.glRedraw();
     }
@@ -212,7 +212,7 @@ class DataTextureSceneModelNode {
             this.meshes[i]._setHighlighted(this._flags);
         }
         if (this._isObject) {
-            this.model.scene._objectHighlightedUpdated(this);
+            this.model.scene._objectHighlightedUpdated(this, highlighted);
         }
         this.model.glRedraw();
     }
@@ -250,7 +250,7 @@ class DataTextureSceneModelNode {
             this.meshes[i]._setXRayed(this._flags);
         }
         if (this._isObject) {
-            this.model.scene._objectXRayedUpdated(this);
+            this.model.scene._objectXRayedUpdated(this, xrayed);
         }
         this.model.glRedraw();
     }
@@ -288,7 +288,7 @@ class DataTextureSceneModelNode {
             this.meshes[i]._setSelected(this._flags);
         }
         if (this._isObject) {
-            this.model.scene._objectSelectedUpdated(this);
+            this.model.scene._objectSelectedUpdated(this, selected);
         }
         this.model.glRedraw();
     }
@@ -679,16 +679,16 @@ class DataTextureSceneModelNode {
         const scene = this.model.scene;
         if (this._isObject) {
             if (this.visible) {
-                scene._objectVisibilityUpdated(this);
+                scene._objectVisibilityUpdated(this, true);
             }
             if (this.highlighted) {
-                scene._objectHighlightedUpdated(this);
+                scene._objectHighlightedUpdated(this, true);
             }
             if (this.xrayed) {
-                scene._objectXRayedUpdated(this);
+                scene._objectXRayedUpdated(this, true);
             }
             if (this.selected) {
-                scene._objectSelectedUpdated(this);
+                scene._objectSelectedUpdated(this, true);
             }
         }
         for (let i = 0, len = this.meshes.length; i < len; i++) {
@@ -707,16 +707,16 @@ class DataTextureSceneModelNode {
         if (this._isObject) {
             scene._deregisterObject(this);
             if (this.visible) {
-                scene._objectVisibilityUpdated(this, false);
+                scene._objectVisibilityUpdated(this, false, false);
             }
             if (this.xrayed) {
-                scene._objectXRayedUpdated(this);
+                scene._objectXRayedUpdated(this, false);
             }
             if (this.selected) {
-                scene._objectSelectedUpdated(this);
+                scene._objectSelectedUpdated(this, false);
             }
             if (this.highlighted) {
-                scene._objectHighlightedUpdated(this);
+                scene._objectHighlightedUpdated(this, false);
             }
             if (this._opacityUpdated) {
                 this.scene._objectColorizeUpdated(this, false);

--- a/src/viewer/scene/models/VBOSceneModel/lib/VBOSceneModelNode.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/VBOSceneModelNode.js
@@ -174,7 +174,7 @@ class VBOSceneModelNode {
             this.meshes[i]._setVisible(this._flags);
         }
         if (this._isObject) {
-            this.model.scene._objectVisibilityUpdated(this);
+            this.model.scene._objectVisibilityUpdated(this, visible);
         }
         this.model.glRedraw();
     }
@@ -212,7 +212,7 @@ class VBOSceneModelNode {
             this.meshes[i]._setHighlighted(this._flags);
         }
         if (this._isObject) {
-            this.model.scene._objectHighlightedUpdated(this);
+            this.model.scene._objectHighlightedUpdated(this, highlighted);
         }
         this.model.glRedraw();
     }
@@ -250,7 +250,7 @@ class VBOSceneModelNode {
             this.meshes[i]._setXRayed(this._flags);
         }
         if (this._isObject) {
-            this.model.scene._objectXRayedUpdated(this);
+            this.model.scene._objectXRayedUpdated(this, xrayed);
         }
         this.model.glRedraw();
     }
@@ -288,7 +288,7 @@ class VBOSceneModelNode {
             this.meshes[i]._setSelected(this._flags);
         }
         if (this._isObject) {
-            this.model.scene._objectSelectedUpdated(this);
+            this.model.scene._objectSelectedUpdated(this, selected);
         }
         this.model.glRedraw();
     }
@@ -690,16 +690,16 @@ class VBOSceneModelNode {
         const scene = this.model.scene;
         if (this._isObject) {
             if (this.visible) {
-                scene._objectVisibilityUpdated(this);
+                scene._objectVisibilityUpdated(this, true);
             }
             if (this.highlighted) {
-                scene._objectHighlightedUpdated(this);
+                scene._objectHighlightedUpdated(this, true);
             }
             if (this.xrayed) {
-                scene._objectXRayedUpdated(this);
+                scene._objectXRayedUpdated(this, true);
             }
             if (this.selected) {
-                scene._objectSelectedUpdated(this);
+                scene._objectSelectedUpdated(this, true);
             }
         }
         for (let i = 0, len = this.meshes.length; i < len; i++) {
@@ -718,21 +718,19 @@ class VBOSceneModelNode {
         if (this._isObject) {
             scene._deregisterObject(this);
             if (this.visible) {
-                scene._objectVisibilityUpdated(this, false);
+                scene._objectVisibilityUpdated(this, false, false);
             }
             if (this.xrayed) {
-                scene._objectXRayedUpdated(this);
+                scene._objectXRayedUpdated(this, false);
             }
             if (this.selected) {
-                scene._objectSelectedUpdated(this);
+                scene._objectSelectedUpdated(this, false);
             }
             if (this.highlighted) {
-                scene._objectHighlightedUpdated(this);
+                scene._objectHighlightedUpdated(this, false);
             }
             if (this._opacityUpdated) {
                 this.scene._objectColorizeUpdated(this, false);
-            }
-            if (this._opacityUpdated) {
                 this.scene._objectOpacityUpdated(this, false);
             }
             this.scene._objectOffsetUpdated(this, false);

--- a/src/viewer/scene/models/VBOSceneModel/lib/VBOSceneModelNode.js
+++ b/src/viewer/scene/models/VBOSceneModel/lib/VBOSceneModelNode.js
@@ -618,7 +618,10 @@ class VBOSceneModelNode {
         this._offsetAABB[4] = this._aabb[4] + this._offset[1];
         this._offsetAABB[5] = this._aabb[5] + this._offset[2];
         this.scene._aabbDirty = true;
-        this.scene._objectOffsetUpdated(this, offset);
+        this.scene._objectOffsetUpdated(
+            this,
+            offset.some((v) => v !== 0)
+        );
         this.model._aabbDirty = true;
         this.model.glRedraw();
     }
@@ -733,7 +736,9 @@ class VBOSceneModelNode {
                 this.scene._objectColorizeUpdated(this, false);
                 this.scene._objectOpacityUpdated(this, false);
             }
-            this.scene._objectOffsetUpdated(this, false);
+
+            if (this.offset.some((v) => v !== 0))
+                this.scene._objectOffsetUpdated(this, false);
         }
         for (let i = 0, len = this.meshes.length; i < len; i++) {
             this.meshes[i]._destroy();

--- a/src/viewer/scene/nodes/Node.js
+++ b/src/viewer/scene/nodes/Node.js
@@ -1345,16 +1345,16 @@ class Node extends Component {
         if (this._isObject) {
             this.scene._deregisterObject(this);
             if (this._visible) {
-                this.scene._objectVisibilityUpdated(this, false);
+                this.scene._objectVisibilityUpdated(this, false, false);
             }
             if (this._xrayed) {
-                this.scene._objectXRayedUpdated(this, false);
+                this.scene._objectXRayedUpdated(this, false, false);
             }
             if (this._selected) {
-                this.scene._objectSelectedUpdated(this, false);
+                this.scene._objectSelectedUpdated(this, false, false);
             }
             if (this._highlighted) {
-                this.scene._objectHighlightedUpdated(this, false);
+                this.scene._objectHighlightedUpdated(this, false, false);
             }
             this.scene._objectColorizeUpdated(this, false);
             this.scene._objectOpacityUpdated(this, false);

--- a/src/viewer/scene/nodes/Node.js
+++ b/src/viewer/scene/nodes/Node.js
@@ -1358,7 +1358,8 @@ class Node extends Component {
             }
             this.scene._objectColorizeUpdated(this, false);
             this.scene._objectOpacityUpdated(this, false);
-            this.scene._objectOffsetUpdated(this, false);
+            if (this.offset.some((v) => v !== 0))
+                this.scene._objectOffsetUpdated(this, false);
         }
         if (this._isModel) {
             this.scene._deregisterModel(this);

--- a/src/viewer/scene/scene/Scene.js
+++ b/src/viewer/scene/scene/Scene.js
@@ -1040,8 +1040,8 @@ class Scene extends Component {
         this._objectIds = null; // Lazy regenerate
     }
 
-    _objectVisibilityUpdated(entity, notify = true) {
-        if (entity.visible) {
+    _objectVisibilityUpdated(entity, bool, notify = true) {
+        if (bool) {
             if (ASSERT_OBJECT_STATE_UPDATE && this.visibleObjects[entity.id]) {
                 console.error("Redundant object visibility update (visible=true)");
                 return;
@@ -1062,8 +1062,8 @@ class Scene extends Component {
         }
     }
 
-    _objectXRayedUpdated(entity, notify = true) {
-        if (entity.xrayed) {
+    _objectXRayedUpdated(entity, bool, notify = true) {
+        if (bool) {
             if (ASSERT_OBJECT_STATE_UPDATE && this.xrayedObjects[entity.id]) {
                 console.error("Redundant object xray update (xrayed=true)");
                 return;
@@ -1084,8 +1084,8 @@ class Scene extends Component {
         }
     }
 
-    _objectHighlightedUpdated(entity, notify = true) {
-        if (entity.highlighted) {
+    _objectHighlightedUpdated(entity, bool, notify = true) {
+        if (bool) {
             if (ASSERT_OBJECT_STATE_UPDATE && this.highlightedObjects[entity.id]) {
                 console.error("Redundant object highlight update (highlighted=true)");
                 return;
@@ -1106,8 +1106,8 @@ class Scene extends Component {
         }
     }
 
-    _objectSelectedUpdated(entity, notify = true) {
-        if (entity.selected) {
+    _objectSelectedUpdated(entity, bool, notify = true) {
+        if (bool) {
             if (ASSERT_OBJECT_STATE_UPDATE && this.selectedObjects[entity.id]) {
                 console.error("Redundant object select update (selected=true)");
                 return;
@@ -1128,8 +1128,8 @@ class Scene extends Component {
         }
     }
 
-    _objectColorizeUpdated(entity, colorized) {
-        if (colorized) {
+    _objectColorizeUpdated(entity, bool) {
+        if (bool) {
             this.colorizedObjects[entity.id] = entity;
             this._numColorizedObjects++;
         } else {
@@ -1139,8 +1139,8 @@ class Scene extends Component {
         this._colorizedObjectIds = null; // Lazy regenerate
     }
 
-    _objectOpacityUpdated(entity, opacityUpdated) {
-        if (opacityUpdated) {
+    _objectOpacityUpdated(entity, bool) {
+        if (bool) {
             this.opacityObjects[entity.id] = entity;
             this._numOpacityObjects++;
         } else {


### PR DESCRIPTION
Following up on #1086 
I have improved my previous fix by modifying Scene.*Updated function behaviours, especially Scene.objectOffsetUpdated.
The fix preserves previous correct behaviours overall and fix memory leaks.