### PR TITLE
Update node.js import to make them es compatible

### DIFF
--- a/src/plugins/GLTFLoaderPlugin/GLTFLoaderPlugin.js
+++ b/src/plugins/GLTFLoaderPlugin/GLTFLoaderPlugin.js
@@ -2,7 +2,7 @@ import {Plugin, SceneModel, utils} from "../../viewer/index.js"
 import {GLTFSceneModelLoader} from "./GLTFSceneModelLoader.js";
 
 import {GLTFDefaultDataSource} from "./GLTFDefaultDataSource.js";
-import {IFCObjectDefaults} from "../../viewer/metadata/IFCObjectDefaults";
+import {IFCObjectDefaults} from "../../viewer/metadata/IFCObjectDefaults.js";
 
 /**
  * {@link Viewer} plugin that loads models from [glTF](https://www.khronos.org/gltf/).

--- a/src/viewer/metadata/MetaModel.js
+++ b/src/viewer/metadata/MetaModel.js
@@ -1,6 +1,6 @@
-import {PropertySet} from "./PropertySet";
-import {MetaObject} from "./MetaObject";
-import {math} from "../scene";
+import {PropertySet} from "./PropertySet.js";
+import {MetaObject} from "./MetaObject.js";
+import {math} from "../scene/math/math.js";
 
 /**
  * @desc Metadata corresponding to an {@link Entity} that represents a model.

--- a/src/viewer/scene/index.js
+++ b/src/viewer/scene/index.js
@@ -19,5 +19,5 @@ export * from "./Component.js";
 export * from "./utils.js";
 export * from "./stats.js";
 export * from "./constants/constants.js";
-export * from "./lod";
-export * from "./vfc";
+export * from "./lod/index.js";
+export * from "./vfc/index.js";

--- a/src/viewer/scene/lod/LOD.js
+++ b/src/viewer/scene/lod/LOD.js
@@ -1,5 +1,5 @@
-import {Component} from "../Component";
-import {LODCullingManager} from "./LODCullingManager";
+import {Component} from "../Component.js";
+import {LODCullingManager} from "./LODCullingManager.js";
 
 /**
  * Manages LOD culling for {@link SceneModel} implementations.

--- a/src/viewer/scene/lod/LODCullingManager.js
+++ b/src/viewer/scene/lod/LODCullingManager.js
@@ -1,4 +1,4 @@
-import {LODState} from "./LODState";
+import {LODState} from "./LODState.js";
 
 /**
  * @private

--- a/src/viewer/scene/lod/LODState.js
+++ b/src/viewer/scene/lod/LODState.js
@@ -5,7 +5,7 @@
  *
  * @private
  */
