### PR TITLE
fix BCF plugin set viewpoint

### DIFF
--- a/src/plugins/BCFViewpointsPlugin/BCFViewpointsPlugin.js
+++ b/src/plugins/BCFViewpointsPlugin/BCFViewpointsPlugin.js
@@ -633,7 +633,7 @@ class BCFViewpointsPlugin extends Plugin {
 
         scene.clearSectionPlanes();
 
-        if (bcfViewpoint.clipping_planes) {
+        if (bcfViewpoint.clipping_planes && bcfViewpoint.clipping_planes.length > 0) {
             bcfViewpoint.clipping_planes.forEach(function (e) {
                 let pos = xyzObjectToArray(e.location, tempVec3);
                 let dir = xyzObjectToArray(e.direction, tempVec3);
@@ -653,7 +653,7 @@ class BCFViewpointsPlugin extends Plugin {
 
         scene.clearLines();
 
-        if (bcfViewpoint.lines) {
+        if (bcfViewpoint.lines && bcfViewpoint.lines.length > 0) {
             const positions = [];
             const indices = [];
             let i = 0;
@@ -683,7 +683,7 @@ class BCFViewpointsPlugin extends Plugin {
 
         scene.clearBitmaps();
 
-        if (bcfViewpoint.bitmaps) {
+        if (bcfViewpoint.bitmaps && bcfViewpoint.bitmaps.length > 0) {
             bcfViewpoint.bitmaps.forEach(function (e) {
                 const bitmap_type = e.bitmap_type || "jpg"; // "jpg" | "png"
                 const bitmap_data = e.bitmap_data; // base64


### PR DESCRIPTION
Use case:

I have a model with an aabb far from origin. I set a viewpoint with the BCFViewpointsPlugin. Even if there is no lines, there is a [`LineSet` added to the scene](https://github.com/xeokit/xeokit-sdk/blob/master/src/plugins/BCFViewpointsPlugin/BCFViewpointsPlugin.js#L676). Because of that, the scene aabb is huge (lineSet at [0, 0, 0] + my model) and not relevant.

This PR prevents the addition of the `LineSet` if `lines.length === 0`.

To be consistent, the same logic is added on `clipping_planes` and `bitmaps` even if they are not problematic.