### PR TITLE
fix ray picking -> RenderBuffer read y

### DIFF
--- a/src/viewer/scene/webgl/RenderBuffer.js
+++ b/src/viewer/scene/webgl/RenderBuffer.js
@@ -167,7 +167,7 @@ class RenderBuffer {
 
     read(pickX, pickY, glFormat = null, glType = null, arrayType = Uint8Array, arrayMultiplier = 4) {
         const x = pickX;
-        const y = (this.buffer.height || this.gl.drawingBufferHeight) - 1 - pickY;
+        const y = (this.buffer.height || this.gl.drawingBufferHeight) - pickY;
         const pix = new arrayType(arrayMultiplier);
         const gl = this.gl;
         gl.readPixels(x, y, 1, 1, glFormat || gl.RGBA, glType || gl.UNSIGNED_BYTE, pix, 0);


### PR DESCRIPTION
[Current exemples of ray picking](https://xeokit.github.io/xeokit-sdk/examples/#picking_ray_matrix) are broken:

![67e988fbd3aec6323f64dc796447e3df](https://github.com/xeokit/xeokit-sdk/assets/22523482/204fa392-886e-4619-b27d-112c7e55ad7e)

After some investigation, the last working xeokit-sdk version was 2.4.0-alpha-28.
The only commit of the 2.4.0-alpha-29 is [this one](https://github.com/xeokit/xeokit-sdk/commit/cd6533bc0f12b7afd646832f86bb8ee20159f0e5).

I reverted the change of the `RenderBuffer` `read` method and the bug was fixed.

Comparing the two versions, I saw the `-1` in the computation of the `y` variable that [was not here previously](https://github.com/xeokit/xeokit-sdk/commit/cd6533bc0f12b7afd646832f86bb8ee20159f0e5#diff-66c3ee6ee85516b7fe6cae02bf8bd162116c853114b3664235eedc73acc86861R170).
Removing the `-1`, the ray picking is fixed and the snap to vertex is still working.

![1e6ff7416c7f6cc5c3519955b75258de](https://github.com/xeokit/xeokit-sdk/assets/22523482/8f2fa6f5-4e0e-4105-815d-dcebc1b36e89)

![46dc123cc2c0ef48e11a3227aaf06d44](https://github.com/xeokit/xeokit-sdk/assets/22523482/10087e79-2cde-4ac1-acaa-54983b126581)
