### PR TITLE
Draw pick normal using 32 bits per color channel instead of default 8

### DIFF
--- a/src/viewer/scene/model/dtx/triangles/renderers/TrianglesDataTexturePickNormalsFlatRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/TrianglesDataTexturePickNormalsFlatRenderer.js
@@ -463,7 +463,7 @@ export class TrianglesDataTexturePickNormalsFlatRenderer {
                 src.push("uniform vec3 sectionPlaneDir" + i + ";");
             }
         }
-        src.push("out vec4 outNormal;");
+        src.push("out highp ivec4 outNormal;");
         src.push("void main(void) {");
         if (clipping) {
             src.push("  bool clippable = vFlags2 > 0;");
@@ -483,7 +483,7 @@ export class TrianglesDataTexturePickNormalsFlatRenderer {
         src.push("  vec3 xTangent = dFdx( vWorldPosition.xyz );");
         src.push("  vec3 yTangent = dFdy( vWorldPosition.xyz );");
         src.push("  vec3 worldNormal = normalize( cross( xTangent, yTangent ) );");
-        src.push("  outNormal = vec4((worldNormal * 0.5) + 0.5, 1.0);");
+        src.push(`  outNormal = ivec4(worldNormal * float(${math.MAX_INT}), 1.0);`);
         src.push("}");
         return src;
     }

--- a/src/viewer/scene/model/dtx/triangles/renderers/TrianglesDataTexturePickNormalsRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/TrianglesDataTexturePickNormalsRenderer.js
@@ -1,5 +1,5 @@
 import {Program} from "../../../../webgl/Program.js";
-import {createRTCViewMat, getPlaneRTCPos} from "../../../../math/rtcCoords.js";
+import {getPlaneRTCPos} from "../../../../math/rtcCoords.js";
 import {math} from "../../../../math/math.js";
 
 const tempVec3a = math.vec3();
@@ -393,7 +393,7 @@ export class TrianglesDataTexturePickNormalsRenderer {
             }
         }
         src.push("in vec3 vWorldNormal;");
-        src.push("out vec4 outNormal;");
+        src.push("out highp ivec4 outNormal;");
         src.push("void main(void) {");
         if (clipping) {
             src.push("  bool clippable = vFlags2 > 0u;");
@@ -412,7 +412,7 @@ export class TrianglesDataTexturePickNormalsRenderer {
             // src.push("    gl_FragDepth = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;");
             src.push("    gl_FragDepth = log2( vFragDepth ) * logDepthBufFC * 0.5;");
         }
-        src.push("    outNormal = vec4((vWorldNormal * 0.5) + 0.5, 1.0);");
+        src.push(`    outNormal = ivec4(vWorldNormal * float(${math.MAX_INT}), 1.0);`);
         src.push("}");
         return src;
     }

