### PR TITLE
Prevent viewer getSnapshot to add canvas on document

### DIFF
--- a/src/viewer/Viewer.js
+++ b/src/viewer/Viewer.js
@@ -320,7 +320,7 @@ class Viewer {
      * @param {Number} [params.height] Desired height of result in pixels - defaults to height of canvas.
      * @param {String} [params.format="jpeg"] Desired format; "jpeg", "png" or "bmp".
      * @param {Boolean} [params.includeGizmos=false] When true, will include gizmos like {@link SectionPlane} in the snapshot.
-     * @param {Boolean} [params.capture=false] When true, will get plugins container that are not document.body and will append an canvas on document.body with the representation of the container draw on it.
+     * @param {Boolean} [params.capture=false] When true, will get plugins container that are not document.body and will append an canvas on document.body with the representation of the container drawn on it.
      * @returns {String} String-encoded image data URI.
      */
     getSnapshot(params = {}) {

--- a/src/viewer/Viewer.js
+++ b/src/viewer/Viewer.js
@@ -320,6 +320,7 @@ class Viewer {
      * @param {Number} [params.height] Desired height of result in pixels - defaults to height of canvas.
      * @param {String} [params.format="jpeg"] Desired format; "jpeg", "png" or "bmp".
      * @param {Boolean} [params.includeGizmos=false] When true, will include gizmos like {@link SectionPlane} in the snapshot.
+     * @param {Boolean} [params.capture=false] When true, will get plugins container that are not document.body and will append an canvas on document.body with the representation of the container draw on it.
      * @returns {String} String-encoded image data URI.
      */
     getSnapshot(params = {}) {
@@ -345,17 +346,19 @@ class Viewer {
             this.sendToPlugins("snapshotStarting"); // Tells plugins to hide things that shouldn't be in snapshot
         }
 
-        const captured = {};
-        for (let i = 0, len = this._plugins.length; i < len; i++) {
-            const plugin = this._plugins[i];
-            if (plugin.getContainerElement) {
-                const container = plugin.getContainerElement();
-                if (container !== document.body) {
-                    if (!captured[container.id]) {
-                        captured[container.id] = true;
-                        html2canvas(container).then(function (canvas) {
-                            document.body.appendChild(canvas);
-                        });
+        if (params.capture) {
+            const captured = {};
+            for (let i = 0, len = this._plugins.length; i < len; i++) {
+                const plugin = this._plugins[i];
+                if (plugin.getContainerElement) {
+                    const container = plugin.getContainerElement();
+                    if (container !== document.body) {
+                        if (!captured[container.id]) {
+                            captured[container.id] = true;
+                            html2canvas(container).then(function (canvas) {
+                                document.body.appendChild(canvas);
+                            });
+                        }
                     }
                 }
             }


### PR DESCRIPTION
[This change](https://github.com/xeokit/xeokit-sdk/commit/78ff80c4db6ec012b9e3753c7241e7e5ae0f94f5#diff-3986a1ed352df2aeac30a1e1db927c1a2285e4ce219ec61dfa57406f01ef4983R349) add a breaking change in the `viewer.getSnapshot()` API. I use the `viewer` with a distance measurement plugin with a specified container that is not `document.body`. But since this change, when a get a snapshot of the viewer, a canvas is also added on the `document.body`. I propose to add a `capture` parameter on `getShapshot` to prevent this behaviour if not requested (must be set to `true` if captured `canvas` are desired).