### PR TITLE
Update MousePanRotateDollyHandler.js - Add page scroll support

### DIFF
--- a/src/viewer/scene/CameraControl/lib/handlers/MousePanRotateDollyHandler.js
+++ b/src/viewer/scene/CameraControl/lib/handlers/MousePanRotateDollyHandler.js
@@ -14,13 +14,17 @@ const getCanvasPosFromEvent = function (event, canvasPos) {
         let element = event.target;
         let totalOffsetLeft = 0;
         let totalOffsetTop = 0;
+        let totalScrollX = 0;
+        let totalScrollY = 0;
         while (element.offsetParent) {
-            totalOffsetLeft += element.offsetLeft;
-            totalOffsetTop += element.offsetTop;
-            element = element.offsetParent;
+          totalOffsetLeft += element.offsetLeft;
+          totalOffsetTop += element.offsetTop;
+          totalScrollX += element.scrollLeft;
+          totalScrollY += element.scrollTop;
+          element = element.offsetParent;
         }
-        canvasPos[0] = event.pageX - totalOffsetLeft;
-        canvasPos[1] = event.pageY - totalOffsetTop;
+        canvasPos[0] = event.pageX + totalScrollX - totalOffsetLeft;
+        canvasPos[1] = event.pageY + totalScrollY - totalOffsetTop;
     }
     return canvasPos;
 };


### PR DESCRIPTION
Add page scroll support

When we have viewer canvas dom element scrolled from top canvas click is not working