### PR TITLE
Auto split LAS pointsets

### DIFF
--- a/src/viewer/scene/model/SceneModel.js
+++ b/src/viewer/scene/model/SceneModel.js
@@ -2916,7 +2916,8 @@ export class SceneModel extends Component {
                         countIndices += cfg.positions ? cfg.positions.length : cfg.positionsCompressed.length;
                         break;
                     case VBO_INSTANCED:
-                        countIndices += cfg.positions ? cfg.positions.length : cfg.positionsCompressed.length;
+                        const geometry = cfg.geometry;
+                        countIndices += geometry.positions ? geometry.positions.length : geometry.positionsCompressed.length;
                         break;
                 }
                 return Math.round(countIndices);


### PR DESCRIPTION
LAS/LAZ files often hold points in one huge array that's too long to fit into a WebGL VBO.

To load such files, this PR extends `LASLoaderPlugin` to automatically split such point sets into multiple meshes within the target `SceneModel`.

Note that we also need to extend `XKTLoaderPlugin` to likewise automatically split point sets when creating geometries and meshes.