### PR TITLE
Extend XKTLoaderPlugin, MetaScene & MetaModel to batch-load split XKT…

### DIFF
--- a/assets/models/xkt/v10/federated/Clinic/model.xkt.manifest.json
+++ b/assets/models/xkt/v10/federated/Clinic/model.xkt.manifest.json
@@ -1,0 +1,13 @@
+{
+  "inputFile": null,
+  "converterApplication": "convert2xkt",
+  "converterApplicationVersion": "v1.1.9",
+  "conversionDate": "10-08-2023- 02-05-01",
+  "outputDir": null,
+  "xktFiles": [
+    "model.glb.xkt",
+    "model_1.glb.xkt",
+    "model_2.glb.xkt",
+    "model_3.glb.xkt"
+  ]
+}

--- a/assets/models/xkt/v2/WestRiverSideHospital/model.xkt.manifest.json
+++ b/assets/models/xkt/v2/WestRiverSideHospital/model.xkt.manifest.json
@@ -1,0 +1,25 @@
+{
+  "inputFile": null,
+  "converterApplication": "convert2xkt",
+  "converterApplicationVersion": "v1.1.9",
+  "conversionDate": "10-08-2023- 02-05-01",
+  "outputDir": null,
+  "xktFiles": [
+    "architectural.xkt",
+    "electrical.xkt",
+    "fireAlarms.xkt",
+    "mechanical.xkt",
+    "plumbing.xkt",
+    "sprinklers.xkt",
+    "structure.xkt"
+  ],
+  "metaModelFiles": [
+    "architectural.json",
+    "electrical.json",
+    "fireAlarms.json",
+    "mechanical.json",
+    "plumbing.json",
+    "sprinklers.json",
+    "structure.json"
+  ]
+}

--- a/examples/buildings/index.html
+++ b/examples/buildings/index.html
@@ -293,6 +293,14 @@
             ["xkt_dtx_DemoProjekt", "Viewing a BIM model exported from ArchiCAD (data textures enabled)"]
         ],
 