-import {math} from "../math";
+import {math} from "../math/math.js";
 
 export class LODState {
 

--- a/src/viewer/scene/marker/Marker.js
+++ b/src/viewer/scene/marker/Marker.js
@@ -1,7 +1,7 @@
 import {math} from '../math/math.js';
 import {Component} from '../Component.js';
 import {worldToRTCPos} from "../math/rtcCoords.js";
-import {SceneModelEntity} from "../model/SceneModelEntity";
+import {SceneModelEntity} from "../model/SceneModelEntity.js";
 
 const tempVec4a = math.vec4();
 const tempVec4b = math.vec4();

--- a/src/viewer/scene/model/SceneModel.js
+++ b/src/viewer/scene/model/SceneModel.js
@@ -31,11 +31,11 @@ import {
     sRGBEncoding
 } from "../constants/constants.js";
 import {createPositionsDecodeMatrix, quantizePositions} from "./compression.js";
-import {uniquifyPositions} from "./dtx/triangles/calculateUniquePositions";
-import {rebucketPositions} from "./dtx/triangles/rebucketPositions";
-import {TrianglesDataTextureLayer} from "./dtx/triangles/TrianglesDataTextureLayer";
-import {SceneModelEntity} from "./SceneModelEntity";
-import {geometryCompressionUtils} from "../math/geometryCompressionUtils";
+import {uniquifyPositions} from "./dtx/triangles/calculateUniquePositions.js";
+import {rebucketPositions} from "./dtx/triangles/rebucketPositions.js";
+import {TrianglesDataTextureLayer} from "./dtx/triangles/TrianglesDataTextureLayer.js";
+import {SceneModelEntity} from "./SceneModelEntity.js";
+import {geometryCompressionUtils} from "../math/geometryCompressionUtils.js";
 
 const tempVec3a = math.vec3();
 const tempMat4 = math.mat4();

--- a/src/viewer/scene/model/dtx/triangles/DataTextureGenerator.js
+++ b/src/viewer/scene/model/dtx/triangles/DataTextureGenerator.js
@@ -1,6 +1,6 @@
-import {createRTCViewMat, math} from "../../../math";
-import {BindableDataTexture} from "./BindableDataTexture";
-import {dataTextureRamStats} from "./dataTextureRamStats";
+import {createRTCViewMat, math} from "../../../math/index.js";
+import {BindableDataTexture} from "./BindableDataTexture.js";
+import {dataTextureRamStats} from "./dataTextureRamStats.js";
 
 /**
  * @private

--- a/src/viewer/scene/model/dtx/triangles/TrianglesDataTextureLayer.js
+++ b/src/viewer/scene/model/dtx/triangles/TrianglesDataTextureLayer.js
@@ -6,8 +6,8 @@ import {geometryCompressionUtils} from "../../../math/geometryCompressionUtils.j
 import {getDataTextureRenderers} from "./TrianglesDataTextureRenderers.js";
 import {TrianglesDataTextureBuffer} from "./TrianglesDataTextureBuffer.js";
 import {DataTextureState} from "./DataTextureState.js"
-import {DataTextureGenerator} from "./DataTextureGenerator";
-import {dataTextureRamStats} from "./dataTextureRamStats";
+import {DataTextureGenerator} from "./DataTextureGenerator.js";
+import {dataTextureRamStats} from "./dataTextureRamStats.js";
 
 /**
  * 12-bits allowed for object ids.

--- a/src/viewer/scene/model/dtx/triangles/renderers/TrianglesDataTextureSnapDepthBufInitRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/TrianglesDataTextureSnapDepthBufInitRenderer.js
@@ -1,6 +1,6 @@
 import {Program} from "../../../../webgl/Program.js";
 import {math} from "../../../../math/math.js";
-import {createRTCViewMat, getPlaneRTCPos} from "../../../../math";
+import {createRTCViewMat, getPlaneRTCPos} from "../../../../math/index.js";
 
 const tempVec3a = math.vec3();
 const tempVec3b = math.vec3();

--- a/src/viewer/scene/model/vbo/trianglesBatching/TrianglesBatchingLayer.js
+++ b/src/viewer/scene/model/vbo/trianglesBatching/TrianglesBatchingLayer.js
@@ -8,7 +8,7 @@ import {geometryCompressionUtils} from "../../../math/geometryCompressionUtils.j
 import {getBatchingRenderers} from "./TrianglesBatchingRenderers.js";
 import {TrianglesBatchingBuffer} from "./TrianglesBatchingBuffer.js";
 import {quantizePositions, transformAndOctEncodeNormals} from "../../compression.js";
-import {getSnapBatchingRenderers} from "../snapBatching/SnapBatchingRenderers";
+import {getSnapBatchingRenderers} from "../snapBatching/SnapBatchingRenderers.js";
 
 const tempMat4 = math.mat4();
 const tempMat4b = math.mat4();

--- a/src/viewer/scene/model/vbo/trianglesInstancing/TrianglesInstancingLayer.js
+++ b/src/viewer/scene/model/vbo/trianglesInstancing/TrianglesInstancingLayer.js
@@ -5,7 +5,7 @@ import {math} from "../../../math/math.js";
 import {RenderState} from "../../../webgl/RenderState.js";
 import {ArrayBuf} from "../../../webgl/ArrayBuf.js";
 import {getInstancingRenderers} from "./TrianglesInstancingRenderers.js";
-import {getSnapInstancingRenderers} from "../snapInstancing/SnapInstancingRenderers";
+import {getSnapInstancingRenderers} from "../snapInstancing/SnapInstancingRenderers.js";
 
 const tempUint8Vec4 = new Uint8Array(4);
 const tempFloat32 = new Float32Array(1);

--- a/src/viewer/scene/scene/Scene.js
+++ b/src/viewer/scene/scene/Scene.js
@@ -19,7 +19,7 @@ import {SAO} from "../postfx/SAO.js";
 import {PointsMaterial} from "../materials/PointsMaterial.js";
 import {LinesMaterial} from "../materials/LinesMaterial.js";
 import {LOD} from "../lod/LOD.js";
-import {VFC} from "../vfc/VFC";
+import {VFC} from "../vfc/VFC.js";
 
 // Enables runtime check for redundant calls to object state update methods, eg. Scene#_objectVisibilityUpdated
 const ASSERT_OBJECT_STATE_UPDATE = false;

--- a/src/viewer/scene/vfc/VFC.js
+++ b/src/viewer/scene/vfc/VFC.js
@@ -1,5 +1,5 @@
-import {Component} from "../Component";
-import {VFCManager} from "./VFCManager";
+import {Component} from "../Component.js";
+import {VFCManager} from "./VFCManager.js";
 
 /**
  * Manages view frustum culling (VFC) for {@link SceneModel} implementations.

--- a/src/viewer/scene/vfc/VFCManager.js
+++ b/src/viewer/scene/vfc/VFCManager.js
@@ -1,4 +1,4 @@
-import {VFCState} from "./VFCState";
+import {VFCState} from "./VFCState.js";
 
 /**
  * @private

--- a/src/viewer/scene/vfc/VFCState.js
+++ b/src/viewer/scene/vfc/VFCState.js
@@ -1,5 +1,5 @@
-import {clusterizeV2} from "./cluster-helper";
-import {math} from "../math";
+import {clusterizeV2} from "./cluster-helper.js";
+import {math} from "../math/math.js";
 
 const tempVec3 = math.vec3();
 


### PR DESCRIPTION
While testing new stuffs on the repo, I use to test examples with a web server (vscode live server) while updating the import of the xeokit sdk from `dist` to `src`. However, a lot of import are not web compatible but node.js compatible. Because of that, it is a pain to serve the examples without a bundler.

This PR aims to ensure the maximum of import are web compatible (some of theme like html2canvas needs to be processed by a bundler or commented to let the viewer start on the browser with the dev server).