--- a/src/viewer/scene/model/vbo/trianglesBatching/renderers/TrianglesBatchingPickNormalsFlatRenderer.js
+++ b/src/viewer/scene/model/vbo/trianglesBatching/renderers/TrianglesBatchingPickNormalsFlatRenderer.js
@@ -1,3 +1,4 @@
+import { math } from "../../../../math/math.js";
 import {VBOSceneModelTriangleBatchingRenderer} from "../../VBOSceneModelRenderers.js";
 
 /**
@@ -90,7 +91,7 @@ class TrianglesBatchingPickNormalsFlatRenderer extends VBOSceneModelTriangleBatc
                 src.push("uniform vec3 sectionPlaneDir" + i + ";");
             }
         }
-        src.push("out vec4 outColor;");
+        src.push("out highp ivec4 outNormal;");
         src.push("void main(void) {");
         if (clipping) {
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
@@ -110,7 +111,7 @@ class TrianglesBatchingPickNormalsFlatRenderer extends VBOSceneModelTriangleBatc
         src.push("  vec3 xTangent = dFdx( vWorldPosition.xyz );");
         src.push("  vec3 yTangent = dFdy( vWorldPosition.xyz );");
         src.push("  vec3 worldNormal = normalize( cross( xTangent, yTangent ) );");
-        src.push("  outColor = vec4((worldNormal * 0.5) + 0.5, 1.0);");
+        src.push(`  outNormal = ivec4(worldNormal * float(${math.MAX_INT}), 1.0);`);
         src.push("}");
         return src;
     }

--- a/src/viewer/scene/model/vbo/trianglesBatching/renderers/TrianglesBatchingPickNormalsRenderer.js
+++ b/src/viewer/scene/model/vbo/trianglesBatching/renderers/TrianglesBatchingPickNormalsRenderer.js
@@ -1,3 +1,4 @@
+import { math } from "../../../../math/math.js";
 import {VBOSceneModelTriangleBatchingRenderer} from "../../VBOSceneModelRenderers.js";
 
 /**
@@ -103,7 +104,7 @@ class TrianglesBatchingPickNormalsRenderer extends VBOSceneModelTriangleBatching
             }
         }
         src.push("in vec3 vWorldNormal;");
-        src.push("out vec4 outColor;");
+        src.push("out highp ivec4 outNormal;");
         src.push("void main(void) {");
         if (clipping) {
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
@@ -120,7 +121,7 @@ class TrianglesBatchingPickNormalsRenderer extends VBOSceneModelTriangleBatching
         if (scene.logarithmicDepthBufferEnabled) {
             src.push("    gl_FragDepth = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;");
         }
-        src.push("    outColor = vec4((vWorldNormal * 0.5) + 0.5, 1.0);");
+        src.push(`    outNormal = ivec4(vWorldNormal * float(${math.MAX_INT}), 1.0);`);
         src.push("}");
         return src;
     }

--- a/src/viewer/scene/model/vbo/trianglesInstancing/renderers/TrianglesInstancingPickNormalsFlatRenderer.js
+++ b/src/viewer/scene/model/vbo/trianglesInstancing/renderers/TrianglesInstancingPickNormalsFlatRenderer.js
@@ -1,3 +1,4 @@
+import { math } from "../../../../math/math.js";
 import {VBOSceneModelTriangleInstancingRenderer} from "../../VBOSceneModelRenderers.js";
 
 /**
@@ -101,7 +102,7 @@ class TrianglesInstancingPickNormalsFlatRenderer extends VBOSceneModelTriangleIn
             }
         }
         src.push("in vec3 vWorldNormal;");
-        src.push("out vec4 outColor;");
+        src.push("out highp ivec4 outNormal;");
         src.push("void main(void) {");
         if (clipping) {
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
@@ -121,7 +122,7 @@ class TrianglesInstancingPickNormalsFlatRenderer extends VBOSceneModelTriangleIn
         src.push("  vec3 xTangent = dFdx( vWorldPosition.xyz );");
         src.push("  vec3 yTangent = dFdy( vWorldPosition.xyz );");
         src.push("  vec3 worldNormal = normalize( cross( xTangent, yTangent ) );");
-        src.push("  outColor = vec4((worldNormal * 0.5) + 0.5, 1.0);");
+        src.push(`  outNormal = ivec4(worldNormal * float(${math.MAX_INT}), 1.0);`);
         src.push("}");
         return src;
     }

--- a/src/viewer/scene/model/vbo/trianglesInstancing/renderers/TrianglesInstancingPickNormalsFlatRenderer.js
+++ b/src/viewer/scene/model/vbo/trianglesInstancing/renderers/TrianglesInstancingPickNormalsFlatRenderer.js
@@ -101,7 +101,6 @@ class TrianglesInstancingPickNormalsFlatRenderer extends VBOSceneModelTriangleIn
                 src.push("uniform vec3 sectionPlaneDir" + i + ";");
             }
         }
-        src.push("in vec3 vWorldNormal;");
         src.push("out highp ivec4 outNormal;");
         src.push("void main(void) {");
         if (clipping) {

--- a/src/viewer/scene/model/vbo/trianglesInstancing/renderers/TrianglesInstancingPickNormalsRenderer.js
+++ b/src/viewer/scene/model/vbo/trianglesInstancing/renderers/TrianglesInstancingPickNormalsRenderer.js
@@ -1,3 +1,4 @@
+import { math } from "../../../../math/math.js";
 import {VBOSceneModelTriangleInstancingRenderer} from "../../VBOSceneModelRenderers.js";
 
 /**
@@ -118,7 +119,7 @@ class TrianglesInstancingPickNormalsRenderer extends VBOSceneModelTriangleInstan
             }
         }
         src.push("in vec3 vWorldNormal;");
-        src.push("out vec4 outColor;");
+        src.push("out highp ivec4 outNormal;");
         src.push("void main(void) {");
         if (clipping) {
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
@@ -135,7 +136,7 @@ class TrianglesInstancingPickNormalsRenderer extends VBOSceneModelTriangleInstan
         if (scene.logarithmicDepthBufferEnabled) {
             src.push("    gl_FragDepth = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;");
         }
-        src.push("    outColor = vec4((vWorldNormal * 0.5) + 0.5, 1.0);");
+        src.push(`    outNormal = ivec4(vWorldNormal * float(${math.MAX_INT}), 1.0);`);
         src.push("}");
         return src;
     }

--- a/src/viewer/scene/webgl/Renderer.js
+++ b/src/viewer/scene/webgl/Renderer.js
@@ -1477,20 +1477,30 @@ const Renderer = function (scene, options) {
         frameCtx.pickViewMatrix = pickViewMatrix;
         frameCtx.pickProjMatrix = pickProjMatrix;
 
+        const pickNormalBuffer = renderBufferManager.getRenderBuffer("pick-normal");
+
+        pickNormalBuffer.bind(gl.RGBA32I);
+
         gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
 
-        gl.clearColor(0, 0, 0, 0);
         gl.enable(gl.DEPTH_TEST);
         gl.disable(gl.CULL_FACE);
         gl.disable(gl.BLEND);
-        gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+        gl.clear(gl.DEPTH_BUFFER_BIT);
+        gl.clearBufferiv(gl.COLOR, 0, new Int32Array([0, 0, 0, 0]));
 
         pickable.drawPickNormals(frameCtx); // Draw color-encoded fragment World-space normals
 
         const resolutionScale = scene.canvas.resolutionScale;
-        const pix = pickBuffer.read(Math.round(canvasPos[0] * resolutionScale), Math.round(canvasPos[1] * resolutionScale));
+        const pix = pickNormalBuffer.read(Math.round(canvasPos[0] * resolutionScale), Math.round(canvasPos[1] * resolutionScale), gl.RGBA_INTEGER, gl.INT, Int32Array, 4);
 
-        const worldNormal = [(pix[0] / 256.0) - 0.5, (pix[1] / 256.0) - 0.5, (pix[2] / 256.0) - 0.5];
+        pickNormalBuffer.unbind();
+
+        const worldNormal = [
+            pix[0] / math.MAX_INT,
+            pix[1] / math.MAX_INT,
+            pix[2] / math.MAX_INT,
+        ];
 
         math.normalizeVec3(worldNormal);
 


### PR DESCRIPTION
Increase the pick normal precision fix this issue : https://github.com/xeokit/xeokit-sdk/issues/523

Before: (section plane **not exactly** parallel to the clicked surface)

![normal8](https://github.com/xeokit/xeokit-sdk/assets/22523482/ffcd36fe-ba1a-4819-8649-7927d9810df1)

After: (section plane **exactly** parallel to the clicked surface)

![normal32](https://github.com/xeokit/xeokit-sdk/assets/22523482/0366bf89-2922-4dad-9576-20153a0dcb55)

Implementation:

It uses another framebuffer instead of the previously used pick frame buffer for picking normals. The new framebuffer uses a RGBA32I color renderable texture.

It uses more VRAM but once the [1 x 1 picking viewport PR](https://github.com/xeokit/xeokit-sdk/pull/1168) will be merged, the difference won't be relevant.

Noticeable difference:

Because of the new normal encoding, the [missing normal issue](https://github.com/xeokit/xeokit-sdk/issues/1141) does not appear the same way. Before, the normalised missing normal could be closed to [zero, zero, zero] or [NaN, NaN, NaN] OS dependent, but now it is only [NaN, NaN, NaN]...