### PR TITLE
Fix pick triangle surface of mesh with origin

### DIFF
--- a/src/viewer/scene/mesh/Mesh.js
+++ b/src/viewer/scene/mesh/Mesh.js
@@ -5,6 +5,7 @@
  @event picked
  */
 import {math} from '../math/math.js';
+import {createRTCViewMat} from '../math/rtcCoords.js';
 import {Component} from '../Component.js';
 import {RenderState} from '../webgl/RenderState.js';
 import {DrawRenderer} from "./draw/DrawRenderer.js";
@@ -2063,11 +2064,8 @@ const pickTriangleSurface = (function () {
 
                 // Attempt to ray-pick the triangle in local space
 
-                let canvasPos;
-
                 if (pickResult.canvasPos) {
-                    canvasPos = pickResult.canvasPos;
-                    math.canvasPosToLocalRay(canvas.canvas, pickViewMatrix, pickProjMatrix, mesh.worldMatrix, canvasPos, localRayOrigin, localRayDir);
+                    math.canvasPosToLocalRay(canvas.canvas, mesh.origin ? createRTCViewMat(pickViewMatrix, mesh.origin) : pickViewMatrix, pickProjMatrix, mesh.worldMatrix, pickResult.canvasPos, localRayOrigin, localRayDir);
 
                 } else if (pickResult.origin && pickResult.direction) {
                     math.worldRayToLocalRay(mesh.worldMatrix, pickResult.origin, pickResult.direction, localRayOrigin, localRayDir);
@@ -2097,6 +2095,12 @@ const pickTriangleSurface = (function () {
                 worldPos[0] = tempVec4b[0];
                 worldPos[1] = tempVec4b[1];
                 worldPos[2] = tempVec4b[2];
+
+                if (pickResult.canvasPos && mesh.origin) {
+                    worldPos[0] += mesh.origin[0];
+                    worldPos[1] += mesh.origin[1];
+                    worldPos[2] += mesh.origin[2];
+                }
 
                 pickResult.worldPos = worldPos;
 


### PR DESCRIPTION
[Meshes](https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/scene/mesh/Mesh.js) with origin have incorrect `pickResult.worldPos` because the `origin` seems ignored. This lead to erroneous zoom.

![mesh-zoom-error](https://github.com/xeokit/xeokit-sdk/assets/22523482/560fe17f-7b41-4ffe-8b6f-f996bf5e7cab)

The first part of the fix is copied from the way [meshes are drawn with origin](https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/scene/mesh/draw/DrawRenderer.js#L97).

Then the worldPos is added to the `mesh.origin` to get the correct coordinates. In the `if` condition, I tested the `pickResult.canvasPos` first to be sure we are in the case of a pick from a canvas position and not a ray pick (maybe the ray pick need a fix too... ? ).

Result: 
![mesh-zoom-fix](https://github.com/xeokit/xeokit-sdk/assets/22523482/44809895-3a43-4e53-b2c4-3aa97bd1afb9)