+        "XKT Multipart": [
+
+            "#XKT + VBOs",
+
+            ["xkt_manifest_Clinic", "Loading a BIM model split into multiple XKT models"],
+            ["xkt_manifest_WestRiverSideHospital", "Loading a BIM model split into multiple XKT models"]
+        ],
+
         "GLB": [
 
             "#Binary glTF + VBOs",

--- a/examples/buildings/xkt_manifest_Clinic.html
+++ b/examples/buildings/xkt_manifest_Clinic.html
@@ -1,0 +1,812 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>xeokit Example</title>
+    <link href="../css/pageStyle.css" rel="stylesheet"/>
+    <style>
+
+        /* ----------------------------------------------------------------------------------------------------------*/
+        /* NavCubePlugin */
+        /* ----------------------------------------------------------------------------------------------------------*/
+
+        #myNavCubeCanvas {
+            position: absolute;
+            width: 250px;
+            height: 250px;
+            bottom: 50px;
+            right: 10px;
+            z-index: 200000;
+        }
+
+        /* ----------------------------------------------------------------------------------------------------------*/
+        /* TreeViewPlugin */
+        /* ----------------------------------------------------------------------------------------------------------*/
+
+        #treeViewContainer {
+            pointer-events: all;
+            height: 100%;
+            overflow-y: scroll;
+            overflow-x: hidden;
+            position: absolute;
+            background-color: rgba(255, 255, 255, 0.2);
+            color: black;
+            top: 140px;
+            z-index: 200000;
+            float: left;
+            left: 0;
+            padding-left: 10px;
+            font-family: 'Roboto', sans-serif;
+            font-size: 15px;
+            user-select: none;
+            -ms-user-select: none;
+            -moz-user-select: none;
+            -webkit-user-select: none;
+            width: 350px;
+        }
+
+        #treeViewContainer ul {
+            list-style: none;
+            padding-left: 1.75em;
+            pointer-events: none;
+        }
+
+        #treeViewContainer ul li {
+            position: relative;
+            width: 500px;
+            pointer-events: none;
+            padding-top: 3px;
+            padding-bottom: 3px;
+            vertical-align: middle;
+        }
+
+        #treeViewContainer ul li a {
+            background-color: #eee;
+            border-radius: 50%;
+            color: #000;
+            display: inline-block;
+            height: 1.5em;
+            left: -1.5em;
+            position: absolute;
+            text-align: center;
+            text-decoration: none;
+            width: 1.5em;
+            pointer-events: all;
+        }
+
+        #treeViewContainer ul li a.plus {
+            background-color: #ded;
+            pointer-events: all;
+        }
+
+        #treeViewContainer ul li a.minus {
+            background-color: #eee;
+            pointer-events: all;
+        }
+
+        #treeViewContainer ul li a:active {
+            top: 1px;
+            pointer-events: all;
+        }
+
+        #treeViewContainer ul li span:hover {
+            color: white;
+            cursor: pointer;
+            background: black;
+            padding-left: 2px;
+            pointer-events: all;
+        }
+
+        #treeViewContainer ul li span {
+            display: inline-block;
+            width: calc(100% - 50px);
+            padding-left: 2px;
+            pointer-events: all;
+            height: 23px;
+        }
+
+        #treeViewContainer .highlighted-node { /* Appearance of node highlighted with TreeViewPlugin#showNode() */
+            border: black solid 1px;
+            background: yellow;
+            color: black;
+            padding-left: 1px;
+            padding-right: 5px;
+            pointer-events: all;
+        }
+
+        /* ----------------------------------------------------------------------------------------------------------*/
+        /* ContextMenu */
+        /* ----------------------------------------------------------------------------------------------------------*/
+
+        .xeokit-context-menu {
+            font-family: 'Roboto', sans-serif;
+            font-size: 15px;
+            display: none;
+            z-index: 300000;
+            background: rgba(255, 255, 255, 0.46);
+            border: 1px solid black;
+            border-radius: 6px;
+            padding: 0;
+            width: 200px;
+        }
+
+        .xeokit-context-menu ul {
+            list-style: none;
+            margin-left: 0;
+            padding: 0;
+        }
+
+        .xeokit-context-menu ul li {
+            list-style-type: none;
+            padding-left: 10px;
+            padding-right: 20px;
+            padding-top: 4px;
+            padding-bottom: 4px;
+            color: black;
+            border-bottom: 1px solid gray;
+            background: rgba(255, 255, 255, 0.46);
+            cursor: pointer;
+            width: calc(100% - 30px);
+        }
+
+        .xeokit-context-menu ul li:hover {
+            background: black;
+            color: white;
+            font-weight: normal;
+        }
+
+        .xeokit-context-menu ul li span {
+            display: inline-block;
+        }
+
+        .xeokit-context-menu .disabled {
+            display: inline-block;
+            color: gray;
+            cursor: default;
+            font-weight: normal;
+        }
+
+        .xeokit-context-menu .disabled:hover {
+            color: gray;
+            cursor: default;
+            background: #eeeeee;
+            font-weight: normal;
+        }
+
+        .buttons {
+            display: flex;
+            flex-direction: row;
+            justify-content: center;
+            align-items: center;
+
+            margin: 0;
+            position: absolute;
+            left: 40px;
+            top: 40px;
+        }
+
+        button {
+            margin: 5px;
+        }
+
+        /* Style for disabled buttons */
+        button[disabled] {
+            opacity: 0.8;
+            cursor: not-allowed;
+        }
+
+        #stats {
+            display: flex;
+            flex-direction: row;
+            justify-content: center;
+            align-items: center;
+            margin: 0;
+            position: absolute;
+            left: 40px;
+            top: 80px;
+        }
+    </style>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
+</head>
+<body>
+<input type="checkbox" id="info-button"/>
+<label for="info-button" class="info-button"><i class="far fa-3x fa-question-circle"></i></label>
+<canvas id="myCanvas"></canvas>
+<canvas id="myNavCubeCanvas"></canvas>
+<div id="stats">
+
+</div>
+<div id="treeViewContainer"></div>
+<div class="slideout-sidebar">
+    <img class="info-icon" src="../assets/images/bim_icon.png"/>
+    <h1>XKTLoaderPlugin</h1>
+    <h2>Loading a federated IFC4 model from the file system, split into multiple XKT files and a manifest</h2>
+
+    <h3>Stats</h3>
+    <ul>
+        <li>
+            <div id="time">Loading JavaScript modules...</div>
+        </li>
+    </ul>
+    <h3>Components used</h3>
+    <ul>
+        <li>
+            <a href="../../docs/class/src/viewer/Viewer.js~Viewer.html"
+               target="_other">Viewer</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js~XKTLoaderPlugin.html"
+               target="_other">XKTLoaderPlugin</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/TreeViewPlugin/TreeViewPlugin.js~TreeViewPlugin.html"
+               target="_other">TreeViewPlugin</a>
+        </li>
+
+    </ul>
+    <h3>Resources</h3>
+    <ul>
+        <li>
+            <a href="https://www.notion.so/xeokit/Splitting-Big-IFC-Models-During-Conversion-for-Improved-Performance-165fc022e94742cf966ee50003572259"
+               target="_other">Splitting Big IFC Models During Conversion for Improved Performance</a>
+        </li>
+        <li>
+            <a href="http://openifcmodel.cs.auckland.ac.nz/Model/Details/274"
+               target="_other">Model source</a>
+        </li>
+    </ul>
+</div>
+</body>
+
+<script type="module">
+
+    import {Viewer, XKTLoaderPlugin, TreeViewPlugin,  ContextMenu} from "../../dist/xeokit-sdk.min.es.js";
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas",
+        transparent: true,
+        dtxEnabled: true
+    });
+
+    viewer.scene.camera.eye = [26.543735598689356, 29.295147183337072, 36.20021104566069];
+    viewer.scene.camera.look = [-23.51624377290216, -8.263137541594404, -21.650089870476542];
+    viewer.scene.camera.up = [-0.2883721466119999, 0.897656342963939, -0.3332485483764247];
+
+    //----------------------------------------------------------------------------------------------------------------------
+    // Load a BIM model comprised of multiple XKT files
+    // The manifest of XKT files is given in model.xkt.manifest.json
+    // This will create a single SceneModel and MetaModel that contains the combined content of all the XKT files
+    //----------------------------------------------------------------------------------------------------------------------
+
+    const xktLoader = new XKTLoaderPlugin(viewer);
+
+    xktLoader.load({
+        manifestSrc: "../../assets/models/xkt/v10/federated/Clinic/model.xkt.manifest.json",
+        id: "myModel"
+    });
+
+    var t0 = performance.now();
+
+    //----------------------------------------------------------------------------------------------------------------------
+    // Create a tree view
+    //----------------------------------------------------------------------------------------------------------------------
+
+    const treeView = new TreeViewPlugin(viewer, {
+        containerElement: document.getElementById("treeViewContainer"),
+        hierarchy: "types",
+        autoExpandDepth: 1
+    });
+
+    const treeViewContextMenu = new ContextMenu({
+
+        items: [
+            [
+                {
+                    title: "View Fit",
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        const objectIds = [];
+                        context.treeViewPlugin.withNodeTree(context.treeViewNode, (treeViewNode) => {
+                            if (treeViewNode.objectId) {
+                                objectIds.push(treeViewNode.objectId);
+                            }
+                        });
+                        scene.setObjectsVisible(objectIds, true);
+                        scene.setObjectsHighlighted(objectIds, true);
+                        context.viewer.cameraFlight.flyTo({
+                            projection: "perspective",
+                            aabb: scene.getAABB(objectIds),
+                            duration: 0.5
+                        }, () => {
+                            setTimeout(function () {
+                                scene.setObjectsHighlighted(scene.highlightedObjectIds, false);
+                            }, 500);
+                        });
+                    }
+                },
+                {
+                    title: "View Fit All",
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        context.viewer.cameraFlight.flyTo({
+                            projection: "perspective",
+                            aabb: scene.getAABB({}),
+                            duration: 0.5
+                        });
+                    }
+                }
+            ],
+            [
+                {
+                    title: "Hide",
+                    doAction: function (context) {
+                        context.treeViewPlugin.withNodeTree(context.treeViewNode, (treeViewNode) => {
+                            if (treeViewNode.objectId) {
+                                const entity = context.viewer.scene.objects[treeViewNode.objectId];
+                                if (entity) {
+                                    entity.visible = false;
+                                }
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "Hide Others",
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        scene.setObjectsVisible(scene.visibleObjectIds, false);
+                        scene.setObjectsXRayed(scene.xrayedObjectIds, false);
+                        scene.setObjectsSelected(scene.selectedObjectIds, false);
+                        scene.setObjectsHighlighted(scene.highlightedObjectIds, false);
+                        context.treeViewPlugin.withNodeTree(context.treeViewNode, (treeViewNode) => {
+                            if (treeViewNode.objectId) {
+                                const entity = scene.objects[treeViewNode.objectId];
+                                if (entity) {
+                                    entity.visible = true;
+                                }
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "Hide All",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.visibleObjectIds.length > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsVisible(context.viewer.scene.visibleObjectIds, false);
+                    }
+                }
+            ],
+            [
+                {
+                    title: "Show",
+                    doAction: function (context) {
+                        context.treeViewPlugin.withNodeTree(context.treeViewNode, (treeViewNode) => {
+                            if (treeViewNode.objectId) {
+                                const entity = context.viewer.scene.objects[treeViewNode.objectId];
+                                if (entity) {
+                                    entity.visible = true;
+                                    entity.xrayed = false;
+                                    entity.selected = false;
+                                }
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "Show Others",
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        scene.setObjectsVisible(scene.objectIds, true);
+                        scene.setObjectsXRayed(scene.xrayedObjectIds, false);
+                        scene.setObjectsSelected(scene.selectedObjectIds, false);
+                        context.treeViewPlugin.withNodeTree(context.treeViewNode, (treeViewNode) => {
+                            if (treeViewNode.objectId) {
+                                const entity = scene.objects[treeViewNode.objectId];
+                                if (entity) {
+                                    entity.visible = false;
+                                }
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "Show All",
+                    getEnabled: function (context) {
+                        const scene = context.viewer.scene;
+                        return (scene.numVisibleObjects < scene.numObjects);
+                    },
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        scene.setObjectsVisible(scene.objectIds, true);
+                        scene.setObjectsXRayed(scene.xrayedObjectIds, false);
+                        scene.setObjectsSelected(scene.selectedObjectIds, false);
+                    }
+                }
+            ],
+            [
+                {
+                    title: "X-Ray",
+                    doAction: function (context) {
+                        context.treeViewPlugin.withNodeTree(context.treeViewNode, (treeViewNode) => {
+                            if (treeViewNode.objectId) {
+                                const entity = context.viewer.scene.objects[treeViewNode.objectId];
+                                if (entity) {
+                                    entity.xrayed = true;
+                                    entity.visible = true;
+                                }
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "Undo X-Ray",
+                    doAction: function (context) {
+                        context.treeViewPlugin.withNodeTree(context.treeViewNode, (treeViewNode) => {
+                            if (treeViewNode.objectId) {
+                                const entity = context.viewer.scene.objects[treeViewNode.objectId];
+                                if (entity) {
+                                    entity.xrayed = false;
+                                }
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "X-Ray Others",
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        scene.setObjectsVisible(scene.objectIds, true);
+                        scene.setObjectsXRayed(scene.objectIds, true);
+                        scene.setObjectsSelected(scene.selectedObjectIds, false);
+                        scene.setObjectsHighlighted(scene.highlightedObjectIds, false);
+                        context.treeViewPlugin.withNodeTree(context.treeViewNode, (treeViewNode) => {
+                            if (treeViewNode.objectId) {
+                                const entity = scene.objects[treeViewNode.objectId];
+                                if (entity) {
+                                    entity.xrayed = false;
+                                }
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "Reset X-Ray",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.numXRayedObjects > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsXRayed(context.viewer.scene.xrayedObjectIds, false);
+                    }
+                }
+            ],
+            [
+                {
+                    title: "Select",
+                    doAction: function (context) {
+                        context.treeViewPlugin.withNodeTree(context.treeViewNode, (treeViewNode) => {
+                            if (treeViewNode.objectId) {
+                                const entity = context.viewer.scene.objects[treeViewNode.objectId];
+                                if (entity) {
+                                    entity.selected = true;
+                                    entity.visible = true;
+                                }
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "Deselect",
+                    doAction: function (context) {
+                        context.treeViewPlugin.withNodeTree(context.treeViewNode, (treeViewNode) => {
+                            if (treeViewNode.objectId) {
+                                const entity = context.viewer.scene.objects[treeViewNode.objectId];
+                                if (entity) {
+                                    entity.selected = false;
+                                }
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "Clear Selection",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.numSelectedObjects > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsSelected(context.viewer.scene.selectedObjectIds, false);
+                    }
+                }
+            ]
+        ]
+    });
+
+    // Right-clicking on a tree node shows the context menu for that node
+
+    treeView.on("contextmenu", (e) => {
+
+        treeViewContextMenu.context = { // Must set context before opening menu
+            viewer: e.viewer,
+            treeViewPlugin: e.treeViewPlugin,
+            treeViewNode: e.treeViewNode,
+            entity: e.viewer.scene.objects[e.treeViewNode.objectId] // Only defined if tree node is a leaf node
+        };
+
+        treeViewContextMenu.show(e.event.pageX, e.event.pageY);
+    });
+
+    // Left-clicking on a tree node isolates that object in the 3D view
+
+    treeView.on("nodeTitleClicked", (e) => {
+        const scene = viewer.scene;
+        const objectIds = [];
+        e.treeViewPlugin.withNodeTree(e.treeViewNode, (treeViewNode) => {
+            if (treeViewNode.objectId) {
+                objectIds.push(treeViewNode.objectId);
+            }
+        });
+        e.treeViewPlugin.unShowNode();
+        scene.setObjectsXRayed(scene.objectIds, true);
+        scene.setObjectsVisible(scene.objectIds, true);
+        scene.setObjectsXRayed(objectIds, false);
+        viewer.cameraFlight.flyTo({
+            aabb: scene.getAABB(objectIds),
+            duration: 0.5
+        }, () => {
+            setTimeout(function () {
+                scene.setObjectsVisible(scene.xrayedObjectIds, false);
+                scene.setObjectsXRayed(scene.xrayedObjectIds, false);
+            }, 500);
+        });
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create two ContextMenus - one for right-click on empty space, the other for right-click on an Entity
+    //------------------------------------------------------------------------------------------------------------------
+
+    const canvasContextMenu = new ContextMenu({
+        enabled: true,
+        context: {
+            viewer: viewer
+        },
+        items: [
+            [
+                {
+                    title: "Hide All",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.numVisibleObjects > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsVisible(context.viewer.scene.visibleObjectIds, false);
+                    }
+                },
+                {
+                    title: "Show All",
+                    getEnabled: function (context) {
+                        const scene = context.viewer.scene;
+                        return (scene.numVisibleObjects < scene.numObjects);
+                    },
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        scene.setObjectsVisible(scene.objectIds, true);
+                        scene.setObjectsXRayed(scene.xrayedObjectIds, false);
+                        scene.setObjectsSelected(scene.selectedObjectIds, false);
+                    }
+                }
+            ],
+            [
+                {
+                    title: "View Fit All",
+                    doAction: function (context) {
+                        context.viewer.cameraFlight.flyTo({
+                            aabb: context.viewer.scene.getAABB()
+                        });
+                    }
+                }
+            ]
+        ]
+    });
+
+    const objectContextMenu = new ContextMenu({
+        items: [
+            [
+                {
+                    title: "View Fit",
+                    doAction: function (context) {
+                        const viewer = context.viewer;
+                        const scene = viewer.scene;
+                        const entity = context.entity;
+                        viewer.cameraFlight.flyTo({
+                            aabb: entity.aabb,
+                            duration: 0.5
+                        }, () => {
+                            setTimeout(function () {
+                                scene.setObjectsHighlighted(scene.highlightedObjectIds, false);
+                            }, 500);
+                        });
+                    }
+                },
+                {
+                    title: "View Fit All",
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        context.viewer.cameraFlight.flyTo({
+                            projection: "perspective",
+                            aabb: scene.getAABB(),
+                            duration: 0.5
+                        });
+                    }
+                },
+                {
+                    title: "Show in Tree",
+                    doAction: function (context) {
+                        const objectId = context.entity.id;
+                        context.treeViewPlugin.showNode(objectId);
+                    }
+                }
+            ],
+            [
+                {
+                    title: "Hide",
+                    getEnabled: function (context) {
+                        return context.entity.visible;
+                    },
+                    doAction: function (context) {
+                        context.entity.visible = false;
+                    }
+                },
+                {
+                    title: "Hide Others",
+                    doAction: function (context) {
+                        const viewer = context.viewer;
+                        const scene = viewer.scene;
+                        const entity = context.entity;
+                        const metaObject = viewer.metaScene.metaObjects[entity.id];
+                        if (!metaObject) {
+                            return;
+                        }
+                        scene.setObjectsVisible(scene.visibleObjectIds, false);
+                        scene.setObjectsXRayed(scene.xrayedObjectIds, false);
+                        scene.setObjectsSelected(scene.selectedObjectIds, false);
+                        scene.setObjectsHighlighted(scene.highlightedObjectIds, false);
+                        metaObject.withMetaObjectsInSubtree((metaObject) => {
+                            const entity = scene.objects[metaObject.id];
+                            if (entity) {
+                                entity.visible = true;
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "Hide All",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.numVisibleObjects > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsVisible(context.viewer.scene.visibleObjectIds, false);
+                    }
+                },
+                {
+                    title: "Show All",
+                    getEnabled: function (context) {
+                        const scene = context.viewer.scene;
+                        return (scene.numVisibleObjects < scene.numObjects);
+                    },
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        scene.setObjectsVisible(scene.objectIds, true);
+                    }
+                }
+            ],
+            [
+                {
+                    title: "X-Ray",
+                    getEnabled: function (context) {
+                        return (!context.entity.xrayed);
+                    },
+                    doAction: function (context) {
+                        context.entity.xrayed = true;
+                    }
+                },
+                {
+                    title: "Undo X-Ray",
+                    getEnabled: function (context) {
+                        return context.entity.xrayed;
+                    },
+                    doAction: function (context) {
+                        context.entity.xrayed = false;
+                    }
+                },
+                {
+                    title: "X-Ray Others",
+                    doAction: function (context) {
+                        const viewer = context.viewer;
+                        const scene = viewer.scene;
+                        const entity = context.entity;
+                        const metaObject = viewer.metaScene.metaObjects[entity.id];
+                        if (!metaObject) {
+                            return;
+                        }
+                        scene.setObjectsVisible(scene.objectIds, true);
+                        scene.setObjectsXRayed(scene.objectIds, true);
+                        scene.setObjectsSelected(scene.selectedObjectIds, false);
+                        scene.setObjectsHighlighted(scene.highlightedObjectIds, false);
+                        metaObject.withMetaObjectsInSubtree((metaObject) => {
+                            const entity = scene.objects[metaObject.id];
+                            if (entity) {
+                                entity.xrayed = false;
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "Reset X-Ray",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.numXRayedObjects > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsXRayed(context.viewer.scene.xrayedObjectIds, false);
+                    }
+                }
+            ],
+            [
+                {
+                    title: "Select",
+                    getEnabled: function (context) {
+                        return (!context.entity.selected);
+                    },
+                    doAction: function (context) {
+                        context.entity.selected = true;
+                    }
+                },
+                {
+                    title: "Undo select",
+                    getEnabled: function (context) {
+                        return context.entity.selected;
+                    },
+                    doAction: function (context) {
+                        context.entity.selected = false;
+                    }
+                },
+                {
+                    title: "Clear Selection",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.numSelectedObjects > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsSelected(context.viewer.scene.selectedObjectIds, false);
+                    }
+                }
+            ]
+        ],
+        enabled: true
+    });
+
+    viewer.cameraControl.on("rightClick", function (e) {
+        var hit = viewer.scene.pick({
+            canvasPos: e.canvasPos
+        });
+        if (hit && hit.entity.isObject) {
+            objectContextMenu.context = { // Must set context before showing menu
+                viewer: viewer,
+                treeViewPlugin: treeView,
+                entity: hit.entity
+            };
+            objectContextMenu.show(e.pagePos[0], e.pagePos[1]);
+        } else {
+            canvasContextMenu.context = { // Must set context before showing menu
+                viewer: viewer
+            };
+            canvasContextMenu.show(e.pagePos[0], e.pagePos[1]);
+        }
+        e.event.preventDefault();
+    });
+
+    window.viewer = viewer;
+
+</script>
+</html>

--- a/examples/buildings/xkt_manifest_WestRiverSideHospital.html
+++ b/examples/buildings/xkt_manifest_WestRiverSideHospital.html
@@ -1,0 +1,817 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>xeokit Example</title>
+    <link href="../css/pageStyle.css" rel="stylesheet"/>
+    <style>
+
+        /* ----------------------------------------------------------------------------------------------------------*/
+        /* NavCubePlugin */
+        /* ----------------------------------------------------------------------------------------------------------*/
+
+        #myNavCubeCanvas {
+            position: absolute;
+            width: 250px;
+            height: 250px;
+            bottom: 50px;
+            right: 10px;
+            z-index: 200000;
+        }
+
+        /* ----------------------------------------------------------------------------------------------------------*/
+        /* TreeViewPlugin */
+        /* ----------------------------------------------------------------------------------------------------------*/
+
+        #treeViewContainer {
+            pointer-events: all;
+            height: 100%;
+            overflow-y: scroll;
+            overflow-x: hidden;
+            position: absolute;
+            background-color: rgba(255, 255, 255, 0.2);
+            color: black;
+            top: 140px;
+            z-index: 200000;
+            float: left;
+            left: 0;
+            padding-left: 10px;
+            font-family: 'Roboto', sans-serif;
+            font-size: 15px;
+            user-select: none;
+            -ms-user-select: none;
+            -moz-user-select: none;
+            -webkit-user-select: none;
+            width: 350px;
+        }
+
+        #treeViewContainer ul {
+            list-style: none;
+            padding-left: 1.75em;
+            pointer-events: none;
+        }
+
+        #treeViewContainer ul li {
+            position: relative;
+            width: 500px;
+            pointer-events: none;
+            padding-top: 3px;
+            padding-bottom: 3px;
+            vertical-align: middle;
+        }
+
+        #treeViewContainer ul li a {
+            background-color: #eee;
+            border-radius: 50%;
+            color: #000;
+            display: inline-block;
+            height: 1.5em;
+            left: -1.5em;
+            position: absolute;
+            text-align: center;
+            text-decoration: none;
+            width: 1.5em;
+            pointer-events: all;
+        }
+
+        #treeViewContainer ul li a.plus {
+            background-color: #ded;
+            pointer-events: all;
+        }
+
+        #treeViewContainer ul li a.minus {
+            background-color: #eee;
+            pointer-events: all;
+        }
+
+        #treeViewContainer ul li a:active {
+            top: 1px;
+            pointer-events: all;
+        }
+
+        #treeViewContainer ul li span:hover {
+            color: white;
+            cursor: pointer;
+            background: black;
+            padding-left: 2px;
+            pointer-events: all;
+        }
+
+        #treeViewContainer ul li span {
+            display: inline-block;
+            width: calc(100% - 50px);
+            padding-left: 2px;
+            pointer-events: all;
+            height: 23px;
+        }
+
+        #treeViewContainer .highlighted-node { /* Appearance of node highlighted with TreeViewPlugin#showNode() */
+            border: black solid 1px;
+            background: yellow;
+            color: black;
+            padding-left: 1px;
+            padding-right: 5px;
+            pointer-events: all;
+        }
+
+        /* ----------------------------------------------------------------------------------------------------------*/
+        /* ContextMenu */
+        /* ----------------------------------------------------------------------------------------------------------*/
+
+        .xeokit-context-menu {
+            font-family: 'Roboto', sans-serif;
+            font-size: 15px;
+            display: none;
+            z-index: 300000;
+            background: rgba(255, 255, 255, 0.46);
+            border: 1px solid black;
+            border-radius: 6px;
+            padding: 0;
+            width: 200px;
+        }
+
+        .xeokit-context-menu ul {
+            list-style: none;
+            margin-left: 0;
+            padding: 0;
+        }
+
+        .xeokit-context-menu ul li {
+            list-style-type: none;
+            padding-left: 10px;
+            padding-right: 20px;
+            padding-top: 4px;
+            padding-bottom: 4px;
+            color: black;
+            border-bottom: 1px solid gray;
+            background: rgba(255, 255, 255, 0.46);
+            cursor: pointer;
+            width: calc(100% - 30px);
+        }
+
+        .xeokit-context-menu ul li:hover {
+            background: black;
+            color: white;
+            font-weight: normal;
+        }
+
+        .xeokit-context-menu ul li span {
+            display: inline-block;
+        }
+
+        .xeokit-context-menu .disabled {
+            display: inline-block;
+            color: gray;
+            cursor: default;
+            font-weight: normal;
+        }
+
+        .xeokit-context-menu .disabled:hover {
+            color: gray;
+            cursor: default;
+            background: #eeeeee;
+            font-weight: normal;
+        }
+
+        .buttons {
+            display: flex;
+            flex-direction: row;
+            justify-content: center;
+            align-items: center;
+
+            margin: 0;
+            position: absolute;
+            left: 40px;
+            top: 40px;
+        }
+
+        button {
+            margin: 5px;
+        }
+
+        /* Style for disabled buttons */
+        button[disabled] {
+            opacity: 0.8;
+            cursor: not-allowed;
+        }
+
+        #stats {
+            display: flex;
+            flex-direction: row;
+            justify-content: center;
+            align-items: center;
+            margin: 0;
+            position: absolute;
+            left: 40px;
+            top: 80px;
+        }
+    </style>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
+</head>
+<body>
+<input type="checkbox" id="info-button"/>
+<label for="info-button" class="info-button"><i class="far fa-3x fa-question-circle"></i></label>
+<canvas id="myCanvas"></canvas>
+<canvas id="myNavCubeCanvas"></canvas>
+<div id="stats">
+
+</div>
+<div id="treeViewContainer"></div>
+<div class="slideout-sidebar">
+    <img class="info-icon" src="../assets/images/bim_icon.png"/>
+    <h1>XKTLoaderPlugin</h1>
+    <h2>Loading a federated IFC4 model from the file system, split into multiple XKT files and a manifest</h2>
+
+    <h3>Stats</h3>
+    <ul>
+        <li>
+            <div id="time">Loading JavaScript modules...</div>
+        </li>
+    </ul>
+    <h3>Components used</h3>
+    <ul>
+        <li>
+            <a href="../../docs/class/src/viewer/Viewer.js~Viewer.html"
+               target="_other">Viewer</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js~XKTLoaderPlugin.html"
+               target="_other">XKTLoaderPlugin</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/TreeViewPlugin/TreeViewPlugin.js~TreeViewPlugin.html"
+               target="_other">TreeViewPlugin</a>
+        </li>
+
+    </ul>
+    <h3>Resources</h3>
+    <ul>
+        <li>
+            <a href="https://www.notion.so/xeokit/Splitting-Big-IFC-Models-During-Conversion-for-Improved-Performance-165fc022e94742cf966ee50003572259"
+               target="_other">Splitting Big IFC Models During Conversion for Improved Performance</a>
+        </li>
+        <li>
+            <a href="http://openifcmodel.cs.auckland.ac.nz/Model/Details/274"
+               target="_other">Model source</a>
+        </li>
+    </ul>
+</div>
+</body>
+
+<script type="module">
+
+    import {Viewer, XKTLoaderPlugin, TreeViewPlugin,  ContextMenu} from "../../dist/xeokit-sdk.min.es.js";
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas",
+        transparent: true,
+        dtxEnabled: true
+    });
+
+    viewer.camera.eye = [110.27, 172.88, -6.49];
+    viewer.camera.look = [33.88, 177.99, -101.79];
+    viewer.camera.up = [0.02, 0.99, 0.03];
+
+    //----------------------------------------------------------------------------------------------------------------------
+    // Load a BIM model comprised of multiple XKT files
+    // The manifest of XKT files is given in model.xkt.manifest.json
+    // This will create a single SceneModel and MetaModel that contains the combined content of all the XKT files
+    //----------------------------------------------------------------------------------------------------------------------
+
+    const xktLoader = new XKTLoaderPlugin(viewer);
+
+    const sceneModel = xktLoader.load({
+        manifestSrc: "../../assets/models/xkt/v2/WestRiverSideHospital/model.xkt.manifest.json",
+        id: "myModel"
+    });
+
+    const t0 = performance.now();
+
+    sceneModel.on("loaded", function () {
+        const t1 = performance.now();
+        document.getElementById("time").innerHTML = "Model loaded in " + Math.floor(t1 - t0) / 1000.0 + " seconds<br>Objects: " + sceneModel.numEntities;
+    });
+
+        //----------------------------------------------------------------------------------------------------------------------
+    // Create a tree view
+    //----------------------------------------------------------------------------------------------------------------------
+
+    const treeView = new TreeViewPlugin(viewer, {
+        containerElement: document.getElementById("treeViewContainer"),
+        hierarchy: "types",
+        autoExpandDepth: 0
+    });
+
+    const treeViewContextMenu = new ContextMenu({
+
+        items: [
+            [
+                {
+                    title: "View Fit",
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        const objectIds = [];
+                        context.treeViewPlugin.withNodeTree(context.treeViewNode, (treeViewNode) => {
+                            if (treeViewNode.objectId) {
+                                objectIds.push(treeViewNode.objectId);
+                            }
+                        });
+                        scene.setObjectsVisible(objectIds, true);
+                        scene.setObjectsHighlighted(objectIds, true);
+                        context.viewer.cameraFlight.flyTo({
+                            projection: "perspective",
+                            aabb: scene.getAABB(objectIds),
+                            duration: 0.5
+                        }, () => {
+                            setTimeout(function () {
+                                scene.setObjectsHighlighted(scene.highlightedObjectIds, false);
+                            }, 500);
+                        });
+                    }
+                },
+                {
+                    title: "View Fit All",
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        context.viewer.cameraFlight.flyTo({
+                            projection: "perspective",
+                            aabb: scene.getAABB({}),
+                            duration: 0.5
+                        });
+                    }
+                }
+            ],
+            [
+                {
+                    title: "Hide",
+                    doAction: function (context) {
+                        context.treeViewPlugin.withNodeTree(context.treeViewNode, (treeViewNode) => {
+                            if (treeViewNode.objectId) {
+                                const entity = context.viewer.scene.objects[treeViewNode.objectId];
+                                if (entity) {
+                                    entity.visible = false;
+                                }
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "Hide Others",
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        scene.setObjectsVisible(scene.visibleObjectIds, false);
+                        scene.setObjectsXRayed(scene.xrayedObjectIds, false);
+                        scene.setObjectsSelected(scene.selectedObjectIds, false);
+                        scene.setObjectsHighlighted(scene.highlightedObjectIds, false);
+                        context.treeViewPlugin.withNodeTree(context.treeViewNode, (treeViewNode) => {
+                            if (treeViewNode.objectId) {
+                                const entity = scene.objects[treeViewNode.objectId];
+                                if (entity) {
+                                    entity.visible = true;
+                                }
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "Hide All",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.visibleObjectIds.length > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsVisible(context.viewer.scene.visibleObjectIds, false);
+                    }
+                }
+            ],
+            [
+                {
+                    title: "Show",
+                    doAction: function (context) {
+                        context.treeViewPlugin.withNodeTree(context.treeViewNode, (treeViewNode) => {
+                            if (treeViewNode.objectId) {
+                                const entity = context.viewer.scene.objects[treeViewNode.objectId];
+                                if (entity) {
+                                    entity.visible = true;
+                                    entity.xrayed = false;
+                                    entity.selected = false;
+                                }
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "Show Others",
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        scene.setObjectsVisible(scene.objectIds, true);
+                        scene.setObjectsXRayed(scene.xrayedObjectIds, false);
+                        scene.setObjectsSelected(scene.selectedObjectIds, false);
+                        context.treeViewPlugin.withNodeTree(context.treeViewNode, (treeViewNode) => {
+                            if (treeViewNode.objectId) {
+                                const entity = scene.objects[treeViewNode.objectId];
+                                if (entity) {
+                                    entity.visible = false;
+                                }
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "Show All",
+                    getEnabled: function (context) {
+                        const scene = context.viewer.scene;
+                        return (scene.numVisibleObjects < scene.numObjects);
+                    },
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        scene.setObjectsVisible(scene.objectIds, true);
+                        scene.setObjectsXRayed(scene.xrayedObjectIds, false);
+                        scene.setObjectsSelected(scene.selectedObjectIds, false);
+                    }
+                }
+            ],
+            [
+                {
+                    title: "X-Ray",
+                    doAction: function (context) {
+                        context.treeViewPlugin.withNodeTree(context.treeViewNode, (treeViewNode) => {
+                            if (treeViewNode.objectId) {
+                                const entity = context.viewer.scene.objects[treeViewNode.objectId];
+                                if (entity) {
+                                    entity.xrayed = true;
+                                    entity.visible = true;
+                                }
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "Undo X-Ray",
+                    doAction: function (context) {
+                        context.treeViewPlugin.withNodeTree(context.treeViewNode, (treeViewNode) => {
+                            if (treeViewNode.objectId) {
+                                const entity = context.viewer.scene.objects[treeViewNode.objectId];
+                                if (entity) {
+                                    entity.xrayed = false;
+                                }
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "X-Ray Others",
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        scene.setObjectsVisible(scene.objectIds, true);
+                        scene.setObjectsXRayed(scene.objectIds, true);
+                        scene.setObjectsSelected(scene.selectedObjectIds, false);
+                        scene.setObjectsHighlighted(scene.highlightedObjectIds, false);
+                        context.treeViewPlugin.withNodeTree(context.treeViewNode, (treeViewNode) => {
+                            if (treeViewNode.objectId) {
+                                const entity = scene.objects[treeViewNode.objectId];
+                                if (entity) {
+                                    entity.xrayed = false;
+                                }
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "Reset X-Ray",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.numXRayedObjects > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsXRayed(context.viewer.scene.xrayedObjectIds, false);
+                    }
+                }
+            ],
+            [
+                {
+                    title: "Select",
+                    doAction: function (context) {
+                        context.treeViewPlugin.withNodeTree(context.treeViewNode, (treeViewNode) => {
+                            if (treeViewNode.objectId) {
+                                const entity = context.viewer.scene.objects[treeViewNode.objectId];
+                                if (entity) {
+                                    entity.selected = true;
+                                    entity.visible = true;
+                                }
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "Deselect",
+                    doAction: function (context) {
+                        context.treeViewPlugin.withNodeTree(context.treeViewNode, (treeViewNode) => {
+                            if (treeViewNode.objectId) {
+                                const entity = context.viewer.scene.objects[treeViewNode.objectId];
+                                if (entity) {
+                                    entity.selected = false;
+                                }
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "Clear Selection",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.numSelectedObjects > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsSelected(context.viewer.scene.selectedObjectIds, false);
+                    }
+                }
+            ]
+        ]
+    });
+
+    // Right-clicking on a tree node shows the context menu for that node
+
+    treeView.on("contextmenu", (e) => {
+
+        treeViewContextMenu.context = { // Must set context before opening menu
+            viewer: e.viewer,
+            treeViewPlugin: e.treeViewPlugin,
+            treeViewNode: e.treeViewNode,
+            entity: e.viewer.scene.objects[e.treeViewNode.objectId] // Only defined if tree node is a leaf node
+        };
+
+        treeViewContextMenu.show(e.event.pageX, e.event.pageY);
+    });
+
+    // Left-clicking on a tree node isolates that object in the 3D view
+
+    treeView.on("nodeTitleClicked", (e) => {
+        const scene = viewer.scene;
+        const objectIds = [];
+        e.treeViewPlugin.withNodeTree(e.treeViewNode, (treeViewNode) => {
+            if (treeViewNode.objectId) {
+                objectIds.push(treeViewNode.objectId);
+            }
+        });
+        e.treeViewPlugin.unShowNode();
+        scene.setObjectsXRayed(scene.objectIds, true);
+        scene.setObjectsVisible(scene.objectIds, true);
+        scene.setObjectsXRayed(objectIds, false);
+        viewer.cameraFlight.flyTo({
+            aabb: scene.getAABB(objectIds),
+            duration: 0.5
+        }, () => {
+            setTimeout(function () {
+                scene.setObjectsVisible(scene.xrayedObjectIds, false);
+                scene.setObjectsXRayed(scene.xrayedObjectIds, false);
+            }, 500);
+        });
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create two ContextMenus - one for right-click on empty space, the other for right-click on an Entity
+    //------------------------------------------------------------------------------------------------------------------
+
+    const canvasContextMenu = new ContextMenu({
+        enabled: true,
+        context: {
+            viewer: viewer
+        },
+        items: [
+            [
+                {
+                    title: "Hide All",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.numVisibleObjects > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsVisible(context.viewer.scene.visibleObjectIds, false);
+                    }
+                },
+                {
+                    title: "Show All",
+                    getEnabled: function (context) {
+                        const scene = context.viewer.scene;
+                        return (scene.numVisibleObjects < scene.numObjects);
+                    },
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        scene.setObjectsVisible(scene.objectIds, true);
+                        scene.setObjectsXRayed(scene.xrayedObjectIds, false);
+                        scene.setObjectsSelected(scene.selectedObjectIds, false);
+                    }
+                }
+            ],
+            [
+                {
+                    title: "View Fit All",
+                    doAction: function (context) {
+                        context.viewer.cameraFlight.flyTo({
+                            aabb: context.viewer.scene.getAABB()
+                        });
+                    }
+                }
+            ]
+        ]
+    });
+
+    const objectContextMenu = new ContextMenu({
+        items: [
+            [
+                {
+                    title: "View Fit",
+                    doAction: function (context) {
+                        const viewer = context.viewer;
+                        const scene = viewer.scene;
+                        const entity = context.entity;
+                        viewer.cameraFlight.flyTo({
+                            aabb: entity.aabb,
+                            duration: 0.5
+                        }, () => {
+                            setTimeout(function () {
+                                scene.setObjectsHighlighted(scene.highlightedObjectIds, false);
+                            }, 500);
+                        });
+                    }
+                },
+                {
+                    title: "View Fit All",
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        context.viewer.cameraFlight.flyTo({
+                            projection: "perspective",
+                            aabb: scene.getAABB(),
+                            duration: 0.5
+                        });
+                    }
+                },
+                {
+                    title: "Show in Tree",
+                    doAction: function (context) {
+                        const objectId = context.entity.id;
+                        context.treeViewPlugin.showNode(objectId);
+                    }
+                }
+            ],
+            [
+                {
+                    title: "Hide",
+                    getEnabled: function (context) {
+                        return context.entity.visible;
+                    },
+                    doAction: function (context) {
+                        context.entity.visible = false;
+                    }
+                },
+                {
+                    title: "Hide Others",
+                    doAction: function (context) {
+                        const viewer = context.viewer;
+                        const scene = viewer.scene;
+                        const entity = context.entity;
+                        const metaObject = viewer.metaScene.metaObjects[entity.id];
+                        if (!metaObject) {
+                            return;
+                        }
+                        scene.setObjectsVisible(scene.visibleObjectIds, false);
+                        scene.setObjectsXRayed(scene.xrayedObjectIds, false);
+                        scene.setObjectsSelected(scene.selectedObjectIds, false);
+                        scene.setObjectsHighlighted(scene.highlightedObjectIds, false);
+                        metaObject.withMetaObjectsInSubtree((metaObject) => {
+                            const entity = scene.objects[metaObject.id];
+                            if (entity) {
+                                entity.visible = true;
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "Hide All",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.numVisibleObjects > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsVisible(context.viewer.scene.visibleObjectIds, false);
+                    }
+                },
+                {
+                    title: "Show All",
+                    getEnabled: function (context) {
+                        const scene = context.viewer.scene;
+                        return (scene.numVisibleObjects < scene.numObjects);
+                    },
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        scene.setObjectsVisible(scene.objectIds, true);
+                    }
+                }
+            ],
+            [
+                {
+                    title: "X-Ray",
+                    getEnabled: function (context) {
+                        return (!context.entity.xrayed);
+                    },
+                    doAction: function (context) {
+                        context.entity.xrayed = true;
+                    }
+                },
+                {
+                    title: "Undo X-Ray",
+                    getEnabled: function (context) {
+                        return context.entity.xrayed;
+                    },
+                    doAction: function (context) {
+                        context.entity.xrayed = false;
+                    }
+                },
+                {
+                    title: "X-Ray Others",
+                    doAction: function (context) {
+                        const viewer = context.viewer;
+                        const scene = viewer.scene;
+                        const entity = context.entity;
+                        const metaObject = viewer.metaScene.metaObjects[entity.id];
+                        if (!metaObject) {
+                            return;
+                        }
+                        scene.setObjectsVisible(scene.objectIds, true);
+                        scene.setObjectsXRayed(scene.objectIds, true);
+                        scene.setObjectsSelected(scene.selectedObjectIds, false);
+                        scene.setObjectsHighlighted(scene.highlightedObjectIds, false);
+                        metaObject.withMetaObjectsInSubtree((metaObject) => {
+                            const entity = scene.objects[metaObject.id];
+                            if (entity) {
+                                entity.xrayed = false;
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "Reset X-Ray",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.numXRayedObjects > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsXRayed(context.viewer.scene.xrayedObjectIds, false);
+                    }
+                }
+            ],
+            [
+                {
+                    title: "Select",
+                    getEnabled: function (context) {
+                        return (!context.entity.selected);
+                    },
+                    doAction: function (context) {
+                        context.entity.selected = true;
+                    }
+                },
+                {
+                    title: "Undo select",
+                    getEnabled: function (context) {
+                        return context.entity.selected;
+                    },
+                    doAction: function (context) {
+                        context.entity.selected = false;
+                    }
+                },
+                {
+                    title: "Clear Selection",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.numSelectedObjects > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsSelected(context.viewer.scene.selectedObjectIds, false);
+                    }
+                }
+            ]
+        ],
+        enabled: true
+    });
+
+    viewer.cameraControl.on("rightClick", function (e) {
+        var hit = viewer.scene.pick({
+            canvasPos: e.canvasPos
+        });
+        if (hit && hit.entity.isObject) {
+            objectContextMenu.context = { // Must set context before showing menu
+                viewer: viewer,
+                treeViewPlugin: treeView,
+                entity: hit.entity
+            };
+            objectContextMenu.show(e.pagePos[0], e.pagePos[1]);
+        } else {
+            canvasContextMenu.context = { // Must set context before showing menu
+                viewer: viewer
+            };
+            canvasContextMenu.show(e.pagePos[0], e.pagePos[1]);
+        }
+        e.event.preventDefault();
+    });
+
+    window.viewer = viewer;
+
+</script>
+</html>

--- a/src/plugins/TreeViewPlugin/TreeViewPlugin.js
+++ b/src/plugins/TreeViewPlugin/TreeViewPlugin.js
@@ -553,7 +553,10 @@ export class TreeViewPlugin extends Plugin {
             const modelIds = Object.keys(this.viewer.metaScene.metaModels);
             for (let i = 0, len = modelIds.length; i < len; i++) {
                 const modelId = modelIds[i];
-                this.addModel(modelId);
+                const metaModel = this.viewer.metaScene.metaModels[modelId];
+                if (metaModel.finalized) {
+                    this.addModel(modelId);
+                }
             }
             this.viewer.scene.on("modelLoaded", (modelId) => {
                 if (this.viewer.metaScene.metaModels[modelId]) {

--- a/src/plugins/XKTLoaderPlugin/XKTDefaultDataSource.js
+++ b/src/plugins/XKTLoaderPlugin/XKTDefaultDataSource.js
@@ -9,6 +9,23 @@ class XKTDefaultDataSource {
     }
 
     /**
+     * Gets manifest JSON.
+     *
+     * @param {String|Number} manifestSrc Identifies the manifest JSON asset.
+     * @param {Function} ok Fired on successful loading of the manifest JSON asset.
+     * @param {Function} error Fired on error while loading the manifest JSON asset.
+     */
+    getManifest(manifestSrc, ok, error) {
+        utils.loadJSON(manifestSrc,
+            (json) => {
+                ok(json);
+            },
+            function (errMsg) {
+                error(errMsg);
+            });
+    }
+
+    /**
      * Gets metamodel JSON.
      *
      * @param {String|Number} metaModelSrc Identifies the metamodel JSON asset.

--- a/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
+++ b/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
@@ -431,38 +431,36 @@ parsers[ParserV10.version] = ParserV10;
  * myViewer.scene.setObjectVisibilities("myModel1#0BTBFw6f90Nfh9rP1dlXrb", true);
  *````
  *
- * # Loading a model from a set of XKT files
+ * # Loading a model from a manifest of XKT files
  *
  * The `ifc2gltf` tool from Creoox, which converts IFC files into glTF geometry and JSON metadata files, has the option to
- * split its output into multiple pairs of glTF and JSON files.
+ * split its output into multiple pairs of glTF and JSON files, accompanied by a JSON manifest that lists the files.
  *
  * To integrate with that option, the `convert2xkt` tool, which converts glTF geometry and JSON metadata files into XKT files,
- * has the option to batch-convert a set of multiple glTF+JSON files into a set of XKT files, in one invocation.
+ * also has the option to batch-convert the glTF+JSON files in the manifest, in one invocation.
  *
- * When use this option, then convert2xkt will output a bunch of glTF and JSON files, along with a JSON manifest file that lists them.
+ * When we use this option, convert2xkt will output a bunch of XKT files, along with a JSON manifest file that lists those XKT files.
  *
- * The XKTLoaderPlugin has the option batch-load all XKT files listed in that manifest into a xeokit Viewer in one shot,
- * combining them into a single SceneModel and MetaDataModel.
+ * Working down the pipeline, the XKTLoaderPlugin has the option batch-load all XKT files listed in that manifest
+ * into a xeokit Viewer in one load operation, combining the XKT files into a single SceneModel and MetaModel.
  *
- * You can learn about this conversion and loading process, with splitting, batch converting and batch loading,
+ * You can learn more about this conversion and loading process, with splitting, batch converting and batch loading,
  * in [this tutorial](https://www.notion.so/xeokit/Importing-Huge-IFC-Models-as-Multiple-XKT-Files-165fc022e94742cf966ee50003572259).
  *
- * Let's imagine that we have a set of such XKT files. As described in the tutorial, they were converted by `ifc2gltf` from an
- * IFC file into a set of glTF+JSON files, that were then converted by convert2xkt.
- *
- * The `convert2xkt` tool has also output a JSON manifest that lists the XKT files it created. The XKT files and their
- * manifest are listed below:
+ * To show how to use XKTLoaderPlugin to load a manifest of XKT files, let's imagine that we have a set of such XKT files. As
+ * described in the tutorial, they were converted by `ifc2gltf` from an IFC file into a set of glTF+JSON files, that were
+ * then converted by convert2xkt into this set of XKT files and a manifest, as shown below.
  *
  * ````bash
  * ./
- * ├── model_1.glb.xkt
- * ├── model_2.glb.xkt
- * ├── model_3.glb.xkt
- * ├── model.glb.xkt
+ * ├── model_1.xkt
+ * ├── model_2.xkt
+ * ├── model_3.xkt
+ * ├── model_4..xkt
  * └── model.xkt.manifest.json
  * ````
  *
- * The `model.xkt.manifest.json` XKT manifest looks something like this:
+ * The `model.xkt.manifest.json` XKT manifest would look something like this:
  *
  * ````json
  * {
@@ -472,10 +470,10 @@ parsers[ParserV10.version] = ParserV10;
  *   "conversionDate": "10-08-2023- 02-05-01",
  *   "outputDir": null,
  *   "xktFiles": [
- *     "model.glb.xkt",
- *     "model_1.glb.xkt",
- *     "model_2.glb.xkt",
- *     "model_3.glb.xkt"
+ *     "model_1.xkt",
+ *     "model_2.xkt",
+ *     "model_3.xkt",
+ *     "model_4.xkt"
  *   ]
  * }
  * ````

--- a/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
+++ b/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
@@ -1,5 +1,6 @@
 import {utils} from "../../viewer/scene/utils.js"
 import {SceneModel} from "../../viewer/scene/model/index.js";
+import {MetaModel} from "../../viewer/metadata/MetaModel.js";
 import {Plugin} from "../../viewer/Plugin.js";
 import {XKTDefaultDataSource} from "./XKTDefaultDataSource.js";
 import {IFCObjectDefaults} from "../../viewer/metadata/IFCObjectDefaults.js";
@@ -14,6 +15,7 @@ import {ParserV7} from "./parsers/ParserV7.js";
 import {ParserV8} from "./parsers/ParserV8.js";
 import {ParserV9} from "./parsers/ParserV9.js";
 import {ParserV10} from "./parsers/ParserV10.js";
+
 
 const parsers = {};
 
@@ -35,7 +37,7 @@ parsers[ParserV10.version] = ParserV10;
  *
  * [[Run this example](https://xeokit.github.io/xeokit-sdk/examples/#loading_XKT_OTCConferenceCenter)]
  *
- * ## Overview
+ * # Overview
  *
  * * XKTLoaderPlugin is the most efficient way to load high-detail models into xeokit.
  * * An *````.XKT````* file is a single BLOB containing a model, compressed using geometry quantization
@@ -48,14 +50,14 @@ parsers[ParserV10.version] = ParserV10;
  * * Set a custom data source for *````.XKT````* and IFC metadata files.
  * * Option to load multiple copies of the same model, without object ID clashes.
  *
- * ## Creating *````.XKT````* Files and Metadata
+ * # Creating *````.XKT````* Files and Metadata
  *
  * We have several sways to convert your files into XKT. See these tutorials for more info:
  *
  * * [Converting Models to XKT with convert2xkt](https://www.notion.so/xeokit/Converting-Models-to-XKT-with-convert2xkt-fa567843313f4db8a7d6535e76da9380) - how to convert various file formats (glTF, IFC, CityJSON, LAS/LAZ...) to XKT using our nodejs-based converter.
  * * [Converting IFC Models to XKT using 3rd-Party Open Source Tools](https://www.notion.so/xeokit/Converting-IFC-Models-to-XKT-using-3rd-Party-Open-Source-Tools-c373e48bc4094ff5b6e5c5700ff580ee) - how to convert IFC files to XKT using 3rd-party open source CLI tools.
  *
- * ## Scene representation
+ * # Scene representation
  *
  * When loading a model, XKTLoaderPlugin creates an {@link Entity} that represents the model, which
  * will have {@link Entity#isModel} set ````true```` and will be registered by {@link Entity#id}
@@ -63,7 +65,7 @@ parsers[ParserV10.version] = ParserV10;
  * model. Those Entities will have {@link Entity#isObject} set ````true```` and will be registered
  * by {@link Entity#id} in {@link Scene#objects}.
  *
- * ## Metadata
+ * # Metadata
  *
  * Since XKT V8, model metadata is included in the XKT file. If the XKT file has metadata, then loading it creates
  * model metadata components within the Viewer, namely a {@link MetaModel} corresponding to the model {@link Entity},
@@ -77,7 +79,7 @@ parsers[ParserV10.version] = ParserV10;
  * For XKT versions prior to V8, we provided the metadata to XKTLoaderPlugin as an accompanying JSON file to load. We can
  * still do that for all XKT versions, and for XKT V8+ it will override any metadata provided within the XKT file.
  *
- * ## Usage
+ * # Usage
  *
  * In the example below we'll load the Schependomlaan model from a [.XKT file](https://github.com/xeokit/xeokit-sdk/tree/master/examples/models/xkt/schependomlaan).
  *
@@ -160,7 +162,7 @@ parsers[ParserV10.version] = ParserV10;
  * model.destroy();
  * ````
  *
- * ## Loading XKT files containing textures
+ * # Loading XKT files containing textures
  *
  * XKTLoaderPlugin uses a {@link KTX2TextureTranscoder} to load textures in XKT files (XKT v10+). An XKTLoaderPlugin has its own
  * default KTX2TextureTranscoder, configured to load the Basis Codec from the CDN. If we wish, we can override that with our own
@@ -205,7 +207,7 @@ parsers[ParserV10.version] = ParserV10;
  * });
  * ````
  *
- * ## Transforming
+ * # Transforming
  *
  * We have the option to rotate, scale and translate each  *````.XKT````* model as we load it.
  *
@@ -225,7 +227,7 @@ parsers[ParserV10.version] = ParserV10;
  * });
  * ````
  *
- * ## Including and excluding IFC types
+ * # Including and excluding IFC types
  *
  * We can also load only those objects that have the specified IFC types.
  *
@@ -255,7 +257,7 @@ parsers[ParserV10.version] = ParserV10;
  * });
  * ````
  *
- * ## Configuring initial IFC object appearances
+ * # Configuring initial IFC object appearances
  *
  * We can specify the custom initial appearance of loaded objects according to their IFC types.
  *
@@ -323,7 +325,7 @@ parsers[ParserV10.version] = ParserV10;
  * });
  * ````
  *
- * ## Configuring a custom data source
+ * # Configuring a custom data source
  *
  * By default, XKTLoaderPlugin will load *````.XKT````* files and metadata JSON over HTTP.
  *
@@ -375,7 +377,7 @@ parsers[ParserV10.version] = ParserV10;
  * });
  * ````
  *
- * ## Loading multiple copies of a model, without object ID clashes
+ * # Loading multiple copies of a model, without object ID clashes
  *
  * Sometimes we need to load two or more instances of the same model, without having clashes
  * between the IDs of the equivalent objects in the model instances.
@@ -428,6 +430,94 @@ parsers[ParserV10.version] = ParserV10;
  * ````javascript
  * myViewer.scene.setObjectVisibilities("myModel1#0BTBFw6f90Nfh9rP1dlXrb", true);
  *````
+ *
+ * # Loading a model from a set of XKT files
+ *
+ * The `ifc2gltf` tool from Creoox, which converts IFC files into glTF geometry and JSON metadata files, has the option to
+ * split its output into multiple pairs of glTF and JSON files.
+ *
+ * To integrate with that option, the `convert2xkt` tool, which converts glTF geometry and JSON metadata files into XKT files,
+ * has the option to batch-convert a set of multiple glTF+JSON files into a set of XKT files, in one invocation.
+ *
+ * When use this option, then convert2xkt will output a bunch of glTF and JSON files, along with a JSON manifest file that lists them.
+ *
+ * The XKTLoaderPlugin has the option batch-load all XKT files listed in that manifest into a xeokit Viewer in one shot,
+ * combining them into a single SceneModel and MetaDataModel.
+ *
+ * You can learn about this conversion and loading process, with splitting, batch converting and batch loading,
+ * in [this tutorial](https://www.notion.so/xeokit/Importing-Huge-IFC-Models-as-Multiple-XKT-Files-165fc022e94742cf966ee50003572259).
+ *
+ * Let's imagine that we have a set of such XKT files. As described in the tutorial, they were converted by `ifc2gltf` from an
+ * IFC file into a set of glTF+JSON files, that were then converted by convert2xkt.
+ *
+ * The `convert2xkt` tool has also output a JSON manifest that lists the XKT files it created. The XKT files and their
+ * manifest are listed below:
+ *
+ * ````bash
+ * ./
+ * ├── model_1.glb.xkt
+ * ├── model_2.glb.xkt
+ * ├── model_3.glb.xkt
+ * ├── model.glb.xkt
+ * └── model.xkt.manifest.json
+ * ````
+ *
+ * The `model.xkt.manifest.json` XKT manifest looks something like this:
+ *
+ * ````json
+ * {
+ *   "inputFile": null,
+ *   "converterApplication": "convert2xkt",
+ *   "converterApplicationVersion": "v1.1.9",
+ *   "conversionDate": "10-08-2023- 02-05-01",
+ *   "outputDir": null,
+ *   "xktFiles": [
+ *     "model.glb.xkt",
+ *     "model_1.glb.xkt",
+ *     "model_2.glb.xkt",
+ *     "model_3.glb.xkt"
+ *   ]
+ * }
+ * ````
+ *
+ * Now, to load all those XKT files into a single SceneModel and MetaModel in one operation, we pass a path to the XKT
+ * manifest to `XKTLoaderPlugin.load`, as shown in the example below:
+ *
+ * ````javascript
+ * import {
+ *   Viewer,
+ *   XKTLoaderPlugin,
+ *   TreeViewPlugin,
+ * } from "xeokit-sdk.es.js";
+ *
+ * constviewer = new Viewer({
+ *   canvasId: "myCanvas"
+ * });
+ *
+ * viewer.scene.camera.eye = [26.54, 29.29, 36.20,];
+ * viewer.scene.camera.look = [-23.51, -8.26, -21.65,];
+ * viewer.scene.camera.up = [-0.2, 0.89, -0.33,];
+ *
+ * const xktLoader = new XKTLoaderPlugin(viewer);
+ *
+ * const sceneModel = xktLoader.load({
+ *   manifestSrc: "model.xkt.manifest.json",
+ *   id: "myModel",
+ * });
+ *
+ * const metaModel = viewer.metaScene.metaModels[sceneModel.id];
+ *
+ * // Then when we need to, we can destroy the SceneModel
+ * // and MetaModel in one shot, like so:
+ *
+ * sceneModel.destroy();
+ * metaModel.destroy();
+ * ````
+ *
+ * The main advantage here, of splitting IFC files like this within the conversion and import pipeline,
+ * is to reduce the memory pressure on each of the `ifc2gltf`, `convert2xkt` and XKTLoaderPlugin components.
+ * They work much reliably (and faster) when processing smaller files (eg. 20MB) than when processing large files (eg. 500MB), where
+ * they have less trouble allocating the system memory they need for conversion and parsing.
  *
  * @class XKTLoaderPlugin
  */
@@ -737,20 +827,8 @@ class XKTLoaderPlugin extends Plugin {
             delete params.id;
         }
 
-        const sceneModel = new SceneModel(this.viewer.scene, utils.apply(params, {
-            isModel: true,
-            textureTranscoder: this._textureTranscoder,
-            maxGeometryBatchSize: this._maxGeometryBatchSize,
-            origin: params.origin,
-            disableVertexWelding: params.disableVertexWelding || false,
-            disableIndexRebucketing: params.disableIndexRebucketing || false,
-            dtxEnabled: params.dtxEnabled
-        }));
-
-        const modelId = sceneModel.id;  // In case ID was auto-generated
-
-        if (!params.src && !params.xkt) {
-            this.error("load() param expected: src or xkt");
+        if (!params.src && !params.xkt && !params.manifestSrc) {
+            this.error("load() param expected: src, xkt or manifestSrc");
             return sceneModel; // Return new empty model
         }
 
@@ -782,29 +860,67 @@ class XKTLoaderPlugin extends Plugin {
         options.excludeUnclassifiedObjects = (params.excludeUnclassifiedObjects !== undefined) ? (!!params.excludeUnclassifiedObjects) : this._excludeUnclassifiedObjects;
         options.globalizeObjectIds = (params.globalizeObjectIds !== undefined && params.globalizeObjectIds !== null) ? (!!params.globalizeObjectIds) : this._globalizeObjectIds;
 
+        const sceneModel = new SceneModel(this.viewer.scene, utils.apply(params, {
+            isModel: true,
+            textureTranscoder: this._textureTranscoder,
+            maxGeometryBatchSize: this._maxGeometryBatchSize,
+            origin: params.origin,
+            disableVertexWelding: params.disableVertexWelding || false,
+            disableIndexRebucketing: params.disableIndexRebucketing || false,
+            dtxEnabled: params.dtxEnabled
+        }));
+
+        const modelId = sceneModel.id;  // In case ID was auto-generated
+
+        const metaModel = new MetaModel({
+            metaScene: this.viewer.metaScene,
+            id: modelId
+        });
+
+        this.viewer.scene.canvas.spinner.processes++;
+
+        const finish = () => {
+            // this._createDefaultMetaModelIfNeeded(sceneModel, params, options);
+            sceneModel.finalize();
+            metaModel.finalize();
+            this.viewer.scene.canvas.spinner.processes--;
+            sceneModel.once("destroyed", () => {
+                this.viewer.metaScene.destroyMetaModel(metaModel.id);
+            });
+            sceneModel.scene.once("tick", () => {
+                if (sceneModel.destroyed) {
+                    return;
+                }
+                sceneModel.scene.fire("modelLoaded", sceneModel.id); // FIXME: Assumes listeners know order of these two events
+                sceneModel.fire("loaded", true, false); // Don't forget the event, for late subscribers
+            });
+        }
+
+        const error = (errMsg) => {
+            this.viewer.scene.canvas.spinner.processes--;
+            this.error(errMsg);
+            sceneModel.fire("error", errMsg);
+        }
+
+        const manifestCtx = {
+            nextMeshId: 0
+        };
+
         if (params.metaModelSrc || params.metaModelData) {
 
             const processMetaModelData = (metaModelData) => {
 
-                const metaModel = this.viewer.metaScene.createMetaModel(modelId, metaModelData, {
+                metaModel.loadData(metaModelData, {
                     includeTypes: includeTypes,
                     excludeTypes: excludeTypes,
                     globalizeObjectIds: options.globalizeObjectIds
                 });
-
-                if (!metaModel) {
-                    return false;
-                }
 
                 if (params.src) {
                     this._loadModel(params.src, params, options, sceneModel);
                 } else {
                     this._parseModel(params.xkt, params, options, sceneModel);
                 }
-
-                sceneModel.once("destroyed", () => {
-                    this.viewer.metaScene.destroyMetaModel(sceneModel.id);
-                });
 
                 return true;
             };
@@ -813,61 +929,106 @@ class XKTLoaderPlugin extends Plugin {
 
                 const metaModelSrc = params.metaModelSrc;
 
-                this.viewer.scene.canvas.spinner.processes++;
-
                 this._dataSource.getMetaModel(metaModelSrc, (metaModelData) => {
-
                     if (sceneModel.destroyed) {
                         return;
                     }
-
                     if (!processMetaModelData(metaModelData)) {
-
-                        this.error(`load(): Failed to load model metadata for model '${modelId} from '${metaModelSrc}' - metadata not valid`);
-
-                        sceneModel.fire("error", "Metadata not valid");
+                        error(`load(): Failed to load model metadata for model '${modelId} from '${metaModelSrc}' - metadata not valid`);
                     }
-
-                    this.viewer.scene.canvas.spinner.processes--;
-
                 }, (errMsg) => {
-
-                    this.error(`load(): Failed to load model metadata for model '${modelId} from  '${metaModelSrc}' - ${errMsg}`);
-
-                    sceneModel.fire("error", `Failed to load model metadata from  '${metaModelSrc}' - ${errMsg}`);
-
-                    this.viewer.scene.canvas.spinner.processes--;
+                    error(`load(): Failed to load model metadata for model '${modelId} from  '${metaModelSrc}' - ${errMsg}`);
                 });
 
             } else if (params.metaModelData) {
-
                 if (!processMetaModelData(params.metaModelData)) {
-
-                    this.error(`load(): Failed to load model metadata for model '${modelId} from '${params.metaModelSrc}' - metadata not valid`);
-
-                    sceneModel.fire("error", "Metadata not valid");
+                    error(`load(): Failed to load model metadata for model '${modelId} from '${params.metaModelSrc}' - metadata not valid`);
                 }
             }
 
+            finish();
+
         } else {
+
             if (params.src) {
+
                 this._loadModel(params.src, params, options, sceneModel);
-            } else {
-                this._parseModel(params.xkt, params, options, sceneModel);
+                finish();
+
+            } else if (params.xkt) {
+
+                this._parseModel(params.xkt, params, options, sceneModel, metaModel, manifestCtx);
+                finish();
+
+            } else if (params.manifestSrc) {
+
+                const baseDir = getBaseDirectory(params.manifestSrc)
+
+                const loadJSONs = (metaDataFiles, done, error) => {
+                    let i = 0;
+                    const loadNext = () => {
+                        if (i >= metaDataFiles.length) {
+                            done();
+                        } else {
+                            this._dataSource.getMetaModel(`${baseDir}${metaDataFiles[i]}`, (metaModelData) => {
+                                metaModel.loadData(metaModelData, {
+                                    includeTypes: includeTypes,
+                                    excludeTypes: excludeTypes,
+                                    globalizeObjectIds: options.globalizeObjectIds
+                                });
+                                i++;
+                                loadNext();
+                            }, error);
+                        }
+                    }
+                    loadNext();
+                }
+
+                const loadXKTs = (xktFiles, done, error) => {
+                    let i = 0;
+                    const loadNext = () => {
+                        if (i >= xktFiles.length) {
+                            done();
+                        } else {
+                            this._dataSource.getXKT(`${baseDir}${xktFiles[i]}`, (arrayBuffer) => {
+                                this._parseModel(arrayBuffer, params, options, sceneModel, metaModel, manifestCtx);
+                                i++;
+                                loadNext();
+                            }, error);
+                        }
+                    }
+                    loadNext();
+                };
+
+                this._dataSource.getManifest(params.manifestSrc, (manifestData) => {
+                    if (sceneModel.destroyed) {
+                        return;
+                    }
+                    const xktFiles = manifestData.xktFiles;
+                    if (!xktFiles || xktFiles.length === 0) {
+                        error(`load(): Failed to load model manifest - manifest not valid`);
+                        return;
+                    }
+                    const metaModelFiles = manifestData.metaModelFiles;
+                    if (metaModelFiles) {
+                        loadJSONs(metaModelFiles, () => {
+                            loadXKTs(xktFiles, finish, error);
+                        }, error);
+                    } else {
+                        loadXKTs(xktFiles, finish, error);
+                    }
+                }, error);
             }
         }
 
         return sceneModel;
     }
 
-    _loadModel(src, params, options, sceneModel) {
-
+    _loadModel(src, params, options, sceneModel, metaModel, manifestCtx) {
         const spinner = this.viewer.scene.canvas.spinner;
-
         spinner.processes++;
-
         this._dataSource.getXKT(params.src, (arrayBuffer) => {
-                this._parseModel(arrayBuffer, params, options, sceneModel);
+                this._parseModel(arrayBuffer, params, options, sceneModel, metaModel, manifestCtx);
                 spinner.processes--;
             },
             (errMsg) => {
@@ -877,24 +1038,19 @@ class XKTLoaderPlugin extends Plugin {
             });
     }
 
-    _parseModel(arrayBuffer, params, options, sceneModel) {
-
+    _parseModel(arrayBuffer, params, options, sceneModel, metaModel, manifestCtx) {
         if (sceneModel.destroyed) {
             return;
         }
-
         const dataView = new DataView(arrayBuffer);
         const dataArray = new Uint8Array(arrayBuffer);
         const xktVersion = dataView.getUint32(0, true);
         const parser = parsers[xktVersion];
-
         if (!parser) {
             this.error("Unsupported .XKT file version: " + xktVersion + " - this XKTLoaderPlugin supports versions " + Object.keys(parsers));
             return;
         }
-
         this.log("Loading .xkt V" + xktVersion);
-
         const numElements = dataView.getUint32(4, true);
         const elements = [];
         let byteOffset = (numElements + 2) * 4;
@@ -903,71 +1059,64 @@ class XKTLoaderPlugin extends Plugin {
             elements.push(dataArray.subarray(byteOffset, byteOffset + elementSize));
             byteOffset += elementSize;
         }
-
-        parser.parse(this.viewer, options, elements, sceneModel);
-
-        sceneModel.finalize();
-
-        this._createDefaultMetaModelIfNeeded(sceneModel, params, options);
-
-        sceneModel.scene.once("tick", () => {
-            if (sceneModel.destroyed) {
-                return;
-            }
-            sceneModel.scene.fire("modelLoaded", sceneModel.id); // FIXME: Assumes listeners know order of these two events
-            sceneModel.fire("loaded", true, false); // Don't forget the event, for late subscribers
-        });
+        parser.parse(this.viewer, options, elements, sceneModel, metaModel, manifestCtx);
     }
 
-    _createDefaultMetaModelIfNeeded(sceneModel, params, options) {
+// _createDefaultMetaModelIfNeeded(sceneModel, params, options) {
+//
+//     const metaModelId = sceneModel.id;
+//
+//     if (!this.viewer.metaScene.metaModels[metaModelId]) {
+//
+//         const metaModelData = {
+//             metaObjects: []
+//         };
+//
+//         metaModelData.metaObjects.push({
+//             id: metaModelId,
+//             type: "default",
+//             name: metaModelId,
+//             parent: null
+//         });
+//
+//         const entityList = sceneModel.entityList;
+//
+//         for (let i = 0, len = entityList.length; i < len; i++) {
+//             const entity = entityList[i];
+//             if (entity.isObject) {
+//                 metaModelData.metaObjects.push({
+//                     id: entity.id,
+//                     type: "default",
+//                     name: entity.id,
+//                     parent: metaModelId
+//                 });
+//             }
+//         }
+//
+//         const src = params.src;
+//
+//         this.viewer.metaScene.createMetaModel(metaModelId, metaModelData, {
+//
+//             includeTypes: options.includeTypes,
+//             excludeTypes: options.excludeTypes,
+//             globalizeObjectIds: options.globalizeObjectIds,
+//
+//             getProperties: async (propertiesId) => {
+//                 return await this._dataSource.getProperties(src, propertiesId);
+//             }
+//         });
+//
+//         sceneModel.once("destroyed", () => {
+//             this.viewer.metaScene.destroyMetaModel(metaModelId);
+//         });
+//     }
+// }
+}
 
-        const metaModelId = sceneModel.id;
-
-        if (!this.viewer.metaScene.metaModels[metaModelId]) {
-
-            const metaModelData = {
-                metaObjects: []
-            };
-
-            metaModelData.metaObjects.push({
-                id: metaModelId,
-                type: "default",
-                name: metaModelId,
-                parent: null
-            });
-
-            const entityList = sceneModel.entityList;
-
-            for (let i = 0, len = entityList.length; i < len; i++) {
-                const entity = entityList[i];
-                if (entity.isObject) {
-                    metaModelData.metaObjects.push({
-                        id: entity.id,
-                        type: "default",
-                        name: entity.id,
-                        parent: metaModelId
-                    });
-                }
-            }
-
-            const src = params.src;
-
-            this.viewer.metaScene.createMetaModel(metaModelId, metaModelData, {
-
-                includeTypes: options.includeTypes,
-                excludeTypes: options.excludeTypes,
-                globalizeObjectIds: options.globalizeObjectIds,
-
-                getProperties: async (propertiesId) => {
-                    return await this._dataSource.getProperties(src, propertiesId);
-                }
-            });
-
-            sceneModel.once("destroyed", () => {
-                this.viewer.metaScene.destroyMetaModel(metaModelId);
-            });
-        }
-    }
+function getBaseDirectory(filePath) {
+    const pathArray = filePath.split('/');
+    pathArray.pop(); // Remove the file name or the last segment of the path
+    return pathArray.join('/') + '/';
 }
 
 export {XKTLoaderPlugin}

--- a/src/plugins/XKTLoaderPlugin/parsers/ParserV1.js
+++ b/src/plugins/XKTLoaderPlugin/parsers/ParserV1.js
@@ -61,7 +61,7 @@ function inflate(deflatedData) {
     };
 }
 
-function load(viewer, options, inflatedData, sceneModel) {
+function load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx) {
 
     sceneModel.positionsCompression = "precompressed";
     sceneModel.normalsCompression = "precompressed";
@@ -157,10 +157,10 @@ function load(viewer, options, inflatedData, sceneModel) {
 /** @private */
 const ParserV1 = {
     version: 1,
-    parse: function (viewer, options, elements, sceneModel) {
+    parse: function (viewer, options, elements, sceneModel, metaModel, manifestCtx) {
         const deflatedData = extract(elements);
         const inflatedData = inflate(deflatedData);
-        load(viewer, options, inflatedData, sceneModel);
+        load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx);
     }
 };
 

--- a/src/plugins/XKTLoaderPlugin/parsers/ParserV2.js
+++ b/src/plugins/XKTLoaderPlugin/parsers/ParserV2.js
@@ -76,7 +76,7 @@ const decompressColor = (function () {
     };
 })();
 
-function load(viewer, options, inflatedData, sceneModel) {
+function load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx) {
 
     sceneModel.positionsCompression = "precompressed";
     sceneModel.normalsCompression = "precompressed";
@@ -147,7 +147,7 @@ function load(viewer, options, inflatedData, sceneModel) {
             const jj = entityMeshIds [j];
 
             const lastMesh = (jj === (numMeshes - 1));
-            const meshId = entityId + ".mesh." + jj;
+            const meshId = manifestCtx.nextMeshId++;
 
             const color = decompressColor(meshColors.subarray((jj * 4), (jj * 4) + 3));
             const opacity = meshColors[(jj * 4) + 3] / 255.0;
@@ -218,10 +218,10 @@ function load(viewer, options, inflatedData, sceneModel) {
 /** @private */
 const ParserV2 = {
     version: 2,
-    parse: function (viewer, options, elements, sceneModel) {
+    parse: function (viewer, options, elements, sceneModel, metaModel, manifestCtx) {
         const deflatedData = extract(elements);
         const inflatedData = inflate(deflatedData);
-        load(viewer, options, inflatedData, sceneModel);
+        load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx);
     }
 };
 

--- a/src/plugins/XKTLoaderPlugin/parsers/ParserV3.js
+++ b/src/plugins/XKTLoaderPlugin/parsers/ParserV3.js
@@ -67,7 +67,7 @@ const decompressColor = (function () {
     };
 })();
 
-function load(viewer, options, inflatedData, sceneModel) {
+function load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx) {
 
     sceneModel.positionsCompression = "precompressed";
     sceneModel.normalsCompression = "precompressed";
@@ -210,10 +210,10 @@ function load(viewer, options, inflatedData, sceneModel) {
 /** @private */
 const ParserV3 = {
     version: 3,
-    parse: function (viewer, options, elements, sceneModel) {
+    parse: function (viewer, options, elements, sceneModel, metaModel, manifestCtx) {
         const deflatedData = extract(elements);
         const inflatedData = inflate(deflatedData);
-        load(viewer, options, inflatedData, sceneModel);
+        load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx);
     }
 };
 

--- a/src/plugins/XKTLoaderPlugin/parsers/ParserV4.js
+++ b/src/plugins/XKTLoaderPlugin/parsers/ParserV4.js
@@ -65,7 +65,7 @@ const decompressColor = (function () {
     };
 })();
 
-function load(viewer, options, inflatedData, sceneModel) {
+function load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx) {
 
     sceneModel.positionsCompression = "precompressed";
     sceneModel.normalsCompression = "precompressed";
@@ -269,10 +269,10 @@ function load(viewer, options, inflatedData, sceneModel) {
 /** @private */
 const ParserV4 = {
     version: 4,
-    parse: function (viewer, options, elements, sceneModel) {
+    parse: function (viewer, options, elements, sceneModel, metaModel, manifestCtx) {
         const deflatedData = extract(elements);
         const inflatedData = inflate(deflatedData);
-        load(viewer, options, inflatedData, sceneModel);
+        load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx);
     }
 };
 

--- a/src/plugins/XKTLoaderPlugin/parsers/ParserV5.js
+++ b/src/plugins/XKTLoaderPlugin/parsers/ParserV5.js
@@ -60,7 +60,7 @@ const decompressColor = (function () {
     };
 })();
 
-function load(viewer, options, inflatedData, sceneModel) {
+function load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx) {
 
     sceneModel.positionsCompression = "disabled"; // Positions in XKT V4 are floats, which we never quantize, for precision with big models
     sceneModel.normalsCompression = "precompressed"; // Normals are oct-encoded though
@@ -234,10 +234,10 @@ function load(viewer, options, inflatedData, sceneModel) {
 /** @private */
 const ParserV5 = {
     version: 5,
-    parse: function (viewer, options, elements, sceneModel) {
+    parse: function (viewer, options, elements, sceneModel, metaModel, manifestCtx) {
         const deflatedData = extract(elements);
         const inflatedData = inflate(deflatedData);
-        load(viewer, options, inflatedData, sceneModel);
+        load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx);
     }
 };
 

--- a/src/plugins/XKTLoaderPlugin/parsers/ParserV6.js
+++ b/src/plugins/XKTLoaderPlugin/parsers/ParserV6.js
@@ -72,7 +72,7 @@ const decompressColor = (function () {
     };
 })();
 
-function load(viewer, options, inflatedData, sceneModel) {
+function load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx) {
 
     const positions = inflatedData.positions;
     const normals = inflatedData.normals;
@@ -101,8 +101,6 @@ function load(viewer, options, inflatedData, sceneModel) {
     const numPrimitiveInstances = primitiveInstances.length;
     const numEntities = eachEntityId.length;
     const numTiles = eachTileEntitiesPortion.length;
-
-    let nextMeshId = 0;
 
     // Count instances of each primitive
 
@@ -223,7 +221,7 @@ function load(viewer, options, inflatedData, sceneModel) {
                 const color = decompressColor(eachPrimitiveColorAndOpacity.subarray((primitiveIndex * 4), (primitiveIndex * 4) + 3));
                 const opacity = eachPrimitiveColorAndOpacity[(primitiveIndex * 4) + 3] / 255.0;
 
-                const meshId = nextMeshId++;
+                const meshId = manifestCtx.nextMeshId++;
 
                 if (isReusedPrimitive) {
 
@@ -291,10 +289,10 @@ function load(viewer, options, inflatedData, sceneModel) {
 /** @private */
 const ParserV6 = {
     version: 6,
-    parse: function (viewer, options, elements, sceneModel) {
+    parse: function (viewer, options, elements, sceneModel, metaModel, manifestCtx) {
         const deflatedData = extract(elements);
         const inflatedData = inflate(deflatedData);
-        load(viewer, options, inflatedData, sceneModel);
+        load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx);
     }
 };
 

--- a/src/plugins/XKTLoaderPlugin/parsers/ParserV7.js
+++ b/src/plugins/XKTLoaderPlugin/parsers/ParserV7.js
@@ -118,7 +118,7 @@ function convertColorsRGBToRGBA(colorsRGB) {
     return colorsRGBA;
 }
 
-function load(viewer, options, inflatedData, sceneModel) {
+function load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx) {
 
     const positions = inflatedData.positions;
     const normals = inflatedData.normals;
@@ -274,7 +274,7 @@ function load(viewer, options, inflatedData, sceneModel) {
                 const meshMetallic = eachMeshMaterial[(meshIndex * 6) + 4] / 255.0;
                 const meshRoughness = eachMeshMaterial[(meshIndex * 6) + 5] / 255.0;
 
-                const meshId = nextMeshId++;
+                const meshId = manifestCtx.nextMeshId++;
 
                 if (isReusedGeometry) {
 
@@ -427,10 +427,10 @@ function load(viewer, options, inflatedData, sceneModel) {
 /** @private */
 const ParserV7 = {
     version: 7,
-    parse: function (viewer, options, elements, sceneModel) {
+    parse: function (viewer, options, elements, sceneModel, metaModel, manifestCtx) {
         const deflatedData = extract(elements);
         const inflatedData = inflate(deflatedData);
-        load(viewer, options, inflatedData, sceneModel);
+        load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx);
     }
 };
 

--- a/src/plugins/XKTLoaderPlugin/parsers/ParserV9.js
+++ b/src/plugins/XKTLoaderPlugin/parsers/ParserV9.js
@@ -109,7 +109,7 @@ const decompressColor = (function () {
     };
 })();
 
-function load(viewer, options, inflatedData, sceneModel) {
+function load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx) {
 
     const metadata = inflatedData.metadata;
 
@@ -144,23 +144,8 @@ function load(viewer, options, inflatedData, sceneModel) {
     const numEntities = eachEntityMeshesPortion.length;
     const numTiles = eachTileEntitiesPortion.length;
 
-    let nextMeshId = 0;
-
-    // Create metamodel, unless already loaded from external JSON file by XKTLoaderPlugin
-
-    const metaModelId = sceneModel.id;
-
-    if (!viewer.metaScene.metaModels[metaModelId]) {
-
-        viewer.metaScene.createMetaModel(metaModelId, metadata, {
-            includeTypes: options.includeTypes,
-            excludeTypes: options.excludeTypes,
-            globalizeObjectIds: options.globalizeObjectIds
-        });
-
-        sceneModel.once("destroyed", () => {
-            viewer.metaScene.destroyMetaModel(metaModelId);
-        });
+    if (metaModel) {
+        metaModel.loadData(metadata); // Can be empty
     }
 
     // Count instances of each geometry
@@ -285,7 +270,7 @@ function load(viewer, options, inflatedData, sceneModel) {
                 const meshMetallic = eachMeshMaterial[(meshIndex * 6) + 4] / 255.0;
                 const meshRoughness = eachMeshMaterial[(meshIndex * 6) + 5] / 255.0;
 
-                const meshId = nextMeshId++;
+                const meshId = manifestCtx.nextMeshId++;
 
                 if (isReusedGeometry) {
 
@@ -517,10 +502,10 @@ function load(viewer, options, inflatedData, sceneModel) {
 /** @private */
 const ParserV9 = {
     version: 9,
-    parse: function (viewer, options, elements, sceneModel) {
+    parse: function (viewer, options, elements, sceneModel, metaModel, manifestCtx) {
         const deflatedData = extract(elements);
         const inflatedData = inflate(deflatedData);
-        load(viewer, options, inflatedData, sceneModel);
+        load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx);
     }
 };
 

--- a/src/viewer/metadata/MetaModel.js
+++ b/src/viewer/metadata/MetaModel.js
@@ -1,3 +1,7 @@
+import {PropertySet} from "./PropertySet";
+import {MetaObject} from "./MetaObject";
+import {math} from "../scene";
+
 /**
  * @desc Metadata corresponding to an {@link Entity} that represents a model.
  *
@@ -16,7 +20,12 @@
 class MetaModel {
 
     /**
-     * @private
+     * Creates a new, unfinalized MetaModel.
+     *
+     * * The MetaModel is immediately registered by {@link MetaModel#id} in {@link MetaScene#metaModels}, even though it's not yet populated.
+     * * The MetaModel then needs to be populated with one or more calls to {@link metaModel#loadData}.
+     * * As we populate it, the MetaModel will create {@link MetaObject}s and {@link PropertySet}s in itself, and in the MetaScene.
+     * * When populated, call {@link MetaModel#finalize} to finish it off, which causes MetaScene to fire a "metaModelCreated" event.
      */
     constructor(params) {
 
@@ -135,6 +144,133 @@ class MetaModel {
          * @type {{}}
          */
         this.graph = params.graph || {};
+
+        this.metaScene.metaModels[this.id] = this;
+
+        /**
+         * True when this MetaModel has been finalized.
+         * @type {boolean}
+         */
+        this.finalized = false;
+    }
+
+    /**
+     * Load metamodel data into this MetaModel.
+     * @param metaModelData
+     */
+    loadData(metaModelData, options={}) {
+
+        if (this.finalized) {
+            throw "MetaScene already finalized - can't add more data";
+        }
+
+        this._globalizeIDs(metaModelData, options)
+
+        const metaScene = this.metaScene;
+
+        // Create global Property Sets
+
+        if (metaModelData.propertySets) {
+            for (let i = 0, len = metaModelData.propertySets.length; i < len; i++) {
+                const propertySetData = metaModelData.propertySets[i];
+                let propertySet = metaScene.propertySets[propertySetData.id];
+                if (!propertySet) {
+                    propertySet = new PropertySet({
+                        id: propertySetData.id,
+                        originalSystemId: propertySetData.originalSystemId || propertySetData.id,
+                        type: propertySetData.type,
+                        name: propertySetData.name,
+                        properties: propertySetData.properties
+                    });
+                    metaScene.propertySets[propertySet.id] = propertySet;
+                }
+                propertySet.metaModels.push(this);
+                this.propertySets.push(propertySet);
+            }
+        }
+
+        if (metaModelData.metaObjects) {
+            for (let i = 0, len = metaModelData.metaObjects.length; i < len; i++) {
+                const metaObjectData = metaModelData.metaObjects[i];
+                const type = metaObjectData.type;
+                const id = metaObjectData.id;
+                const originalSystemId = metaObjectData.originalSystemId;
+                const propertySetIds = metaObjectData.propertySets || metaObjectData.propertySetIds;
+                let metaObject = metaScene.metaObjects[id];
+                if (!metaObject) {
+                    metaObject = new MetaObject({
+                        id,
+                        originalSystemId,
+                        parentId: metaObjectData.parent,
+                        type,
+                        name: metaObjectData.name,
+                        propertySetIds
+                    });
+                    this.metaScene.metaObjects[id] = metaObject;
+                }
+                metaObject.metaModels.push(this);
+                if (!metaObjectData.parent) {
+                    this.rootMetaObjects.push(metaObject);
+                    metaScene.rootMetaObjects[id] = metaObject;
+                }
+                this.metaObjects.push(metaObject);
+            }
+        }
+    }
+
+    finalize() {
+
+        if (this.finalized) {
+            throw "MetaScene already finalized - can't re-finalize";
+        }
+
+        // Re-link MetaScene's entire MetaObject parent/child hierarchy
+
+        const metaScene = this.metaScene;
+
+        for (let objectId in metaScene.metaObjects) {
+            const metaObject = metaScene.metaObjects[objectId];
+            if (metaObject.children) {
+                metaObject.children = [];
+            }
+
+            // Re-link each MetaObject's property sets
+
+            if (metaObject.propertySets) {
+                metaObject.propertySets = [];
+            }
+            if (metaObject.propertySetIds) {
+                for (let i = 0, len = metaObject.propertySetIds.length; i < len; i++) {
+                    const propertySetId = metaObject.propertySetIds[i];
+                    const propertySet = metaScene.propertySets[propertySetId];
+                    metaObject.propertySets.push(propertySet);
+                }
+            }
+        }
+
+        for (let objectId in metaScene.metaObjects) {
+            const metaObject = metaScene.metaObjects[objectId];
+            if (metaObject.parentId) {
+                const parentMetaObject = metaScene.metaObjects[metaObject.parentId];
+                if (parentMetaObject) {
+                    metaObject.parent = parentMetaObject;
+                    (parentMetaObject.children || (parentMetaObject.children = [])).push(metaObject);
+                }
+            }
+        }
+
+        // Rebuild MetaScene's MetaObjects-by-type lookup
+
+        metaScene.metaObjectsByType = {};
+        for (let objectId in metaScene.metaObjects) {
+            const metaObject = metaScene.metaObjects[objectId];
+            const type = metaObject.type;
+            (metaScene.metaObjectsByType[type] || (metaScene.metaObjectsByType[type] = {}))[objectId] = metaObject;
+        }
+
+        this.finalized = true;
+
+        this.metaScene.fire("metaModelCreated", this.id);
     }
 
     getJSON() {
@@ -169,6 +305,54 @@ class MetaModel {
             metaObjects: metaObjects
         };
         return json;
+    }
+
+    _globalizeIDs(metaModelData, options) {
+
+        const globalize = !!options.globalizeObjectIds;
+
+        if (metaModelData.metaObjects) {
+            for (let i = 0, len = metaModelData.metaObjects.length; i < len; i++) {
+                const metaObjectData = metaModelData.metaObjects[i];
+
+                // Globalize MetaObject IDs and parent IDs
+
+                metaObjectData.originalSystemId = metaObjectData.id;
+                metaObjectData.originalParentSystemId = metaObjectData.parent;
+                if (globalize) {
+                    metaObjectData.id = math.globalizeObjectId(this.id, metaObjectData.id);
+                    metaObjectData.parent = math.globalizeObjectId(this.id, metaObjectData.parent);
+                }
+
+                // Globalize MetaObject property set IDs
+
+                if (globalize) {
+                    const propertySetIds = metaObjectData.propertySetIds;
+                    if (propertySetIds) {
+                        const propertySetGlobalIds = [];
+                        for (let j = 0, lenj = propertySetIds.length; j < lenj; j++) {
+                            propertySetGlobalIds.push(math.globalizeObjectId(this.id, propertySetIds[j]));
+                        }
+                        metaObjectData.propertySetIds = propertySetGlobalIds;
+                        metaObjectData.originalSystemPropertySetIds = propertySetIds;
+                    }
+                } else {
+                    metaObjectData.originalSystemPropertySetIds = metaObjectData.propertySetIds;
+                }
+            }
+        }
+
+        // Globalize global PropertySet IDs
+
+        if (metaModelData.propertySets) {
+            for (let i = 0, len = metaModelData.propertySets.length; i < len; i++) {
+                const propertySet = metaModelData.propertySets[i];
+                propertySet.originalSystemId = propertySet.id;
+                if (globalize) {
+                    propertySet.id = math.globalizeObjectId(mothis.id, propertySet.id);
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
# Extend XKTLoaderPlugin to load a model split into multiple XKT files, in one shot

The `ifc2gltf` tool from Creoox, which converts IFC files into glTF geometry and JSON metadata files, has the option to
split its output into multiple pairs of glTF and JSON files, accompanied by a JSON manifest that lists the files.

To integrate with that option, the `convert2xkt` tool, which converts glTF geometry and JSON metadata files into XKT files,
also has the option to batch-convert the glTF+JSON files in the manifest, in one invocation.

When we use this option, convert2xkt will output a bunch of XKT files, along with a JSON manifest file that lists those XKT files.

Working down the pipeline, the XKTLoaderPlugin has the option batch-load all XKT files listed in that manifest
into a xeokit Viewer in one load operation, combining the XKT files into a single SceneModel and MetaModel.

You can learn more about this conversion and loading process, with splitting, batch converting and batch loading,
in [this tutorial](https://www.notion.so/xeokit/Importing-Huge-IFC-Models-as-Multiple-XKT-Files-165fc022e94742cf966ee50003572259).

To show how to use XKTLoaderPlugin to load a manifest of XKT files, let's imagine that we have a set of such XKT files. As
described in the tutorial, they were converted by `ifc2gltf` from an IFC file into a set of glTF+JSON files, that were
then converted by convert2xkt into this set of XKT files and a manifest, as shown below.

````bash
./
├── model_1.xkt
├── model_2.xkt
├── model_3.xkt
├── model_4..xkt
└── model.xkt.manifest.json
````

The `model.xkt.manifest.json` XKT manifest would look something like this:

````json
{
  "inputFile": null,
  "converterApplication": "convert2xkt",
  "converterApplicationVersion": "v1.1.9",
  "conversionDate": "10-08-2023- 02-05-01",
  "outputDir": null,
  "xktFiles": [
    "model_1.xkt",
    "model_2.xkt",
    "model_3.xkt",
    "model_4.xkt"
  ]
}
````

Now, to load all those XKT files into a single SceneModel and MetaModel in one operation, we pass a path to the XKT
manifest to `XKTLoaderPlugin.load`, as shown in the example below:

````javascript
import {
  Viewer,
  XKTLoaderPlugin,
  TreeViewPlugin,
} from "xeokit-sdk.es.js";

constviewer = new Viewer({
  canvasId: "myCanvas"
});

viewer.scene.camera.eye = [26.54, 29.29, 36.20,];
viewer.scene.camera.look = [-23.51, -8.26, -21.65,];
viewer.scene.camera.up = [-0.2, 0.89, -0.33,];

const xktLoader = new XKTLoaderPlugin(viewer);

const sceneModel = xktLoader.load({
  manifestSrc: "model.xkt.manifest.json",
  id: "myModel",
});

const metaModel = viewer.metaScene.metaModels[sceneModel.id];

// Then when we need to, we can destroy the SceneModel
// and MetaModel in one shot, like so:

sceneModel.destroy();
metaModel.destroy();
````

The main advantage here, of splitting IFC files like this within the conversion and import pipeline,
is to reduce the memory pressure on each of the `ifc2gltf`, `convert2xkt` and XKTLoaderPlugin components.
They work much reliably (and faster) when processing smaller files (eg. 20MB) than when processing large files (eg. 500MB), where they have less trouble allocating the system memory they need for conversion and parsing.