### PR TITLE
Pick normals using a 3x3 viewport

### DIFF
--- a/src/viewer/scene/model/dtx/triangles/renderers/TrianglesDataTexturePickDepthRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/TrianglesDataTexturePickDepthRenderer.js
@@ -96,6 +96,7 @@ export class TrianglesDataTexturePickDepthRenderer {
         gl.uniform1i(this._uRenderPass, renderPass);
         gl.uniform1i(this._uPickInvisible, frameCtx.pickInvisible);
         gl.uniform2fv(this._uPickClipPos, frameCtx.pickClipPos);
+        gl.uniform2f(this._uDrawingBufferSize, gl.drawingBufferWidth, gl.drawingBufferHeight);
         gl.uniform1f(this._uPickZNear, frameCtx.pickZNear);
         gl.uniform1f(this._uPickZFar, frameCtx.pickZFar);
         gl.uniformMatrix4fv(this._uWorldMatrix, false, rotationMatrixConjugate);
@@ -171,6 +172,7 @@ export class TrianglesDataTexturePickDepthRenderer {
         this._uRenderPass = program.getLocation("renderPass");
         this._uPickInvisible = program.getLocation("pickInvisible");
         this._uPickClipPos = program.getLocation("pickClipPos");
+        this._uDrawingBufferSize = program.getLocation("drawingBufferSize");
         this._uWorldMatrix = program.getLocation("worldMatrix");
         this._uViewMatrix = program.getLocation("viewMatrix");
         this._uProjMatrix = program.getLocation("projMatrix");
@@ -261,10 +263,11 @@ export class TrianglesDataTexturePickDepthRenderer {
         }
 
         src.push("uniform vec2 pickClipPos;");
+        src.push("uniform vec2 drawingBufferSize;");
 
         src.push("vec4 remapClipPos(vec4 clipPos) {");
         src.push("    clipPos.xy /= clipPos.w;")
-        src.push("    clipPos.xy -= pickClipPos;");
+        src.push(`    clipPos.xy = (clipPos.xy - pickClipPos) * drawingBufferSize;`);
         src.push("    clipPos.xy *= clipPos.w;")
         src.push("    return clipPos;")
         src.push("}");

--- a/src/viewer/scene/model/dtx/triangles/renderers/TrianglesDataTexturePickMeshRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/TrianglesDataTexturePickMeshRenderer.js
@@ -82,6 +82,7 @@ export class TrianglesDataTexturePickMeshRenderer {
             rtcCameraEye = camera.eye;
         }
         gl.uniform2fv(this._uPickClipPos, frameCtx.pickClipPos);
+        gl.uniform2f(this._uDrawingBufferSize, gl.drawingBufferWidth, gl.drawingBufferHeight);
         gl.uniformMatrix4fv(this._uSceneModelWorldMatrix, false, rotationMatrixConjugate);
         gl.uniformMatrix4fv(this._uViewMatrix, false, rtcViewMatrix);
         gl.uniformMatrix4fv(this._uProjMatrix, false, camera.projMatrix);
@@ -156,6 +157,7 @@ export class TrianglesDataTexturePickMeshRenderer {
         this._uRenderPass = program.getLocation("renderPass");
         this._uPickInvisible = program.getLocation("pickInvisible");
         this._uPickClipPos = program.getLocation("pickClipPos");
+        this._uDrawingBufferSize = program.getLocation("drawingBufferSize");
         this._uSceneModelWorldMatrix = program.getLocation("sceneModelWorldMatrix");
         this._uViewMatrix = program.getLocation("viewMatrix");
         this._uProjMatrix = program.getLocation("projMatrix");
@@ -254,10 +256,11 @@ export class TrianglesDataTexturePickMeshRenderer {
         }
 
         src.push("uniform vec2 pickClipPos;");
+        src.push("uniform vec2 drawingBufferSize;");
 
         src.push("vec4 remapClipPos(vec4 clipPos) {");
         src.push("    clipPos.xy /= clipPos.w;")
-        src.push("    clipPos.xy -= pickClipPos;");
+        src.push(`    clipPos.xy = (clipPos.xy - pickClipPos) * drawingBufferSize;`);
         src.push("    clipPos.xy *= clipPos.w;")
         src.push("    return clipPos;")
         src.push("}");

--- a/src/viewer/scene/model/dtx/triangles/renderers/TrianglesDataTexturePickNormalsFlatRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/TrianglesDataTexturePickNormalsFlatRenderer.js
@@ -91,6 +91,7 @@ export class TrianglesDataTexturePickNormalsFlatRenderer {
         gl.uniform1i(this._uRenderPass, renderPass);
         gl.uniform1i(this._uPickInvisible, frameCtx.pickInvisible);
         gl.uniform2fv(this._uPickClipPos, frameCtx.pickClipPos);
+        gl.uniform2f(this._uDrawingBufferSize, gl.drawingBufferWidth, gl.drawingBufferHeight);
 
         gl.uniformMatrix4fv(this._uWorldMatrix, false, model.worldMatrix);
 
@@ -260,6 +261,7 @@ export class TrianglesDataTexturePickNormalsFlatRenderer {
         this._uRenderPass = program.getLocation("renderPass");
         this._uPickInvisible = program.getLocation("pickInvisible");
         this._uPickClipPos = program.getLocation("pickClipPos");
+        this._uDrawingBufferSize = program.getLocation("drawingBufferSize");
         this._uPositionsDecodeMatrix = program.getLocation("positionsDecodeMatrix");
         this._uWorldMatrix = program.getLocation("worldMatrix");
         this._uViewMatrix = program.getLocation("viewMatrix");
@@ -350,11 +352,12 @@ export class TrianglesDataTexturePickNormalsFlatRenderer {
             src.push("out float isPerspective;");
         }
 
+        src.push("uniform vec2 drawingBufferSize;");
         src.push("uniform vec2 pickClipPos;");
 
         src.push("vec4 remapClipPos(vec4 clipPos) {");
-        src.push("    clipPos.xy /= clipPos.w;")
-        src.push("    clipPos.xy -= pickClipPos;");
+        src.push("    clipPos.xy /= clipPos.w;");
+        src.push(`    clipPos.xy = (clipPos.xy - pickClipPos) * (drawingBufferSize / 3.0);`);
         src.push("    clipPos.xy *= clipPos.w;")
         src.push("    return clipPos;")
         src.push("}");

--- a/src/viewer/scene/model/dtx/triangles/renderers/TrianglesDataTexturePickNormalsRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/TrianglesDataTexturePickNormalsRenderer.js
@@ -76,6 +76,7 @@ export class TrianglesDataTexturePickNormalsRenderer {
 
         gl.uniform1i(this._uPickInvisible, frameCtx.pickInvisible);
         gl.uniform2fv(this._uPickClipPos, frameCtx.pickClipPos);
+        gl.uniform2f(this._uDrawingBufferSize, gl.drawingBufferWidth, gl.drawingBufferHeight);
 
         if (scene.logarithmicDepthBufferEnabled) {
             const logDepthBufFC = 2.0 / (Math.log(camera.project.far + 1.0) / Math.LN2);  // TODO: Far should be from projection matrix?
@@ -159,6 +160,7 @@ export class TrianglesDataTexturePickNormalsRenderer {
         this._uRenderPass = program.getLocation("renderPass");
         this._uPickInvisible = program.getLocation("pickInvisible");
         this._uPickClipPos = program.getLocation("pickClipPos");
+        this._uDrawingBufferSize = program.getLocation("drawingBufferSize");
 
         this._uSectionPlanes = [];
 
@@ -243,11 +245,12 @@ export class TrianglesDataTexturePickNormalsRenderer {
             src.push("out float isPerspective;");
         }
 
+        src.push("uniform vec2 drawingBufferSize;");
         src.push("uniform vec2 pickClipPos;");
 
         src.push("vec4 remapClipPos(vec4 clipPos) {");
-        src.push("    clipPos.xy /= clipPos.w;")
-        src.push("    clipPos.xy -= pickClipPos;");
+        src.push("    clipPos.xy /= clipPos.w;");
+        src.push(`    clipPos.xy = (clipPos.xy - pickClipPos) * (drawingBufferSize / 3.0);`);
         src.push("    clipPos.xy *= clipPos.w;")
         src.push("    return clipPos;")
         src.push("}");

--- a/src/viewer/scene/model/vbo/VBOSceneModelRenderers.js
+++ b/src/viewer/scene/model/vbo/VBOSceneModelRenderers.js
@@ -82,12 +82,17 @@ class VBOSceneModelRenderer {
         return src;
     }
 
-    _addRemapClipPosLines(src) {
+    _addRemapClipPosLines(src, viewportSize = 1) {
+        src.push("uniform vec2 drawingBufferSize;");
         src.push("uniform vec2 pickClipPos;");
 
         src.push("vec4 remapClipPos(vec4 clipPos) {");
-        src.push("    clipPos.xy /= clipPos.w;")
-        src.push("    clipPos.xy -= pickClipPos;");
+        src.push("    clipPos.xy /= clipPos.w;");
+        if (viewportSize === 1) {
+            src.push("    clipPos.xy = (clipPos.xy - pickClipPos) * drawingBufferSize;");
+        } else {
+            src.push(`    clipPos.xy = (clipPos.xy - pickClipPos) * (drawingBufferSize / float(${viewportSize}));`);
+        }
         src.push("    clipPos.xy *= clipPos.w;")
         src.push("    return clipPos;")
         src.push("}");
@@ -228,6 +233,7 @@ class VBOSceneModelRenderer {
         this._uPickZNear = program.getLocation("pickZNear");
         this._uPickZFar = program.getLocation("pickZFar");
         this._uPickClipPos = program.getLocation("pickClipPos");
+        this._uDrawingBufferSize = program.getLocation("drawingBufferSize");
 
         this._uColorMap = "uColorMap";
         this._uMetallicRoughMap = "uMetallicRoughMap";
@@ -492,6 +498,10 @@ class VBOSceneModelRenderer {
 
         if (this._uPickClipPos) {
             gl.uniform2fv(this._uPickClipPos, frameCtx.pickClipPos);
+        }
+
+        if (this._uDrawingBufferSize) {
+            gl.uniform2f(this._uDrawingBufferSize, gl.drawingBufferWidth, gl.drawingBufferHeight);
         }
 
         if (this._uPositionsDecodeMatrix) {

--- a/src/viewer/scene/model/vbo/trianglesBatching/renderers/TrianglesBatchingPickNormalsFlatRenderer.js
+++ b/src/viewer/scene/model/vbo/trianglesBatching/renderers/TrianglesBatchingPickNormalsFlatRenderer.js
@@ -23,7 +23,7 @@ class TrianglesBatchingPickNormalsFlatRenderer extends VBOSceneModelTriangleBatc
 
         this._addMatricesUniformBlockLines(src);
 
-        this._addRemapClipPosLines(src);
+        this._addRemapClipPosLines(src, 3);
 
         if (scene.logarithmicDepthBufferEnabled) {
             src.push("uniform float logDepthBufFC;");

--- a/src/viewer/scene/model/vbo/trianglesBatching/renderers/TrianglesBatchingPickNormalsRenderer.js
+++ b/src/viewer/scene/model/vbo/trianglesBatching/renderers/TrianglesBatchingPickNormalsRenderer.js
@@ -24,7 +24,7 @@ class TrianglesBatchingPickNormalsRenderer extends VBOSceneModelTriangleBatching
 
         this._addMatricesUniformBlockLines(src);
 
-        this._addRemapClipPosLines(src);
+        this._addRemapClipPosLines(src, 3);
 
         if (scene.logarithmicDepthBufferEnabled) {
             src.push("uniform float logDepthBufFC;");

--- a/src/viewer/scene/model/vbo/trianglesInstancing/renderers/TrianglesInstancingPickNormalsFlatRenderer.js
+++ b/src/viewer/scene/model/vbo/trianglesInstancing/renderers/TrianglesInstancingPickNormalsFlatRenderer.js
@@ -27,7 +27,7 @@ class TrianglesInstancingPickNormalsFlatRenderer extends VBOSceneModelTriangleIn
 
         this._addMatricesUniformBlockLines(src);
 
-        this._addRemapClipPosLines(src);
+        this._addRemapClipPosLines(src, 3);
 
         if (scene.logarithmicDepthBufferEnabled) {
             src.push("uniform float logDepthBufFC;");

--- a/src/viewer/scene/model/vbo/trianglesInstancing/renderers/TrianglesInstancingPickNormalsRenderer.js
+++ b/src/viewer/scene/model/vbo/trianglesInstancing/renderers/TrianglesInstancingPickNormalsRenderer.js
@@ -31,7 +31,7 @@ class TrianglesInstancingPickNormalsRenderer extends VBOSceneModelTriangleInstan
 
         this._addMatricesUniformBlockLines(src);
 
-        this._addRemapClipPosLines(src);
+        this._addRemapClipPosLines(src, 3);
 
         if (scene.logarithmicDepthBufferEnabled) {
             src.push("uniform float logDepthBufFC;");

--- a/src/viewer/scene/webgl/Renderer.js
+++ b/src/viewer/scene/webgl/Renderer.js
@@ -1486,11 +1486,11 @@ const Renderer = function (scene, options) {
             getClipPosY(canvasPos[1], gl.drawingBufferHeight),
         ];
 
-        const pickNormalBuffer = renderBufferManager.getRenderBuffer("pick-normal", { size: [1, 1] });
+        const pickNormalBuffer = renderBufferManager.getRenderBuffer("pick-normal", { size: [3, 3] });
 
         pickNormalBuffer.bind(gl.RGBA32I);
 
-        gl.viewport(0, 0, 1, 1);
+        gl.viewport(0, 0, pickNormalBuffer.size[0], pickNormalBuffer.size[1]);
 
         gl.enable(gl.DEPTH_TEST);
         gl.disable(gl.CULL_FACE);
@@ -1500,7 +1500,7 @@ const Renderer = function (scene, options) {
 
         pickable.drawPickNormals(frameCtx); // Draw color-encoded fragment World-space normals
 
-        const pix = pickNormalBuffer.read(0, 0, gl.RGBA_INTEGER, gl.INT, Int32Array, 4);
+        const pix = pickNormalBuffer.read(1, 1, gl.RGBA_INTEGER, gl.INT, Int32Array, 4);
 
         pickNormalBuffer.unbind();
 


### PR DESCRIPTION
It seems that partiale derivatives don't work very well on a 1x1 viewport. Indeed, picked normals have a flipped direction sometimes. It may be due to the fact that fragments are computed using 2x2 block, and partiale derivative use this implementation to compute de derivative across neighbouring fragment... Pure supposition but using a 3x3 viewport fix the normal flipped direction issue.

Also, this PR slightly update the lines added for picking (as it is the same for picking normals). Indeed, it adds the `_uDrawingBufferSize` uniform for all pick renderer + uses it in the clip space remapping function to be more correct.