### PR TITLE
Improve vbo scene model snap pick performance

### DIFF
--- a/src/viewer/scene/model/vbo/VBOSceneModelRenderers.js
+++ b/src/viewer/scene/model/vbo/VBOSceneModelRenderers.js
@@ -351,14 +351,14 @@ class VBOSceneModelRenderer {
 
         }
 
-        this._aPosition.bindArrayBuffer(this._instancing ? state.positionsBuf : state.positionsBuf);
+        this._aPosition.bindArrayBuffer(state.positionsBuf);
 
         if (this._aUV) {
-            this._aUV.bindArrayBuffer(this._instancing ? state.uvBuf : state.uvBuf);
+            this._aUV.bindArrayBuffer(state.uvBuf);
         }
 
         if (this._aNormal) {
-            this._aNormal.bindArrayBuffer(this._instancing ? state.normalsBuf : state.normalsBuf);
+            this._aNormal.bindArrayBuffer(state.normalsBuf);
         }
 
         if (this._aMetallicRoughness) {
@@ -369,7 +369,7 @@ class VBOSceneModelRenderer {
         }
 
         if (this._aColor) {
-            this._aColor.bindArrayBuffer(state.colorsBuf ? state.colorsBuf : state.colorsBuf);
+            this._aColor.bindArrayBuffer(state.colorsBuf);
             if (this._instancing && state.colorsBuf) {
                 gl.vertexAttribDivisor(this._aColor.location, 1);
             }
@@ -521,7 +521,7 @@ class VBOSceneModelRenderer {
         }
 
         if (this._uUVDecodeMatrix) {
-            gl.uniformMatrix3fv(this._uUVDecodeMatrix, false, this._instancing ? state.uvDecodeMatrix : state.uvDecodeMatrix);
+            gl.uniformMatrix3fv(this._uUVDecodeMatrix, false, state.uvDecodeMatrix);
         }
 
         if (this._uIntensityRange && pointsMaterial.filterIntensity) {
@@ -793,6 +793,7 @@ class VBOSceneModelLineInstancingRenderer extends VBOSceneModelRenderer {
 }
 
 export {
+    VBOSceneModelRenderer,
     VBOSceneModelTriangleBatchingRenderer,
     VBOSceneModelTriangleBatchingEdgesRenderer,
     VBOSceneModelTriangleInstancingRenderer,

--- a/src/viewer/scene/model/vbo/snapBatching/SnapBatchingDepthBufInitRenderer.js
+++ b/src/viewer/scene/model/vbo/snapBatching/SnapBatchingDepthBufInitRenderer.js
@@ -1,12 +1,11 @@
-import {Program} from "../../../webgl/Program.js";
-import {createRTCViewMat, getPlaneRTCPos} from "../../../math/rtcCoords.js";
+import {VBOSceneModelRenderer} from "../VBOSceneModelRenderers.js";
+import {createRTCViewMat} from "../../../math/rtcCoords.js";
 import {math} from "../../../math/math.js";
 
 const tempVec3a = math.vec3();
 const tempVec3b = math.vec3();
 const tempVec3c = math.vec3();
 const tempVec3d = math.vec3();
-const tempVec3e = math.vec3();
 const tempMat4a = math.mat4();
 
 const SNAPPING_LOG_DEPTH_BUF_ENABLED = true; // Improves occlusion accuracy at distance
@@ -14,22 +13,7 @@ const SNAPPING_LOG_DEPTH_BUF_ENABLED = true; // Improves occlusion accuracy at d
 /**
  * @private
  */
-export class SnapBatchingDepthBufInitRenderer {
-
-    constructor(scene) {
-        this._scene = scene;
-        this._hash = this._getHash();
-        this._allocate();
-    }
-
-    getValid() {
-        return this._hash === this._getHash();
-    };
-
-    _getHash() {
-        return this._scene._sectionPlanesState.getHash();
-    }
-
+export class SnapBatchingDepthBufInitRenderer extends VBOSceneModelRenderer {
     drawLayer(frameCtx, batchingLayer, renderPass) {
 
         if (!this._program) {
@@ -53,6 +37,12 @@ export class SnapBatchingDepthBufInitRenderer {
         const {position, rotationMatrix, rotationMatrixConjugate} = model;
         const aabb = batchingLayer.aabb;
         const viewMatrix = frameCtx.pickViewMatrix || camera.viewMatrix;
+
+        if (this._vaoCache.has(batchingLayer)) {
+            gl.bindVertexArray(this._vaoCache.get(batchingLayer));
+        } else {
+            this._vaoCache.set(batchingLayer, this._makeVAO(state))
+        }
 
         const coordinateScaler = tempVec3a;
         coordinateScaler[0] = math.safeInv(aabb[3] - aabb[0]) * math.MAX_INT;
@@ -105,80 +95,43 @@ export class SnapBatchingDepthBufInitRenderer {
         gl.uniform3fv(this._uCoordinateScaler, coordinateScaler);
         gl.uniform1i(this._uRenderPass, renderPass);
         gl.uniform1i(this._uPickInvisible, frameCtx.pickInvisible);
-        gl.uniform1i(this._uSolid, batchingLayer.solid);
-        gl.uniformMatrix4fv(this._uWorldMatrix, false, rotationMatrixConjugate);
-        gl.uniformMatrix4fv(this._uViewMatrix, false, rtcViewMatrix);
-        gl.uniformMatrix4fv(this._uProjMatrix, false, camera.projMatrix);
+
+        let offset = 0;
+        const mat4Size = 4 * 4;
+
+        this._matricesUniformBlockBufferData.set(rotationMatrixConjugate, 0);
+        this._matricesUniformBlockBufferData.set(rtcViewMatrix, offset += mat4Size);
+        this._matricesUniformBlockBufferData.set(camera.projMatrix, offset += mat4Size);
+        this._matricesUniformBlockBufferData.set(state.positionsDecodeMatrix, offset += mat4Size);
+
+        gl.bindBuffer(gl.UNIFORM_BUFFER, this._matricesUniformBlockBuffer);
+        gl.bufferData(gl.UNIFORM_BUFFER, this._matricesUniformBlockBufferData, gl.DYNAMIC_DRAW);
+
+        gl.bindBufferBase(
+            gl.UNIFORM_BUFFER,
+            this._matricesUniformBlockBufferBindingPoint,
+            this._matricesUniformBlockBuffer);
+
         if (SNAPPING_LOG_DEPTH_BUF_ENABLED) {
             const logDepthBufFC = 2.0 / (Math.log(frameCtx.pickZFar + 1.0) / Math.LN2); // TODO: Far from pick project matrix?
             gl.uniform1f(this._uLogDepthBufFC, logDepthBufFC);
         }
-        const numSectionPlanes = scene._sectionPlanesState.sectionPlanes.length;
-        if (numSectionPlanes > 0) {
-            const sectionPlanes = scene._sectionPlanesState.sectionPlanes;
-            const baseIndex = batchingLayer.layerIndex * numSectionPlanes;
-            const renderFlags = model.renderFlags;
-            for (let sectionPlaneIndex = 0; sectionPlaneIndex < numSectionPlanes; sectionPlaneIndex++) {
-                const sectionPlaneUniforms = this._uSectionPlanes[sectionPlaneIndex];
-                if (sectionPlaneUniforms) {
-                    const active = renderFlags.sectionPlanesActivePerLayer[baseIndex + sectionPlaneIndex];
-                    gl.uniform1i(sectionPlaneUniforms.active, active ? 1 : 0);
-                    if (active) {
-                        const sectionPlane = sectionPlanes[sectionPlaneIndex];
-                        if (origin) {
-                            const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3e);
-                            gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
-                        } else {
-                            gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);
-                        }
-                        gl.uniform3fv(sectionPlaneUniforms.dir, sectionPlane.dir);
-                    }
-                }
-            }
-        }
+
+        this.setSectionPlanesStateUniforms(batchingLayer);
         //=============================================================
         // TODO: Use drawElements count and offset to draw only one entity
         //=============================================================
-        gl.uniformMatrix4fv(this._uPositionsDecodeMatrix, false, batchingLayer._state.positionsDecodeMatrix);
-        this._aPosition.bindArrayBuffer(state.positionsBuf);
-        if (this._aOffset) {
-            this._aOffset.bindArrayBuffer(state.offsetsBuf);
-        }
-        if (this._aFlags) {
-            this._aFlags.bindArrayBuffer(state.flagsBuf);
-        }
+
         state.indicesBuf.bind();
         gl.drawElements(gl.TRIANGLES, state.indicesBuf.numItems, state.indicesBuf.itemType, 0);
         state.indicesBuf.unbind();
     }
 
     _allocate() {
-        const scene = this._scene;
-        const gl = scene.canvas.gl;
-        this._program = new Program(gl, this._buildShader());
-        if (this._program.errors) {
-            this.errors = this._program.errors;
-            return;
-        }
+        super._allocate();
+
         const program = this._program;
-        this._uRenderPass = program.getLocation("renderPass");
-        this._uPickInvisible = program.getLocation("pickInvisible");
-        this._uSolid = program.getLocation("solid");
-        this._uPositionsDecodeMatrix = program.getLocation("positionsDecodeMatrix");
-        this._uWorldMatrix = program.getLocation("worldMatrix");
-        this._uViewMatrix = program.getLocation("viewMatrix");
-        this._uProjMatrix = program.getLocation("projMatrix");
-        this._uSectionPlanes = [];
-        for (let i = 0, len = scene._sectionPlanesState.sectionPlanes.length; i < len; i++) {
-            this._uSectionPlanes.push({
-                active: program.getLocation("sectionPlaneActive" + i),
-                pos: program.getLocation("sectionPlanePos" + i),
-                dir: program.getLocation("sectionPlaneDir" + i)
-            });
-        }
-        this._aPosition = program.getAttribute("position");
-        this._aOffset = program.getAttribute("offset");
-        this._aFlags = program.getAttribute("flags");
+
         if (SNAPPING_LOG_DEPTH_BUF_ENABLED) {
             this._uLogDepthBufFC = program.getLocation("logDepthBufFC");
         }
@@ -191,13 +144,6 @@ export class SnapBatchingDepthBufInitRenderer {
 
     _bindProgram() {
         this._program.bind();
-    }
-
-    _buildShader() {
-        return {
-            vertex: this._buildVertexShader(),
-            fragment: this._buildFragmentShader()
-        };
     }
 
     _buildVertexShader() {
@@ -226,11 +172,9 @@ export class SnapBatchingDepthBufInitRenderer {
         }
         src.push("in float flags;");
         src.push("uniform bool pickInvisible;");
-        src.push("uniform bool solid;");
-        src.push("uniform mat4 worldMatrix;");
-        src.push("uniform mat4 viewMatrix;");
-        src.push("uniform mat4 projMatrix;");
-        src.push("uniform mat4 positionsDecodeMatrix;");
+
+        this._addMatricesUniformBlockLines(src);
+
         src.push("uniform vec3 uCameraEyeRtc;");
         src.push("uniform vec2 snapVectorA;");
         src.push("uniform vec2 snapInvVectorAB;");

--- a/src/viewer/scene/model/vbo/snapInstancing/SnapInstancingDepthBufInitRenderer.js
+++ b/src/viewer/scene/model/vbo/snapInstancing/SnapInstancingDepthBufInitRenderer.js
@@ -1,12 +1,11 @@
-import {Program} from "../../../webgl/Program.js";
-import {createRTCViewMat, getPlaneRTCPos} from "../../../math/rtcCoords.js";
+import {VBOSceneModelRenderer} from "../VBOSceneModelRenderers.js";
+import {createRTCViewMat} from "../../../math/rtcCoords.js";
 import {math} from "../../../math/math.js";
 
 const tempVec3a = math.vec3();
 const tempVec3b = math.vec3();
 const tempVec3c = math.vec3();
 const tempVec3d = math.vec3();
-const tempVec3e = math.vec3();
 const tempMat4a = math.mat4();
 
 const SNAPPING_LOG_DEPTH_BUF_ENABLED = true; // Improves occlusion accuracy at distance
@@ -14,20 +13,10 @@ const SNAPPING_LOG_DEPTH_BUF_ENABLED = true; // Improves occlusion accuracy at d
 /**
  * @private
  */
-class SnapInstancingDepthBufInitRenderer {
+class SnapInstancingDepthBufInitRenderer extends VBOSceneModelRenderer {
 
     constructor(scene) {
-        this._scene = scene;
-        this._hash = this._getHash();
-        this._allocate();
-    }
-
-    getValid() {
-        return this._hash === this._getHash();
-    };
-
-    _getHash() {
-        return this._scene._sectionPlanesState.getHash();
+        super(scene, false, { instancing: true });
     }
 
     drawLayer(frameCtx, instancingLayer, renderPass) {
@@ -53,6 +42,12 @@ class SnapInstancingDepthBufInitRenderer {
         const {position, rotationMatrix, rotationMatrixConjugate} = model;
         const aabb = instancingLayer.aabb;
         const viewMatrix = frameCtx.pickViewMatrix || camera.viewMatrix;
+
+        if (this._vaoCache.has(instancingLayer)) {
+            gl.bindVertexArray(this._vaoCache.get(instancingLayer));
+        } else {
+            this._vaoCache.set(instancingLayer, this._makeVAO(state))
+        }
 
         const coordinateScaler = tempVec3a;
         coordinateScaler[0] = math.safeInv(aabb[3] - aabb[0]) * math.MAX_INT;
@@ -103,40 +98,30 @@ class SnapInstancingDepthBufInitRenderer {
         gl.uniform3fv(this._uCoordinateScaler, coordinateScaler);
         gl.uniform1i(this._uRenderPass, renderPass);
         gl.uniform1i(this._uPickInvisible, frameCtx.pickInvisible);
-        gl.uniformMatrix4fv(this._uWorldMatrix, false, rotationMatrixConjugate);
-        gl.uniformMatrix4fv(this._uViewMatrix, false, rtcViewMatrix);
-        gl.uniformMatrix4fv(this._uProjMatrix, false, camera.projMatrix);
+
+        let offset = 0;
+        const mat4Size = 4 * 4;
+
+        this._matricesUniformBlockBufferData.set(rotationMatrixConjugate, 0);
+        this._matricesUniformBlockBufferData.set(rtcViewMatrix, offset += mat4Size);
+        this._matricesUniformBlockBufferData.set(camera.projMatrix, offset += mat4Size);
+        this._matricesUniformBlockBufferData.set(state.positionsDecodeMatrix, offset += mat4Size);
+
+        gl.bindBuffer(gl.UNIFORM_BUFFER, this._matricesUniformBlockBuffer);
+        gl.bufferData(gl.UNIFORM_BUFFER, this._matricesUniformBlockBufferData, gl.DYNAMIC_DRAW);
+
+        gl.bindBufferBase(
+            gl.UNIFORM_BUFFER,
+            this._matricesUniformBlockBufferBindingPoint,
+            this._matricesUniformBlockBuffer);
+
 
         if (SNAPPING_LOG_DEPTH_BUF_ENABLED) {
             const logDepthBufFC = 2.0 / (Math.log(frameCtx.pickZFar + 1.0) / Math.LN2);
             gl.uniform1f(this._uLogDepthBufFC, logDepthBufFC);
         }
 
-        const numSectionPlanes = scene._sectionPlanesState.sectionPlanes.length;
-        if (numSectionPlanes > 0) {
-            const sectionPlanes = scene._sectionPlanesState.sectionPlanes;
-            const baseIndex = instancingLayer.layerIndex * numSectionPlanes;
-            const renderFlags = model.renderFlags;
-            for (let sectionPlaneIndex = 0; sectionPlaneIndex < numSectionPlanes; sectionPlaneIndex++) {
-                const sectionPlaneUniforms = this._uSectionPlanes[sectionPlaneIndex];
-                if (sectionPlaneUniforms) {
-                    const active = renderFlags.sectionPlanesActivePerLayer[baseIndex + sectionPlaneIndex];
-                    gl.uniform1i(sectionPlaneUniforms.active, active ? 1 : 0);
-                    if (active) {
-                        const sectionPlane = sectionPlanes[sectionPlaneIndex];
-                        if (origin) {
-                            const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3e);
-                            gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
-                        } else {
-                            gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);
-                        }
-                        gl.uniform3fv(sectionPlaneUniforms.dir, sectionPlane.dir);
-                    }
-                }
-            }
-        }
-
-        gl.uniformMatrix4fv(this._uPositionsDecodeMatrix, false, state.positionsDecodeMatrix);
+        this.setSectionPlanesStateUniforms(instancingLayer);
 
         this._aModelMatrixCol0.bindArrayBuffer(state.modelMatrixCol0Buf);
         this._aModelMatrixCol1.bindArrayBuffer(state.modelMatrixCol1Buf);
@@ -146,15 +131,10 @@ class SnapInstancingDepthBufInitRenderer {
         gl.vertexAttribDivisor(this._aModelMatrixCol1.location, 1);
         gl.vertexAttribDivisor(this._aModelMatrixCol2.location, 1);
 
-        this._aPosition.bindArrayBuffer(state.positionsBuf);
 
         if (this._aFlags) {
             this._aFlags.bindArrayBuffer(state.flagsBuf);
             gl.vertexAttribDivisor(this._aFlags.location, 1);
-        }
-        if (this._aOffset) {
-            this._aOffset.bindArrayBuffer(state.offsetsBuf);
-            gl.vertexAttribDivisor(this._aOffset.location, 1);
         }
 
         state.indicesBuf.bind();
@@ -174,34 +154,10 @@ class SnapInstancingDepthBufInitRenderer {
     }
 
     _allocate() {
-        const scene = this._scene;
-        const gl = scene.canvas.gl;
-        this._program = new Program(gl, this._buildShader());
-        if (this._program.errors) {
-            this.errors = this._program.errors;
-            return;
-        }
+        super._allocate();
+
         const program = this._program;
-        this._uRenderPass = program.getLocation("renderPass");
-        this._uPickInvisible = program.getLocation("pickInvisible");
-        this._uPositionsDecodeMatrix = program.getLocation("positionsDecodeMatrix");
-        this._uWorldMatrix = program.getLocation("worldMatrix");
-        this._uViewMatrix = program.getLocation("viewMatrix");
-        this._uProjMatrix = program.getLocation("projMatrix");
-        this._uSectionPlanes = [];
-        for (let i = 0, len = scene._sectionPlanesState.sectionPlanes.length; i < len; i++) {
-            this._uSectionPlanes.push({
-                active: program.getLocation("sectionPlaneActive" + i),
-                pos: program.getLocation("sectionPlanePos" + i),
-                dir: program.getLocation("sectionPlaneDir" + i)
-            });
-        }
-        this._aPosition = program.getAttribute("position");
-        this._aOffset = program.getAttribute("offset");
-        this._aFlags = program.getAttribute("flags");
-        this._aModelMatrixCol0 = program.getAttribute("modelMatrixCol0");
-        this._aModelMatrixCol1 = program.getAttribute("modelMatrixCol1");
-        this._aModelMatrixCol2 = program.getAttribute("modelMatrixCol2");
+
         if (SNAPPING_LOG_DEPTH_BUF_ENABLED) {
             this._uLogDepthBufFC = program.getLocation("logDepthBufFC");
         }
@@ -215,13 +171,6 @@ class SnapInstancingDepthBufInitRenderer {
     _bindProgram() {
         this._program.bind();
 
-    }
-
-    _buildShader() {
-        return {
-            vertex: this._buildVertexShader(),
-            fragment: this._buildFragmentShader()
-        };
     }
 
     _buildVertexShader() {
@@ -254,10 +203,9 @@ class SnapInstancingDepthBufInitRenderer {
         src.push("in vec4 modelMatrixCol1;");
         src.push("in vec4 modelMatrixCol2;");
         src.push("uniform bool pickInvisible;");
-        src.push("uniform mat4 worldMatrix;");
-        src.push("uniform mat4 viewMatrix;");
-        src.push("uniform mat4 projMatrix;")
-        src.push("uniform mat4 positionsDecodeMatrix;");
+
+        this._addMatricesUniformBlockLines(src);
+
         src.push("uniform vec3 uCameraEyeRtc;");
         src.push("uniform vec2 snapVectorA;");
         src.push("uniform vec2 snapInvVectorAB;");

--- a/src/viewer/scene/model/vbo/snapInstancing/SnapInstancingDepthRenderer.js
+++ b/src/viewer/scene/model/vbo/snapInstancing/SnapInstancingDepthRenderer.js
@@ -1,12 +1,11 @@
-import {Program} from "../../../webgl/Program.js";
-import {createRTCViewMat, getPlaneRTCPos} from "../../../math/rtcCoords.js";
+import {VBOSceneModelRenderer} from "../VBOSceneModelRenderers.js";
+import {createRTCViewMat} from "../../../math/rtcCoords.js";
 import {math} from "../../../math/math.js";
 
 const tempVec3a = math.vec3();
 const tempVec3b = math.vec3();
 const tempVec3c = math.vec3();
 const tempVec3d = math.vec3();
-const tempVec3e = math.vec3();
 const tempMat4a = math.mat4();
 
 const SNAPPING_LOG_DEPTH_BUF_ENABLED = true; // Improves occlusion accuracy at distance
@@ -14,20 +13,10 @@ const SNAPPING_LOG_DEPTH_BUF_ENABLED = true; // Improves occlusion accuracy at d
 /**
  * @private
  */
-class SnapInstancingDepthRenderer {
+class SnapInstancingDepthRenderer extends VBOSceneModelRenderer {
 
     constructor(scene) {
-        this._scene = scene;
-        this._hash = this._getHash();
-        this._allocate();
-    }
-
-    getValid() {
-        return this._hash === this._getHash();
-    };
-
-    _getHash() {
-        return this._scene._sectionPlanesState.getHash();
+        super(scene, false, { instancing: true });
     }
 
     drawLayer(frameCtx, instancingLayer, renderPass) {
@@ -53,6 +42,12 @@ class SnapInstancingDepthRenderer {
         const {position, rotationMatrix, rotationMatrixConjugate} = model;
         const aabb = instancingLayer.aabb;
         const viewMatrix = frameCtx.pickViewMatrix || camera.viewMatrix;
+
+        if (this._vaoCache.has(instancingLayer)) {
+            gl.bindVertexArray(this._vaoCache.get(instancingLayer));
+        } else {
+            this._vaoCache.set(instancingLayer, this._makeVAO(state))
+        }
 
         const coordinateScaler = tempVec3a;
         coordinateScaler[0] = math.safeInv(aabb[3] - aabb[0]) * math.MAX_INT;
@@ -104,51 +99,41 @@ class SnapInstancingDepthRenderer {
         gl.uniform3fv(this._uCoordinateScaler, coordinateScaler);
         gl.uniform1i(this._uRenderPass, renderPass);
         gl.uniform1i(this._uPickInvisible, frameCtx.pickInvisible);
-        gl.uniformMatrix4fv(this._uViewMatrix, false, rtcViewMatrix);
-        gl.uniformMatrix4fv(this._uWorldMatrix, false, rotationMatrixConjugate);
-        gl.uniformMatrix4fv(this._uProjMatrix, false, camera.projMatrix);
+
+        let offset = 0;
+        const mat4Size = 4 * 4;
+
+        this._matricesUniformBlockBufferData.set(rotationMatrixConjugate, 0);
+        this._matricesUniformBlockBufferData.set(rtcViewMatrix, offset += mat4Size);
+        this._matricesUniformBlockBufferData.set(camera.projMatrix, offset += mat4Size);
+        this._matricesUniformBlockBufferData.set(state.positionsDecodeMatrix, offset += mat4Size);
+
+        gl.bindBuffer(gl.UNIFORM_BUFFER, this._matricesUniformBlockBuffer);
+        gl.bufferData(gl.UNIFORM_BUFFER, this._matricesUniformBlockBufferData, gl.DYNAMIC_DRAW);
+
+        gl.bindBufferBase(
+            gl.UNIFORM_BUFFER,
+            this._matricesUniformBlockBufferBindingPoint,
+            this._matricesUniformBlockBuffer);
+
         if (SNAPPING_LOG_DEPTH_BUF_ENABLED) {
             const logDepthBufFC = 2.0 / (Math.log(frameCtx.pickZFar + 1.0) / Math.LN2); // TODO: Far from pick project matrix
             gl.uniform1f(this._uLogDepthBufFC, logDepthBufFC);
         }
-        const numSectionPlanes = scene._sectionPlanesState.sectionPlanes.length;
-        if (numSectionPlanes > 0) {
-            const sectionPlanes = scene._sectionPlanesState.sectionPlanes;
-            const baseIndex = instancingLayer.layerIndex * numSectionPlanes;
-            const renderFlags = model.renderFlags;
-            for (let sectionPlaneIndex = 0; sectionPlaneIndex < numSectionPlanes; sectionPlaneIndex++) {
-                const sectionPlaneUniforms = this._uSectionPlanes[sectionPlaneIndex];
-                if (sectionPlaneUniforms) {
-                    const active = renderFlags.sectionPlanesActivePerLayer[baseIndex + sectionPlaneIndex];
-                    gl.uniform1i(sectionPlaneUniforms.active, active ? 1 : 0);
-                    if (active) {
-                        const sectionPlane = sectionPlanes[sectionPlaneIndex];
-                        if (origin) {
-                            const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3e);
-                            gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
-                        } else {
-                            gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);
-                        }
-                        gl.uniform3fv(sectionPlaneUniforms.dir, sectionPlane.dir);
-                    }
-                }
-            }
-        }
 
-        gl.uniformMatrix4fv(this._uPositionsDecodeMatrix, false, state.positionsDecodeMatrix);
+        this.setSectionPlanesStateUniforms(instancingLayer);
+
+
         this._aModelMatrixCol0.bindArrayBuffer(state.modelMatrixCol0Buf);
         this._aModelMatrixCol1.bindArrayBuffer(state.modelMatrixCol1Buf);
         this._aModelMatrixCol2.bindArrayBuffer(state.modelMatrixCol2Buf);
         gl.vertexAttribDivisor(this._aModelMatrixCol0.location, 1);
         gl.vertexAttribDivisor(this._aModelMatrixCol1.location, 1);
         gl.vertexAttribDivisor(this._aModelMatrixCol2.location, 1);
-        this._aPosition.bindArrayBuffer(state.positionsBuf);
+
         this._aFlags.bindArrayBuffer(state.flagsBuf);
         gl.vertexAttribDivisor(this._aFlags.location, 1);
-        if (this._aOffset) {
-            this._aOffset.bindArrayBuffer(state.offsetsBuf);
-            gl.vertexAttribDivisor(this._aOffset.location, 1);
-        }
+
         if (frameCtx.snapMode === "edge") {
             state.edgeIndicesBuf.bind();
             gl.drawElementsInstanced(gl.LINES, state.edgeIndicesBuf.numItems, state.edgeIndicesBuf.itemType, 0, state.numInstances);
@@ -167,34 +152,10 @@ class SnapInstancingDepthRenderer {
     }
 
     _allocate() {
-        const scene = this._scene;
-        const gl = scene.canvas.gl;
-        this._program = new Program(gl, this._buildShader());
-        if (this._program.errors) {
-            this.errors = this._program.errors;
-            return;
-        }
+        super._allocate();
+
         const program = this._program;
-        this._uRenderPass = program.getLocation("renderPass");
-        this._uPickInvisible = program.getLocation("pickInvisible");
-        this._uPositionsDecodeMatrix = program.getLocation("positionsDecodeMatrix");
-        this._uWorldMatrix = program.getLocation("worldMatrix");
-        this._uViewMatrix = program.getLocation("viewMatrix");
-        this._uProjMatrix = program.getLocation("projMatrix");
-        this._uSectionPlanes = [];
-        for (let i = 0, len = scene._sectionPlanesState.sectionPlanes.length; i < len; i++) {
-            this._uSectionPlanes.push({
-                active: program.getLocation("sectionPlaneActive" + i),
-                pos: program.getLocation("sectionPlanePos" + i),
-                dir: program.getLocation("sectionPlaneDir" + i)
-            });
-        }
-        this._aPosition = program.getAttribute("position");
-        this._aOffset = program.getAttribute("offset");
-        this._aFlags = program.getAttribute("flags");
-        this._aModelMatrixCol0 = program.getAttribute("modelMatrixCol0");
-        this._aModelMatrixCol1 = program.getAttribute("modelMatrixCol1");
-        this._aModelMatrixCol2 = program.getAttribute("modelMatrixCol2");
+
         if (SNAPPING_LOG_DEPTH_BUF_ENABLED) {
             this._uLogDepthBufFC = program.getLocation("logDepthBufFC");
         }
@@ -208,13 +169,6 @@ class SnapInstancingDepthRenderer {
     _bindProgram() {
         this._program.bind();
 
-    }
-
-    _buildShader() {
-        return {
-            vertex: this._buildVertexShader(),
-            fragment: this._buildFragmentShader()
-        };
     }
 
     _buildVertexShader() {
@@ -247,10 +201,9 @@ class SnapInstancingDepthRenderer {
         src.push("in vec4 modelMatrixCol1;");
         src.push("in vec4 modelMatrixCol2;");
         src.push("uniform bool pickInvisible;");
-        src.push("uniform mat4 worldMatrix;");
-        src.push("uniform mat4 viewMatrix;");
-        src.push("uniform mat4 projMatrix;")
-        src.push("uniform mat4 positionsDecodeMatrix;");
+
+        this._addMatricesUniformBlockLines(src);
+
         src.push("uniform vec3 uCameraEyeRtc;"); 
         src.push("uniform vec2 snapVectorA;"); 
         src.push("uniform vec2 snapInvVectorAB;"); 


### PR DESCRIPTION
Like other vbo batching/instancing renderers, vbo snap renderers now use ubo and vao to limite WebGL API calls like matrix4v, buffer bindings...