### PR TITLE
Fix snapshots => flip Y

### DIFF
--- a/src/viewer/scene/webgl/RenderBuffer.js
+++ b/src/viewer/scene/webgl/RenderBuffer.js
@@ -221,15 +221,23 @@ class RenderBuffer {
         const canvas = imageDataCache.canvas;
         const imageData = imageDataCache.imageData;
         const context = imageDataCache.context;
-        gl.readPixels(0, 0, this.buffer.width, this.buffer.height, gl.RGBA, gl.UNSIGNED_BYTE, pixelData);
+        const { width, height } = this.buffer;
+        gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, pixelData);
         imageData.data.set(pixelData);
         context.putImageData(imageData, 0, 0);
+
+        // flip Y
+        context.save();
+        context.globalCompositeOperation = 'copy';
+        context.scale(1, -1);
+        context.drawImage(canvas, 0, -height, width, height);
+        context.restore();
+
         let format = params.format || "png";
         if (format !== "jpeg" && format !== "png" && format !== "bmp") {
             console.error("Unsupported image format: '" + format + "' - supported types are 'jpeg', 'bmp' and 'png' - defaulting to 'png'");
             format = "png";
         }
-        const flipy = true; // Account for WebGL texture flipping
         return canvas.toDataURL(`image/${format}`);
     }
 


### PR DESCRIPTION
[Snapshots](https://xeokit.github.io/xeokit-sdk/examples/#screenshots_png_getSnapshot) are flipped along the Y axis since [2.4.0-alpha-28](https://github.com/xeokit/xeokit-sdk/commit/accf10f241a8e2ac4a45c25ec8bb227d8af871e3) and more precisely [this commit](https://github.com/xeokit/xeokit-sdk/commit/0b0696ec02412f5838df82ec3553c2f10db53bf8).

<img width="992" alt="Screenshot 2023-07-18 at 11 26 09" src="https://github.com/xeokit/xeokit-sdk/assets/22523482/1ec18f25-82d6-439f-b9aa-5bc4662714d8">
