### PR TITLE
feature: add dual snap mode => vertex + edge

### DIFF
--- a/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsControl.js
+++ b/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsControl.js
@@ -144,8 +144,11 @@ class DistanceMeasurementsControl extends Component {
                 this.markerDiv.style.marginLeft = `${event.canvasPos[0] - 5}px`;
                 this.markerDiv.style.marginTop = `${event.canvasPos[1] - 5}px`;
                 this.markerDiv.style.background = "pink";
-                if (event.snappedToVertex || event.snappedToEdge) {
+                if (event.snapType === "vertex") {
                     this.markerDiv.style.background = "greenyellow";
+                    this.markerDiv.style.border ="2px solid green";
+                } else if (event.snapType === "edge") {
+                    this.markerDiv.style.background = "lightblue";
                     this.markerDiv.style.border ="2px solid green";
                 } else {
                     this.markerDiv.style.background = "pink";

--- a/src/viewer/scene/CameraControl/CameraControl.js
+++ b/src/viewer/scene/CameraControl/CameraControl.js
@@ -16,6 +16,8 @@ import {math} from "../math/math.js";
 import {TouchPickHandler} from "./lib/handlers/TouchPickHandler.js";
 
 const DEFAULT_SNAP_PICK_RADIUS = 30;
+const DEFAULT_SNAP_VERTEX = true;
+const DEFAULT_SNAP_EDGE = true;
 
 /**
  * @desc Controls the {@link Camera} with user input, and fires events when the user interacts with pickable {@link Entity}s.
@@ -643,7 +645,8 @@ class CameraControl extends Component {
             smartPivot: false,
             doubleClickTimeFrame: 250,
             
-            snapMode: "vertex",
+            snapVertex: DEFAULT_SNAP_VERTEX,
+            snapEdge: DEFAULT_SNAP_EDGE,
             snapRadius: DEFAULT_SNAP_PICK_RADIUS,
 
             // Rotation
@@ -897,32 +900,39 @@ class CameraControl extends Component {
     }
 
     /**
-     * Sets the current snap mode for "hoverSnapOrSurface" events, to specify whether the pointer
-     * snaps to the nearest vertex or the nearest edge.
+     * Sets whether the pointer snap to vertex.
      *
-     * Accepted values are:
-     *
-     * * "vertex" - (default) snap to the nearest vertex, or
-     * * "edge" - snap to the nearest edge.
-     *
-     * @param {String} snapMode The snap mode: "vertex" or "edge".
+     * @param {boolean} snapVertex
      */
-    set snapMode(snapMode) {
-        snapMode = snapMode || "vertex";
-        if (snapMode !== "vertex" && snapMode !== "edge") {
-            this.error("Unsupported value for snapMode: " + snapMode + " - supported values are 'vertex' and 'edge' - defaulting to 'vertex'");
-            snapMode = "vertex";
-        }
-        this._configs.snapMode = snapMode;
+    set snapVertex(snapVertex) {
+        this._configs.snapVertex = !!snapVertex;
     }
 
     /**
-     * Gets the current snap mode.
+     * Gets whether the pointer snap to vertex.
      *
-     * @returns {String} The snap mode: "vertex" or "edge".
+     * @returns {boolean}
      */
-    get snapMode() {
-        return this._configs.snapMode;
+    get snapVertex() {
+        return this._configs.snapVertex;
+    }
+
+    /**
+     * Sets whether the pointer snap to edge.
+     *
+     * @param {boolean} snapEdge
+     */
+    set snapEdge(snapEdge) {
+        this._configs.snapEdge = !!snapEdge;
+    }
+
+    /**
+     * Gets whether the pointer snap to edge.
+     *
+     * @returns {boolean}
+     */
+    get snapEdge() {
+        return this._configs.snapEdge;
     }
 
     /**

--- a/src/viewer/scene/CameraControl/lib/controllers/PickController.js
+++ b/src/viewer/scene/CameraControl/lib/controllers/PickController.js
@@ -98,7 +98,8 @@ class PickController {
             const snapPickResult = this._scene.snapPick({
                 canvasPos: this.pickCursorPos,
                 snapRadius: this._configs.snapRadius,
-                snapMode: this._configs.snapMode,
+                snapVertex: this._configs.snapVertex,
+                snapEdge: this._configs.snapEdge,
             });
             if (snapPickResult && snapPickResult.snappedWorldPos) {
                 this.snapPickResult = snapPickResult;
@@ -198,11 +199,7 @@ class PickController {
                 const pickResult = new PickResult();
                 pickResult.worldPos = this.snapPickResult.snappedWorldPos;
                 pickResult.canvasPos = this.snapPickResult.snappedCanvasPos;
-                if (this._configs.snapMode === "vertex") {
-                    pickResult.snappedToVertex = true;
-                } else {
-                    pickResult.snappedToEdge = true;
-                }
+                pickResult.snapType = this.snapPickResult.snapType;
                 this._cameraControl.fire("hoverSnapOrSurface", pickResult, true);
                 this.snapPickResult = null;
             } else {

--- a/src/viewer/scene/scene/Scene.js
+++ b/src/viewer/scene/scene/Scene.js
@@ -2216,13 +2216,15 @@ class Scene extends Component {
      * @param {Object} params Picking parameters.
      * @param {Number[]} [params.canvasPos] Canvas-space coordinates. When ray-picking, this will override the **origin** and ** direction** parameters and will cause the ray to be fired through the canvas at this position, directly along the negative View-space Z-axis.
      * @param {Number} [params.snapRadius=30] The snap radius, in canvas pixels
-     * @param {"vertex"|"edge"} [params.snapMode="vertex"] Whether to snap to vertex or edge.
+     * @param {boolean} [params.snapVertex=true] Whether to snap to vertex.
+     * @param {boolean} [params.snapEdge=true] Whether to snap to edge.
      */
     snapPick(params) {
         return this._renderer.snapPick(
             params.canvasPos,
             params.snapRadius || 30,
-            params.snapMode || "vertex"
+            params.snapVertex,
+            params.snapEdge,
         );
     }
 

--- a/src/viewer/scene/webgl/PickResult.js
+++ b/src/viewer/scene/webgl/PickResult.js
@@ -49,16 +49,10 @@ class PickResult {
         this.touchInput = false;
 
         /**
-         * True when snapped to the nearest vertex position.
-         * @type {boolean}
+         * "vertex" or "edge" when snapped to the nearest vertex or edge position.
+         * @type {"vertex"|"edge"}
          */
-        this.snappedToVertex = false;
-
-        /**
-         * True when snapped to the nearest edge.
-         * @type {boolean}
-         */
-        this.snappedToEdge = false;
+        this.snapType = null;
 
         this._canvasPos = new Int16Array([0, 0]);
         this._origin = new Float64Array([0, 0, 0]);
@@ -331,8 +325,7 @@ class PickResult {
         this._gotWorldNormal = false;
         this._gotUV = false;
         this.touchInput = false;
-        this.snappedToVertex = false;
-        this.snappedToEdge = false;
+        this.snapType = null;
     }
 }
 


### PR DESCRIPTION
This PR adds the ability to snap vertex AND edge. If both are found, vertex are snapped with higher priority. The main purpose of this changes is to do this dual snap picking with only one depth buffer initialisation to improve performance in comparaison of doing two snap picking simultaneously with different snap mode.

![dualSnap](https://github.com/xeokit/xeokit-sdk/assets/22523482/b4fcbe53-bc9a-43ab-870e-d782fcca2fc3)

**API changes** : (BEAKING CHANGES)

- `snapMode` is only used as `frameCtx` property.
- CameraControl now has `snapVertex: boolean` & `snapEdge: boolean` properties instead of `snapMode`. (In case of both are `false`, the snapPick falls back to a regular pick with `canvasPos` and `pickSurface: true`)
- scene.snapPick accept `snapVertex: boolean` & `snapEdge: boolean` arguments instead of `snapMode`.
- `pickResult` has `snapType`: null|"vertex"|"edge" property instead of `snappedToVertex: boolean` & `snappedToEdge: boolean`.

**Implementation** :

Only `Renderer` logic, no shader update. No changes for mono type snap (only vertex or only edge).

On dual type snap, `frameCtx.snapPickLayerParams` stores empty x 1 then the edge layer params first, then empty x 1, then the vertex layer params. The empty x 1 is because the `w` of the drawn snap color is 0 if no snap, and if !== 0, represents the layer params number. The second empty x 1 is to make this line works fine (done by the `frameCtx.snapPickLayerNumber++` between the two `snapPickDrawSnapDepths` calls):

```js
const pickedLayerParmasSurface = layerParamsSurface[Math.abs(pickResultMiddleXY[3]) % layerParamsSurface.length];
```

Indeed, if `layerParamsSurface` has a length of 10, pickResultMiddleXY[3] can be 12 if a vertex snap was drawn but thanks to the % it falls back to the 2 index and layerParamsSurface[foundIndex] is not `undefined`.

Then, this line allow to know if the snap pick is a vertex pick or an edge pick:

```js
const isVertex = snapVertex && snapEdge ? snapPickResultArray[i + 3] > layerParamsSnap.length / 2 : snapVertex,
```

Has edge pick are stored on the first half of the `layerParamsSnap` array and vertex pick on the last half.

**To go further**

In case of a snapPick in center position, the previous implementation got the `pickedLayerParmasSurface` from the `layerParamsSurface` (see [here](https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/scene/webgl/Renderer.js#L1357)) array which is not correct as snap pick params are stored in the `layerParamsSnap` array. But if this is fine, the `layerParamsSnap` may not be really needed as it is the same values as the `layerParamsSurface` array. It may be interesting to simplify this code to only use the `layerParamsSurface` array.