### PR TITLE
Fix XKT 9 globalize IDs

### DIFF
--- a/src/plugins/XKTLoaderPlugin/parsers/ParserV9.js
+++ b/src/plugins/XKTLoaderPlugin/parsers/ParserV9.js
@@ -147,7 +147,11 @@ function load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx)
     const numTiles = eachTileEntitiesPortion.length;
 
     if (metaModel) {
-        metaModel.loadData(metadata); // Can be empty
+        metaModel.loadData(metadata, {
+            includeTypes: options.includeTypes,
+            excludeTypes: options.excludeTypes,
+            globalizeObjectIds: options.globalizeObjectIds
+        }); // Can be empty
     }
 
     // Count instances of each geometry


### PR DESCRIPTION
Fixes the `globalizeObjectIds` option for `XKTLoaderPlugin` when loading XKT v9.