### PR TITLE
Initial touch measurements controls

### DIFF
--- a/examples/measurement/angle_createWithTouch_snapping.html
+++ b/examples/measurement/angle_createWithTouch_snapping.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>xeokit Example</title>
+    <link href="../css/pageStyle.css" rel="stylesheet"/>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
+</head>
+<body>
+<input type="checkbox" id="info-button"/>
+<label for="info-button" class="info-button"><i class="far fa-3x fa-question-circle"></i></label>
+<canvas id="myCanvas"></canvas>
+<div class="slideout-sidebar">
+    <img class="info-icon" src="../../assets/images/measure_angle_icon.png"/>
+    <h1>AngleMeasurementPlugin with AngleMeasurementsTouchControl and PointerLens</h1>
+    <h2>Tap on the model to create angle measurements, with vertex and edge snapping</h2>
+    <p>In this example, we're loading a BIM model from the file system, then creating angle measurements wherever the
+        user clicks on the model with the Touch.</p>
+    <h3>Components Used</h3>
+    <ul>
+        <li>
+            <a href="../../docs/class/src/viewer/Viewer.js~Viewer.html"
+               target="_other">Viewer</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/AngleMeasurementsPlugin/AngleMeasurementsPlugin.js~AngleMeasurementsPlugin.html"
+               target="_other">AngleMeasurementsPlugin</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/AngleMeasurementsPlugin/AngleMeasurementsTouchControl.js~AngleMeasurementsTouchControl.html"
+               target="_other">AngleMeasurementsTouchControl</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/extras/PointerLens/PointerLens.js~PointerLens.html"
+               target="_other">PointerLens</a>
+        </li>
+    </ul>
+    <h3>Resources</h3>
+    <ul>
+        <li>
+            <a href="http://openifcmodel.cs.auckland.ac.nz/Model/Details/274"
+               target="_other">Model source</a>
+        </li>
+    </ul>
+</div>
+</body>
+<script type="module">
+
+    import {
+        Viewer,
+        XKTLoaderPlugin,
+        AngleMeasurementsPlugin,
+        AngleMeasurementsTouchControl,
+        PointerLens
+    } from "../../dist/xeokit-sdk.es.js";
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas",
+        dtxEnabled: true
+    });
+
+    viewer.camera.eye = [-3.93, 2.85, 27.01];
+    viewer.camera.look = [4.40, 3.72, 8.89];
+    viewer.camera.up = [-0.01, 0.99, 0.039];
+
+    const xktLoader = new XKTLoaderPlugin(viewer);
+
+    const sceneModel = xktLoader.load({
+        id: "myModel",
+        src: "../../assets/models/xkt/v10/glTF-Embedded/Duplex_A_20110505.glTFEmbedded.xkt",
+        edges: true
+    });
+
+    const angleMeasurements = new AngleMeasurementsPlugin(viewer);
+
+    const angleMeasurementsTouchControl = new AngleMeasurementsTouchControl(angleMeasurements, {
+        pointerLens: new PointerLens(viewer)
+    });
+
+    angleMeasurementsTouchControl.snapping = true;
+
+    angleMeasurementsTouchControl.activate();
+
+</script>
+</html>

--- a/examples/measurement/distance_createWithTouch_snapping.html
+++ b/examples/measurement/distance_createWithTouch_snapping.html
@@ -1,0 +1,282 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>xeokit Example</title>
+    <link href="../css/pageStyle.css" rel="stylesheet"/>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
+
+    <style>
+
+        .viewer-ruler-wire-highlighted {
+            border: 2px solid white !important;
+        }
+
+        .viewer-ruler-label-highlighted {
+            border: 2px solid white !important;
+        }
+
+        .viewer-ruler-dot-highlighted {
+            border: 2px solid white !important;
+        }
+
+        .xeokit-context-menu {
+            font-family: 'Roboto', sans-serif;
+            font-size: 15px;
+            display: none;
+            z-index: 300000;
+            background: rgba(255, 255, 255, 0.46);
+            border: 1px solid black;
+            border-radius: 6px;
+            padding: 0;
+            width: 200px;
+        }
+
+        .xeokit-context-menu ul {
+            list-style: none;
+            margin-left: 0;
+            padding: 0;
+        }
+
+        .xeokit-context-menu ul li {
+            list-style-type: none;
+            padding-left: 10px;
+            padding-right: 20px;
+            padding-top: 4px;
+            padding-bottom: 4px;
+            color: black;
+            border-bottom: 1px solid gray;
+            background: rgba(255, 255, 255, 0.46);
+            cursor: pointer;
+            width: calc(100% - 30px);
+        }
+
+        .xeokit-context-menu ul li:hover {
+            background: black;
+            color: white;
+            font-weight: normal;
+        }
+
+        .xeokit-context-menu ul li span {
+            display: inline-block;
+        }
+
+        .xeokit-context-menu .disabled {
+            display: inline-block;
+            color: gray;
+            cursor: default;
+            font-weight: normal;
+        }
+
+        .xeokit-context-menu .disabled:hover {
+            color: gray;
+            cursor: default;
+            background: #eeeeee;
+            font-weight: normal;
+        }
+
+    </style>
+</head>
+<body>
+<input type="checkbox" id="info-button"/>
+<label for="info-button" class="info-button"><i class="far fa-3x fa-question-circle"></i></label>
+<canvas id="myCanvas"></canvas>
+<div class="slideout-sidebar">
+    <img class="info-icon" src="../../assets/images/measure_distance_icon.png"/>
+    <h1>DistanceMeasurementPlugin with DistanceMeasurementsTouchControl and PointerLens</h1>
+    <h2>Tap on the model to create distance measurements, with no vertex and edge snapping</h2>
+    <p>In this example, we're loading a BIM model from the file system, then creating distance measurements wherever the
+        user clicks on the model with the Touch.</p>
+    <h3>Components Used</h3>
+    <ul>
+        <li>
+            <a href="../../docs/class/src/viewer/Viewer.js~Viewer.html"
+               target="_other">Viewer</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsPlugin.js~DistanceMeasurementsPlugin.html"
+               target="_other">DistanceMeasurementsPlugin</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsTouchControl.js~DistanceMeasurementsTouchControl.html"
+               target="_other">DistanceMeasurementsTouchControl</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/extras/PointerLens/PointerLens.js~PointerLens.html"
+               target="_other">PointerLens</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js~XKTLoaderPlugin.html"
+               target="_other">XKTLoaderPlugin</a>
+        </li>
+    </ul>
+    <h3>Resources</h3>
+    <ul>
+        <li>
+            <a href="http://openifcmodel.cs.auckland.ac.nz/Model/Details/274"
+               target="_other">Model source</a>
+        </li>
+    </ul>
+</div>
+</body>
+<script type="module">
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Import the modules we need for this example
+    //------------------------------------------------------------------------------------------------------------------
+
+    import {Viewer, XKTLoaderPlugin, ContextMenu, DistanceMeasurementsPlugin, DistanceMeasurementsTouchControl, PointerLens} from "../../dist/xeokit-sdk.es.js";
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a Viewer and arrange the camera
+    //------------------------------------------------------------------------------------------------------------------
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas",
+        dtxEnabled: true
+    });
+
+    viewer.camera.eye = [-3.93, 2.85, 27.01];
+    viewer.camera.look = [4.40, 3.72, 8.89];
+    viewer.camera.up = [-0.01, 0.99, 0.039];
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Load a model
+    //------------------------------------------------------------------------------------------------------------------
+
+    const xktLoader = new XKTLoaderPlugin(viewer);
+
+    const sceneModel = xktLoader.load({
+        id: "myModel",
+        src: "../../assets/models/xkt/v10/glTF-Embedded/Duplex_A_20110505.glTFEmbedded.xkt",
+        edges: true
+    });
+
+    sceneModel.on("loaded", ()=>{
+        viewer.cameraFlight.jumpTo(sceneModel);
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // DistanceMeasurementsPlugin, DistanceMeasurementsTouchControl and PointerLens
+    //------------------------------------------------------------------------------------------------------------------
+
+    const distanceMeasurements = new DistanceMeasurementsPlugin(viewer);
+
+    const distanceMeasurementsTouchControl  = new DistanceMeasurementsTouchControl(distanceMeasurements, {
+        pointerLens : new PointerLens(viewer)
+    })
+
+    distanceMeasurementsTouchControl.snapping = true;
+
+    distanceMeasurementsTouchControl.activate();
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a context menu to delete and configure measurements
+    //------------------------------------------------------------------------------------------------------------------
+
+    const distanceMeasurementsContextMenu = new ContextMenu({
+        items: [
+            [
+                {
+                    title: "Clear",
+                    doAction: function (context) {
+                        context.distanceMeasurement.destroy();
+                    }
+                },
+                {
+                    getTitle: (context) => {
+                        return context.distanceMeasurement.axisVisible ? "Hide Axis" : "Show Axis";
+                    },
+                    doAction: function (context) {
+                        context.distanceMeasurement.axisVisible = !context.distanceMeasurement.axisVisible;
+                    }
+                },
+                {
+                    getTitle: (context) => {
+                        return context.distanceMeasurement.labelsVisible ? "Hide Labels" : "Show Labels";
+                    },
+                    doAction: function (context) {
+                        context.distanceMeasurement.labelsVisible = !context.distanceMeasurement.labelsVisible;
+                    }
+                }
+            ], [
+                {
+                    title: "Clear All",
+                    getEnabled: function (context) {
+                        return (Object.keys(context.distanceMeasurementsPlugin.measurements).length > 0);
+                    },
+                    doAction: function (context) {
+                        context.distanceMeasurementsPlugin.clear();
+                    }
+                }
+            ]
+        ]
+    });
+
+    distanceMeasurementsContextMenu.on("hidden", () => {
+        if (distanceMeasurementsContextMenu.context.distanceMeasurement) {
+            distanceMeasurementsContextMenu.context.distanceMeasurement.setHighlighted(false);
+        }
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a context menu to activate and deactivate the control
+    //------------------------------------------------------------------------------------------------------------------
+
+    const canvasContextMenu = new ContextMenu({
+        enabled: true,
+        context: {
+            viewer: viewer
+        },
+        items: [
+            [
+                {
+                    getTitle: (context) => {
+                        return distanceMeasurements.control.active ? "Deactivate Control" : "Activate Control";
+                    },
+                    doAction: function (context) {
+                        distanceMeasurements.control.active
+                            ? distanceMeasurements.control.deactivate()
+                            : distanceMeasurements.control.activate();
+                    }
+                }
+            ]
+        ]
+    });
+
+    // viewer.cameraControl.on("rightClick", function (e) {
+    //     canvasContextMenu.show(e.pagePos[0], e.pagePos[1]);
+    //     e.event.preventDefault();
+    // });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create an DistanceMeasurementsPlugin, activate its DistanceMeasuremntsControl
+    //------------------------------------------------------------------------------------------------------------------
+
+    distanceMeasurements.on("TouchOver", (e) => {
+        e.distanceMeasurement.setHighlighted(true);
+    });
+
+    distanceMeasurements.on("TouchLeave", (e) => {
+        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.distanceMeasurement.id === e.distanceMeasurement.id) {
+            return;
+        }
+        e.distanceMeasurement.setHighlighted(false);
+    });
+
+    distanceMeasurements.on("contextMenu", (e) => {
+        distanceMeasurementsContextMenu.context = { // Must set context before showing menu
+            viewer: viewer,
+            distanceMeasurementsPlugin: distanceMeasurements,
+            distanceMeasurement: e.distanceMeasurement
+        };
+        distanceMeasurementsContextMenu.show(e.event.clientX, e.event.clientY);
+        e.event.preventDefault();
+    });
+
+    window.viewer = viewer;
+
+</script>
+</html>

--- a/examples/measurement/index.html
+++ b/examples/measurement/index.html
@@ -258,9 +258,12 @@
 
         "Measuring Distances": [
 
-            "# Creating distance measurements with mouse",
+            "# Creating distance measurements with mouse, snapping enabled",
             ["distance_createWithMouse_snapping", "Click with mouse on model to create distance measurements, snapping enabled"],
             ["distance_createWithMouse_snapping_Lyon", "Click with mouse on model to create distance measurements, snapping enabled"],
+
+            "# Creating distance measurements with touch, snapping enabled",
+            ["distance_createWithTouch_snapping", "Touch on model to create distance measurements, snapping enabled"],
 
             "# Creating distance measurements with mouse, snapping disabled",
             ["distance_createWithMouse_nosnapping", "Click with mouse on model to create distance measurements, snapping disabled"],
@@ -275,6 +278,9 @@
 
             "# Creating angle measurements with mouse, snapping enabled",
             ["angle_createWithMouse_snapping", "Click with mouse on model to create angle measurements, snapping enabled"],
+
+            "# Creating angle measurements with touch, snapping enabled",
+            ["angle_createWithTouch_snapping", "Touch on model to create angle measurements, snapping enabled"],
 
             "# Creating angle measurements with mouse, snapping disabled",
             ["angle_createWithMouse_nosnapping", "Click with mouse on model to create angle measurements, snapping disabled"],

--- a/src/plugins/AngleMeasurementsPlugin/AngleMeasurementsTouchControl.js
+++ b/src/plugins/AngleMeasurementsPlugin/AngleMeasurementsTouchControl.js
@@ -1,0 +1,1053 @@
+import {Component} from "../../viewer/scene/Component.js";
+import {math} from "../../viewer/scene/math/math.js";
+import {AngleMeasurementsControl} from "./AngleMeasurementsControl";
+
+const TOUCH_FINDING_ORIGIN = 0;
+const QUICK_TOUCH_FINDING_ORIGIN = 1;
+const LONG_TOUCH_FINDING_ORIGIN = 2;
+const TOUCH_FINDING_CORNER = 3;
+const QUICK_TOUCH_MOUSE_FINDING_CORNER = 4;
+const LONG_TOUCH_MOUSE_FINDING_CORNER = 5;
+const TOUCH_FINDING_TARGET = 6;
+const QUICK_TOUCH_FINDING_TARGET = 7;
+const LONG_TOUCH_FINDING_TARGET = 8;
+const TOUCH_CANCELING = 9;
+
+/**
+ * Creates {@link AngleMeasurement}s from mouse and touch input.
+ *
+ * Belongs to a {@link AngleMeasurementsPlugin}. Located at {@link AngleMeasurementsPlugin#control}.
+ *
+ * Once the AngleMeasurementControl is activated, the first click on any {@link Entity} begins constructing a {@link AngleMeasurement}, fixing its origin to that Entity. The next click on any Entity will complete the AngleMeasurement, fixing its target to that second Entity. The AngleMeasurementControl will then wait for the next click on any Entity, to begin constructing another AngleMeasurement, and so on, until deactivated.
+ *
+ * See {@link AngleMeasurementsPlugin} for more info.
+ *
+ * @experimental
+ */
+export class AngleMeasurementsTouchControl extends AngleMeasurementsControl{
+
+    /**
+     * Creates a AngleMeasurementsTouchControl bound to the given AngleMeasurementsPlugin.
+     */
+    constructor(angleMeasurementsPlugin, cfg = {}) {
+
+        super(angleMeasurementsPlugin.viewer.scene);
+
+        this.pointerLens = cfg.pointerLens;
+
+        this._active = false;
+        this._touchState = TOUCH_FINDING_ORIGIN;
+
+        this._currentAngleMeasurement = null;
+        
+        const markerDiv = document.createElement('div');
+        const canvas = this.scene.canvas.canvas;
+        canvas.parentNode.insertBefore(markerDiv, canvas);
+
+        markerDiv.style.background = "black";
+        markerDiv.style.border = "2px solid blue";
+        markerDiv.style.borderRadius = "10px";
+        markerDiv.style.width = "5px";
+        markerDiv.style.height = "5px";
+        markerDiv.style.margin = "-200px -200px";
+        markerDiv.style.zIndex = "100";
+        markerDiv.style.position = "absolute";
+        markerDiv.style.pointerEvents = "none";
+
+        this.markerDiv = markerDiv;
+
+        this._onTouchStart = null;
+        this._onTouchMove = null;
+        this._onTouchEnd = null;
+
+        this._longTouchTimeoutMs = 400;
+
+        this._snapEdge = cfg.snapEdge !== false;
+        this._snapVertex = cfg.snapVertex !== false;
+
+        this._attachPlugin(angleMeasurementsPlugin, cfg);
+    }
+
+    _attachPlugin(angleMeasurementsPlugin) {
+
+        /**
+         * The {@link AngleMeasurementsPlugin} that owns this AngleMeasurementsTouchControl.
+         * @type {AngleMeasurementsPlugin}
+         */
+        this.angleMeasurementsPlugin = angleMeasurementsPlugin;
+
+        /**
+         * The {@link AngleMeasurementsPlugin} that owns this AngleMeasurementsTouchControl.
+         * @type {AngleMeasurementsPlugin}
+         */
+        this.plugin = angleMeasurementsPlugin;
+    }
+
+    
+    /** Gets if this AngleMeasurementsControl is currently active, where it is responding to input.
+     *
+     * @returns {Boolean}
+     */
+    get active() {
+        return this._active;
+    }
+
+    /**
+     * Sets whether snap-to-vertex is enabled for this AngleMeasurementsControl.
+     * This is `true` by default.
+     * @param snapVertex
+     */
+    set snapVertex(snapVertex) {
+        this._snapVertex = snapVertex;
+    }
+
+    /**
+     * Gets whether snap-to-vertex is enabled for this AngleMeasurementsControl.
+     * This is `true` by default.
+     * @returns {*}
+     */
+    get snapVertex() {
+        return this._snapVertex;
+    }
+
+    /**
+     * Sets whether snap-to-edge is enabled for this AngleMeasurementsControl.
+     * This is `true` by default.
+     * @param snapEdge
+     */
+    set snapEdge(snapEdge) {
+        this._snapEdge = snapEdge;
+    }
+
+    /**
+     * Gets whether snap-to-edge is enabled for this AngleMeasurementsControl.
+     * This is `true` by default.
+     * @returns {*}
+     */
+    get snapEdge() {
+        return this._snapEdge;
+    }
+
+    /**
+     * Activates this AngleMeasurementsControl, ready to respond to input.
+     */
+    activate() {
+
+        if (this._active) {
+            return;
+        }
+
+        const plugin = this.plugin;
+        const scene = this.scene;
+        const input = scene.input;
+        const canvas = scene.canvas.canvas;
+
+        const clickTolerance = 20;
+
+        const cameraControl = this.plugin.viewer.cameraControl;
+
+        const pointerLens = this.pointerLens;
+
+        let longTouchTimeout = null;
+
+        const disableCameraMouseControl = () => {
+            cameraControl.active = false;
+        }
+
+        const enableCameraMouseControl = () => {
+            cameraControl.active = true;
+        }
+
+        // const scheduleSurfacePickIfNeeded = () => {
+        //     if (!cameraControl._handlers[2]._active) {
+        //         cameraControl._controllers.pickController.schedulePickSurface = true;
+        //         cameraControl._controllers.pickController.update();
+        //     }
+        // }
+
+        this._touchState = TOUCH_FINDING_ORIGIN;
+
+        const touchStartCanvasPos = math.vec2();
+        const touchMoveCanvasPos = math.vec2();
+        const touchEndCanvasPos = math.vec2();
+        const pointerWorldPos = math.vec3();
+
+        canvas.addEventListener("touchstart", this._onTouchStart = (event) => {
+
+            const currentNumTouches = event.touches.length;
+
+            if (currentNumTouches !== 1) {
+                return;
+            }
+
+            const touchX = event.touches[0].clientX;
+            const touchY = event.touches[0].clientY;
+
+            touchStartCanvasPos.set([touchX, touchY]);
+            touchMoveCanvasPos.set([touchX, touchY]);
+
+            switch (this._touchState) {
+
+                case TOUCH_FINDING_ORIGIN:
+                    if (currentNumTouches !== 1 && longTouchTimeout !== null) { // Two or more fingers down
+                        clearTimeout(longTouchTimeout);
+                        longTouchTimeout = null;
+                        this._touchState = TOUCH_CANCELING;
+                        // console.log("touchstart: this._touchState= TOUCH_FINDING_ORIGIN -> TOUCH_CANCELING")
+                        return;
+                    }
+                    if (currentNumTouches === 1) { // One finger down
+                        longTouchTimeout = setTimeout(() => {
+                            longTouchTimeout = null;
+                            if (currentNumTouches !== 1 ||
+                                touchMoveCanvasPos[0] > touchStartCanvasPos[0] + clickTolerance ||
+                                touchMoveCanvasPos[0] < touchStartCanvasPos[0] - clickTolerance ||
+                                touchMoveCanvasPos[1] > touchStartCanvasPos[1] + clickTolerance ||
+                                touchMoveCanvasPos[1] < touchStartCanvasPos[1] - clickTolerance) {
+                                return;   // Has moved
+                            }
+                            // Long touch
+                            disableCameraMouseControl();
+                            if (pointerLens) {
+                                pointerLens.visible = true;
+                                pointerLens.centerPos = touchStartCanvasPos;
+                                pointerLens.cursorPos = touchStartCanvasPos;
+                            }
+                            if (pointerLens) {
+                                pointerLens.centerPos = touchMoveCanvasPos;
+                            }
+                            const snapPickResult = scene.snapPick({
+                                canvasPos: touchMoveCanvasPos,
+                                snapVertex: this._snapVertex,
+                                snapEdge: this._snapEdge
+                            });
+                            if (snapPickResult && snapPickResult.snappedWorldPos) {
+                                if (pointerLens) {
+                                    pointerLens.cursorPos = snapPickResult.snappedCanvasPos;
+                                    pointerLens.snapped = true;
+                                }
+                                pointerWorldPos.set(snapPickResult.snappedWorldPos);
+                                if (!this._currentAngleMeasurement) {
+                                    this._currentAngleMeasurement = plugin.createMeasurement({
+                                        id: math.createUUID(),
+                                        origin: {
+                                            worldPos: snapPickResult.snappedWorldPos
+                                        },
+                                        corner: {
+                                            worldPos: snapPickResult.snappedWorldPos
+                                        },
+                                        target: {
+                                            worldPos: snapPickResult.snappedWorldPos
+                                        }
+                                    });
+                                    this._currentAngleMeasurement.clickable = false;
+                                    this._currentAngleMeasurement.originVisible = true;
+                                    this._currentAngleMeasurement.originWireVisible = false;
+                                    this._currentAngleMeasurement.cornerVisible = false;
+                                    this._currentAngleMeasurement.cornerWireVisible = false;
+                                    this._currentAngleMeasurement.targetVisible = false;
+                                    this._currentAngleMeasurement.targetWireVisible = false;
+                                    this._currentAngleMeasurement.angleVisible = false
+                                } else {
+                                    this._currentAngleMeasurement.origin.worldPos = snapPickResult.snappedWorldPos;
+                                }
+                                this.fire("measurementStart", this._currentAngleMeasurement);
+                                this._touchState = LONG_TOUCH_FINDING_ORIGIN;
+                                // console.log("touchstart: this._touchState= TOUCH_FINDING_ORIGIN -> LONG_TOUCH_FINDING_ORIGIN")
+                            } else {
+                                const pickResult = scene.pick({
+                                    canvasPos: touchMoveCanvasPos,
+                                    pickSurface: true
+                                })
+                                if (pickResult && pickResult.worldPos) {
+                                    if (pointerLens) {
+                                        pointerLens.cursorPos = pickResult.canvasPos;
+                                        pointerLens.snapped = false;
+                                    }
+                                    pointerWorldPos.set(pickResult.worldPos);
+                                    if (!this._currentAngleMeasurement) {
+                                        this._currentAngleMeasurement = plugin.createMeasurement({
+                                            id: math.createUUID(),
+                                            origin: {
+                                                worldPos: pickResult.worldPos
+                                            },
+                                            corner: {
+                                                worldPos: pickResult.worldPos
+                                            },
+                                            target: {
+                                                worldPos: pickResult.worldPos
+                                            }
+                                        });
+                                        this._currentAngleMeasurement.clickable = false;
+                                        this._currentAngleMeasurement.originVisible = true;
+                                        this._currentAngleMeasurement.originWireVisible = false;
+                                        this._currentAngleMeasurement.cornerVisible = false;
+                                        this._currentAngleMeasurement.cornerWireVisible = false;
+                                        this._currentAngleMeasurement.targetVisible = false;
+                                        this._currentAngleMeasurement.targetWireVisible = false;
+                                        this._currentAngleMeasurement.angleVisible = false
+                                    } else {
+                                        this._currentAngleMeasurement.origin.worldPos = pickResult.worldPos;
+                                    }
+                                    this.fire("measurementStart", this._currentAngleMeasurement);
+                                } else {
+                                    if (pointerLens) {
+                                        pointerLens.cursorPos = null;
+                                        pointerLens.snapped = false;
+                                    }
+                                }
+                            }
+                            this._touchState = LONG_TOUCH_FINDING_ORIGIN;
+                            // console.log("touchstart: this._touchState= TOUCH_FINDING_ORIGIN -> LONG_TOUCH_FINDING_ORIGIN")
+                        }, this._longTouchTimeoutMs);
+                        this._touchState = QUICK_TOUCH_FINDING_ORIGIN;
+                        // console.log("touchstart: this._touchState= TOUCH_FINDING_ORIGIN -> QUICK_TOUCH_FINDING_ORIGIN")
+                    }
+                    break;
+
+                case TOUCH_FINDING_CORNER:
+                    if (currentNumTouches !== 1 && longTouchTimeout !== null) { // Two or more fingers down
+                        clearTimeout(longTouchTimeout);
+                        longTouchTimeout = null;
+                        this._touchState = TOUCH_CANCELING;
+                        // console.log("touchstart: this._touchState= TOUCH_FINDING_CORNER -> TOUCH_CANCELING")
+                        return;
+                    }
+                    if (currentNumTouches === 1) { // One finger down
+                        longTouchTimeout = setTimeout(() => {
+                            longTouchTimeout = null;
+                            if (currentNumTouches !== 1 ||
+                                touchMoveCanvasPos[0] > touchStartCanvasPos[0] + clickTolerance ||
+                                touchMoveCanvasPos[0] < touchStartCanvasPos[0] - clickTolerance ||
+                                touchMoveCanvasPos[1] > touchStartCanvasPos[1] + clickTolerance ||
+                                touchMoveCanvasPos[1] < touchStartCanvasPos[1] - clickTolerance) {
+                                return;   // Has moved
+                            }
+                            // Long touch
+                            disableCameraMouseControl();
+                            if (pointerLens) {
+                                pointerLens.visible = true;
+                                pointerLens.centerPos = touchStartCanvasPos;
+                                pointerLens.cursorPos = touchStartCanvasPos;
+                            }
+
+                            if (pointerLens) {
+                                pointerLens.centerPos = touchMoveCanvasPos;
+                            }
+                            const snapPickResult = scene.snapPick({
+                                canvasPos: touchMoveCanvasPos,
+                                snapVertex: this._snapVertex,
+                                snapEdge: this._snapEdge
+                            });
+                            if (snapPickResult && snapPickResult.snappedWorldPos) {
+                                if (pointerLens) {
+                                    pointerLens.cursorPos = snapPickResult.snappedCanvasPos;
+                                    pointerLens.snapped = true;
+                                }
+                                pointerWorldPos.set(snapPickResult.snappedWorldPos);
+                                this._currentAngleMeasurement.corner.worldPos = snapPickResult.snappedWorldPos;
+                                this._currentAngleMeasurement.originVisible = true;
+                                this._currentAngleMeasurement.originWireVisible = true;
+                                this._currentAngleMeasurement.cornerVisible = true;
+                                this._currentAngleMeasurement.cornerWireVisible = false;
+                                this._currentAngleMeasurement.targetVisible = false;
+                                this._currentAngleMeasurement.targetWireVisible = false;
+                                this._currentAngleMeasurement.angleVisible = false
+                            } else {
+                                const pickResult = scene.pick({
+                                    canvasPos: touchMoveCanvasPos,
+                                    pickSurface: true
+                                })
+                                if (pickResult && pickResult.worldPos) {
+                                    if (pointerLens) {
+                                        pointerLens.cursorPos = pickResult.canvasPos;
+                                        pointerLens.snapped = false;
+                                    }
+                                    pointerWorldPos.set(pickResult.worldPos);
+                                    this._currentAngleMeasurement.corner.worldPos = pickResult.worldPos;
+                                    this._currentAngleMeasurement.originVisible = true;
+                                    this._currentAngleMeasurement.originWireVisible = true;
+                                    this._currentAngleMeasurement.cornerVisible = true;
+                                    this._currentAngleMeasurement.cornerWireVisible = false;
+                                    this._currentAngleMeasurement.targetVisible = false;
+                                    this._currentAngleMeasurement.targetWireVisible = false;
+                                    this._currentAngleMeasurement.angleVisible = false
+                                } else {
+                                    if (pointerLens) {
+                                        pointerLens.cursorPos = null;
+                                        pointerLens.snapped = false;
+                                    }
+                                }
+                            }
+                            this._touchState = LONG_TOUCH_MOUSE_FINDING_CORNER;
+                            // console.log("touchstart: this._touchState= TOUCH_FINDING_CORNER -> LONG_TOUCH_MOUSE_FINDING_CORNER")
+                        }, this._longTouchTimeoutMs);
+                        this._touchState = QUICK_TOUCH_MOUSE_FINDING_CORNER;
+                        // console.log("touchstart: this._touchState= TOUCH_FINDING_CORNER -> QUICK_TOUCH_MOUSE_FINDING_CORNER")
+                    }
+                    break;
+
+                case TOUCH_FINDING_TARGET:
+                    if (currentNumTouches !== 1 && longTouchTimeout !== null) { // Two or more fingers down
+                        clearTimeout(longTouchTimeout);
+                        longTouchTimeout = null;
+                        return;
+                    }
+                    if (currentNumTouches === 1) { // One finger down
+                        longTouchTimeout = setTimeout(() => {
+                            longTouchTimeout = null;
+                            if (currentNumTouches !== 1 ||
+                                touchMoveCanvasPos[0] > touchStartCanvasPos[0] + clickTolerance ||
+                                touchMoveCanvasPos[0] < touchStartCanvasPos[0] - clickTolerance ||
+                                touchMoveCanvasPos[1] > touchStartCanvasPos[1] + clickTolerance ||
+                                touchMoveCanvasPos[1] < touchStartCanvasPos[1] - clickTolerance) {
+                                // Has moved
+                                return;
+                            }
+                            // Long touch
+                            disableCameraMouseControl();
+                            if (pointerLens) {
+                                pointerLens.visible = true;
+                                pointerLens.centerPos = touchStartCanvasPos;
+                            }
+
+                            const snapPickResult = scene.snapPick({
+                                canvasPos: touchMoveCanvasPos,
+                                snapVertex: this._snapVertex,
+                                snapEdge: this._snapEdge
+                            });
+                            if (snapPickResult && snapPickResult.snappedWorldPos) {
+                                if (pointerLens) {
+                                    pointerLens.cursorPos = snapPickResult.snappedCanvasPos;
+                                    pointerLens.snapped = true;
+                                }
+                                pointerWorldPos.set(snapPickResult.snappedWorldPos);
+                                this._currentAngleMeasurement.target.worldPos = snapPickResult.snappedWorldPos;
+                                this._currentAngleMeasurement.originVisible = true;
+                                this._currentAngleMeasurement.originWireVisible = true;
+                                this._currentAngleMeasurement.cornerVisible = true;
+                                this._currentAngleMeasurement.cornerWireVisible = true;
+                                this._currentAngleMeasurement.targetVisible = true;
+                                this._currentAngleMeasurement.targetWireVisible = true;
+                                this._currentAngleMeasurement.angleVisible = true;
+                            } else {
+                                const pickResult = scene.pick({
+                                    canvasPos: touchMoveCanvasPos,
+                                    pickSurface: true
+                                })
+                                if (pickResult && pickResult.worldPos) {
+                                    if (pointerLens) {
+                                        pointerLens.cursorPos = pickResult.canvasPos;
+                                        pointerLens.snapped = false;
+                                    }
+                                    pointerWorldPos.set(pickResult.worldPos);
+                                    this._currentAngleMeasurement.target.worldPos = pickResult.worldPos;
+                                    this._currentAngleMeasurement.originVisible = true;
+                                    this._currentAngleMeasurement.originWireVisible = true;
+                                    this._currentAngleMeasurement.cornerVisible = true;
+                                    this._currentAngleMeasurement.cornerWireVisible = true;
+                                    this._currentAngleMeasurement.targetVisible = true;
+                                    this._currentAngleMeasurement.targetWireVisible = true;
+                                    this._currentAngleMeasurement.angleVisible = true;
+                                } else {
+                                    if (pointerLens) {
+                                        pointerLens.cursorPos = null;
+                                        pointerLens.snapped = false;
+                                    }
+                                }
+                            }
+                            this._touchState = LONG_TOUCH_FINDING_TARGET;
+                            // console.log("touchstart: this._touchState= TOUCH_FINDING_TARGET -> LONG_TOUCH_FINDING_TARGET")
+                        }, this._longTouchTimeoutMs);
+                        this._touchState = QUICK_TOUCH_FINDING_TARGET;
+                        // console.log("touchstart: this._touchState= TOUCH_FINDING_TARGET -> QUICK_TOUCH_FINDING_TARGET")
+                    }
+                    break;
+
+                default:
+                    if (longTouchTimeout !== null) {
+                        clearTimeout(longTouchTimeout);
+                        longTouchTimeout = null;
+                    }
+                    enableCameraMouseControl();
+                    this._touchState = TOUCH_CANCELING;
+                    // console.log("touchstart: this._touchState= default -> TOUCH_CANCELING")
+
+                    return;
+            }
+
+        }, {passive: true});
+
+        canvas.addEventListener("touchmove", this._onTouchMove = (event) => {
+            const currentNumTouches = event.touches.length;
+            if (currentNumTouches !== 1) {
+                return;
+            }
+            const touchX = event.touches[0].clientX;
+            const touchY = event.touches[0].clientY;
+            touchMoveCanvasPos.set([touchX, touchY]);
+            let snapPickResult;
+            let pickResult;
+
+            switch (this._touchState) {
+
+                case TOUCH_CANCELING:
+                    break;
+
+                case TOUCH_FINDING_ORIGIN:
+                    this._touchState = TOUCH_FINDING_ORIGIN;
+                    // console.log("touchmove: this._touchState= TOUCH_FINDING_ORIGIN -> TOUCH_FINDING_ORIGIN")
+                    break;
+
+                case QUICK_TOUCH_FINDING_ORIGIN:
+                    this._touchState = QUICK_TOUCH_FINDING_ORIGIN;
+                    // console.log("touchmove: this._touchState= QUICK_TOUCH_FINDING_ORIGIN -> QUICK_TOUCH_FINDING_ORIGIN")
+                    break;
+
+                case LONG_TOUCH_FINDING_ORIGIN:
+                    if (pointerLens) {
+                        pointerLens.centerPos = touchMoveCanvasPos;
+                    }
+                    snapPickResult = scene.snapPick({
+                        canvasPos: touchMoveCanvasPos,
+                        snapVertex: this._snapVertex,
+                        snapEdge: this._snapEdge
+                    });
+                    if (snapPickResult && snapPickResult.snappedWorldPos) {
+                        if (pointerLens) {
+                            pointerLens.cursorPos = snapPickResult.snappedCanvasPos;
+                            pointerLens.snapped = true;
+                        }
+                        pointerWorldPos.set(snapPickResult.snappedWorldPos);
+                        if (!this._currentAngleMeasurement) {
+                            this._currentAngleMeasurement = plugin.createMeasurement({
+                                id: math.createUUID(),
+                                origin: {
+                                    worldPos: snapPickResult.snappedWorldPos
+                                },
+                                corner: {
+                                    worldPos: snapPickResult.snappedWorldPos
+                                },
+                                target: {
+                                    worldPos: snapPickResult.snappedWorldPos
+                                }
+                            });
+                            this._currentAngleMeasurement.clickable = false;
+                            this._currentAngleMeasurement.originVisible = true;
+                            this._currentAngleMeasurement.originWireVisible = false;
+                            this._currentAngleMeasurement.cornerVisible = false;
+                            this._currentAngleMeasurement.cornerWireVisible = false;
+                            this._currentAngleMeasurement.targetVisible = false;
+                            this._currentAngleMeasurement.targetWireVisible = false;
+                            this._currentAngleMeasurement.angleVisible = false
+                        } else {
+                            this._currentAngleMeasurement.origin.worldPos = snapPickResult.snappedWorldPos;
+                        }
+                        this.fire("measurementStart", this._currentAngleMeasurement);
+                    } else {
+                        pickResult = scene.pick({
+                            canvasPos: touchMoveCanvasPos,
+                            pickSurface: true
+                        })
+                        if (pickResult && pickResult.worldPos) {
+                            if (pointerLens) {
+                                pointerLens.cursorPos = pickResult.canvasPos;
+                                pointerLens.snapped = false;
+                            }
+                            pointerWorldPos.set(pickResult.worldPos);
+                            if (!this._currentAngleMeasurement) {
+                                this._currentAngleMeasurement = plugin.createMeasurement({
+                                    id: math.createUUID(),
+                                    origin: {
+                                        worldPos: pickResult.worldPos
+                                    },
+                                    corner: {
+                                        worldPos: pickResult.worldPos
+                                    },
+                                    target: {
+                                        worldPos: pickResult.worldPos
+                                    }
+                                });
+                                this._currentAngleMeasurement.clickable = false;
+                                this._currentAngleMeasurement.originVisible = true;
+                                this._currentAngleMeasurement.originWireVisible = false;
+                                this._currentAngleMeasurement.cornerVisible = false;
+                                this._currentAngleMeasurement.cornerWireVisible = false;
+                                this._currentAngleMeasurement.targetVisible = false;
+                                this._currentAngleMeasurement.targetWireVisible = false;
+                                this._currentAngleMeasurement.angleVisible = false
+                            } else {
+                                this._currentAngleMeasurement.origin.worldPos = pickResult.worldPos;
+                            }
+                            this.fire("measurementStart", this._currentAngleMeasurement);
+                        } else {
+                            if (pointerLens) {
+                                pointerLens.cursorPos = null;
+                                pointerLens.snapped = false;
+                            }
+                        }
+                    }
+                    this._touchState = LONG_TOUCH_FINDING_ORIGIN;
+                    // console.log("touchmove: this._touchState= LONG_TOUCH_FINDING_ORIGIN -> LONG_TOUCH_FINDING_ORIGIN")
+                    break;
+
+                case TOUCH_FINDING_CORNER:
+                    this._touchState = TOUCH_FINDING_CORNER;
+                    // console.log("touchmove: this._touchState= TOUCH_FINDING_CORNER -> TOUCH_FINDING_CORNER")
+                    break;
+
+                case QUICK_TOUCH_MOUSE_FINDING_CORNER:
+                    this._touchState = QUICK_TOUCH_MOUSE_FINDING_CORNER;
+                    // console.log("touchmove: this._touchState= QUICK_TOUCH_MOUSE_FINDING_CORNER -> QUICK_TOUCH_MOUSE_FINDING_CORNER")
+                    break;
+
+                case LONG_TOUCH_MOUSE_FINDING_CORNER:
+                    if (pointerLens) {
+                        pointerLens.centerPos = touchMoveCanvasPos;
+                    }
+                    snapPickResult = scene.snapPick({
+                        canvasPos: touchMoveCanvasPos,
+                        snapVertex: this._snapVertex,
+                        snapEdge: this._snapEdge
+                    });
+                    if (snapPickResult && snapPickResult.snappedWorldPos) {
+                        if (pointerLens) {
+                            pointerLens.cursorPos = snapPickResult.snappedCanvasPos;
+                            pointerLens.snapped = true;
+                        }
+                        pointerWorldPos.set(snapPickResult.snappedWorldPos);
+                        this._currentAngleMeasurement.corner.worldPos = snapPickResult.snappedWorldPos;
+                        this._currentAngleMeasurement.originVisible = true;
+                        this._currentAngleMeasurement.originWireVisible = true;
+                        this._currentAngleMeasurement.cornerVisible = true;
+                        this._currentAngleMeasurement.cornerWireVisible = false;
+                        this._currentAngleMeasurement.targetVisible = false;
+                        this._currentAngleMeasurement.targetWireVisible = false;
+                        this._currentAngleMeasurement.angleVisible = false;
+                    } else {
+                        pickResult = scene.pick({
+                            canvasPos: touchMoveCanvasPos,
+                            pickSurface: true
+                        })
+                        if (pickResult && pickResult.worldPos) {
+                            if (pointerLens) {
+                                pointerLens.cursorPos = pickResult.canvasPos;
+                                pointerLens.snapped = false;
+                            }
+                            pointerWorldPos.set(pickResult.worldPos);
+                            this._currentAngleMeasurement.corner.worldPos = pickResult.worldPos;
+                            this._currentAngleMeasurement.originVisible = true;
+                            this._currentAngleMeasurement.originWireVisible = true;
+                            this._currentAngleMeasurement.cornerVisible = true;
+                            this._currentAngleMeasurement.cornerWireVisible = false;
+                            this._currentAngleMeasurement.targetVisible = false;
+                            this._currentAngleMeasurement.targetWireVisible = false;
+                            this._currentAngleMeasurement.angleVisible = false;
+                        } else {
+                            if (pointerLens) {
+                                pointerLens.cursorPos = null;
+                                pointerLens.snapped = false;
+                            }
+                        }
+                    }
+                    this._touchState = LONG_TOUCH_MOUSE_FINDING_CORNER;
+                    // console.log("touchmove: this._touchState= LONG_TOUCH_MOUSE_FINDING_CORNER -> LONG_TOUCH_MOUSE_FINDING_CORNER")
+                    break;
+
+                case TOUCH_FINDING_TARGET:
+                    this._touchState = TOUCH_FINDING_TARGET;
+                    // console.log("touchmove: this._touchState= TOUCH_FINDING_TARGET -> TOUCH_FINDING_TARGET")
+                    break;
+
+                case QUICK_TOUCH_FINDING_TARGET:
+                    this._touchState = QUICK_TOUCH_FINDING_TARGET;
+                    // console.log("touchmove: this._touchState= QUICK_TOUCH_FINDING_TARGET -> QUICK_TOUCH_FINDING_TARGET")
+                    break;
+
+                case LONG_TOUCH_FINDING_TARGET:
+                    if (currentNumTouches !== 1 && longTouchTimeout !== null) { // Two or more fingers down
+                        clearTimeout(longTouchTimeout);
+                        longTouchTimeout = null;
+                        if (pointerLens) {
+                            pointerLens.visible = false;
+                        }
+                        enableCameraMouseControl();
+                        this._touchState = TOUCH_CANCELING;
+                        // console.log("touchmove: this._touchState= QUICK_TOUCH_FINDING_TARGET -> TOUCH_CANCELING")
+                        return;
+                    }
+                    if (pointerLens) {
+                        pointerLens.centerPos = touchMoveCanvasPos;
+                    }
+                    snapPickResult = scene.snapPick({
+                        canvasPos: touchMoveCanvasPos,
+                        snapVertex: this._snapVertex,
+                        snapEdge: this._snapEdge
+                    });
+                    if (snapPickResult && snapPickResult.snappedWorldPos) {
+                        if (pointerLens) {
+                            pointerLens.cursorPos = snapPickResult.snappedCanvasPos;
+                            pointerLens.snapped = true;
+                        }
+                        this._currentAngleMeasurement.target.worldPos = snapPickResult.snappedWorldPos;
+                        this._currentAngleMeasurement.originVisible = true;
+                        this._currentAngleMeasurement.originWireVisible = true;
+                        this._currentAngleMeasurement.cornerVisible = true;
+                        this._currentAngleMeasurement.cornerWireVisible = true;
+                        this._currentAngleMeasurement.targetVisible = true;
+                        this._currentAngleMeasurement.targetWireVisible = true;
+                        this._currentAngleMeasurement.angleVisible = true;
+                    } else {
+                        pickResult = scene.pick({
+                            canvasPos: touchMoveCanvasPos,
+                            pickSurface: true
+                        })
+                        if (pickResult && pickResult.worldPos) {
+                            if (pointerLens) {
+                                pointerLens.cursorPos = pickResult.canvasPos;
+                                pointerLens.snapped = false;
+                            }
+                            this._currentAngleMeasurement.target.worldPos = pickResult.worldPos;
+                            this._currentAngleMeasurement.originVisible = true;
+                            this._currentAngleMeasurement.originWireVisible = true;
+                            this._currentAngleMeasurement.cornerVisible = true;
+                            this._currentAngleMeasurement.cornerWireVisible = true;
+                            this._currentAngleMeasurement.targetVisible = true;
+                            this._currentAngleMeasurement.targetWireVisible = true;
+                            this._currentAngleMeasurement.angleVisible = true;
+                        }
+                    }
+                    this._touchState = LONG_TOUCH_FINDING_TARGET;
+                    break;
+
+                default:
+                    this._touchState = TOUCH_FINDING_ORIGIN;
+                    // console.log("touchmove: this._touchState= default -> TOUCH_FINDING_ORIGIN")
+                    break;
+            }
+        }, {passive: true});
+
+
+        canvas.addEventListener("touchend", this._onTouchEnd = (event) => {
+
+            const currentNumTouches = event.changedTouches.length;
+
+            if (currentNumTouches !== 1) {
+                return;
+            }
+
+            enableCameraMouseControl();
+            clearTimeout(longTouchTimeout);
+            longTouchTimeout = null;
+
+            const touchX = event.changedTouches[0].clientX;
+            const touchY = event.changedTouches[0].clientY;
+
+            touchEndCanvasPos.set([touchX, touchY]);
+
+            switch (this._touchState) {
+
+                case TOUCH_CANCELING:
+                    this._touchState = TOUCH_FINDING_ORIGIN;
+                    // console.log("touchend: this._touchState= TOUCH_CANCELING -> TOUCH_FINDING_ORIGIN")
+                    break;
+
+                case TOUCH_FINDING_ORIGIN:
+                    this._touchState = TOUCH_FINDING_ORIGIN;
+                    // console.log("touchend: this._touchState= TOUCH_FINDING_ORIGIN -> TOUCH_FINDING_ORIGIN")
+                    break;
+
+                case TOUCH_FINDING_CORNER:
+                    this._touchState = TOUCH_FINDING_CORNER;
+                    // console.log("touchend: this._touchState= TOUCH_FINDING_ORIGIN -> TOUCH_FINDING_CORNER")
+                    break;
+
+                case TOUCH_FINDING_TARGET:
+                    this._touchState = TOUCH_FINDING_TARGET;
+                    // console.log("touchend: this._touchState= TOUCH_FINDING_TARGET -> TOUCH_FINDING_TARGET")
+                    break;
+
+                case QUICK_TOUCH_FINDING_ORIGIN:
+                    if (currentNumTouches !== 1 ||
+                        touchEndCanvasPos[0] > touchStartCanvasPos[0] + clickTolerance ||
+                        touchEndCanvasPos[0] < touchStartCanvasPos[0] - clickTolerance ||
+                        touchEndCanvasPos[1] > touchStartCanvasPos[1] + clickTolerance ||
+                        touchEndCanvasPos[1] < touchStartCanvasPos[1] - clickTolerance) {
+                        if (this._currentAngleMeasurement) {
+                            this._currentAngleMeasurement.destroy();
+                            this._currentAngleMeasurement = null;
+                        }
+                        this._touchState = TOUCH_FINDING_ORIGIN;
+                        // console.log("touchend: this._touchState= QUICK_TOUCH_FINDING_ORIGIN (pointer moved, destroy measurement) -> TOUCH_FINDING_ORIGIN")
+                        break;
+                    } else {
+                        const pickResult = scene.pick({
+                            canvasPos: touchEndCanvasPos,
+                            pickSurface: true
+                        })
+                        if (pickResult && pickResult.worldPos) {
+                            if (pointerLens) {
+                                pointerLens.cursorPos = pickResult.canvasPos;
+                                pointerLens.snapped = false;
+                            }
+                            this._currentAngleMeasurement = plugin.createMeasurement({
+                                id: math.createUUID(),
+                                origin: {
+                                    worldPos: pickResult.worldPos
+                                },
+                                corner: {
+                                    worldPos: pickResult.worldPos
+                                },
+                                target: {
+                                    worldPos: pickResult.worldPos
+                                }
+                            });
+                            this._currentAngleMeasurement.clickable = false;
+                            this._currentAngleMeasurement.originVisible = true;
+                            this._currentAngleMeasurement.originWireVisible = false;
+                            this._currentAngleMeasurement.cornerVisible = false;
+                            this._currentAngleMeasurement.cornerWireVisible = false;
+                            this._currentAngleMeasurement.targetVisible = false;
+                            this._currentAngleMeasurement.targetWireVisible = false;
+                            this._currentAngleMeasurement.angleVisible = false
+                            this.fire("measurementStart", this._currentAngleMeasurement);
+                            this._touchState = TOUCH_FINDING_CORNER;
+                            // console.log("touchend: this._touchState= QUICK_TOUCH_FINDING_ORIGIN (picked, begin measurement) -> TOUCH_FINDING_CORNER")
+                            break;
+                        } else {
+                            if (this._currentAngleMeasurement) { // Not likely needed, but safe
+                                this._currentAngleMeasurement.destroy();
+                                this._currentAngleMeasurement = null;
+                            }
+                            this._touchState = TOUCH_FINDING_ORIGIN;
+                            // console.log("touchend: this._touchState= QUICK_TOUCH_FINDING_ORIGIN (nothing picked)  -> TOUCH_FINDING_ORIGIN")
+                            break;
+                        }
+                    }
+
+                case LONG_TOUCH_FINDING_ORIGIN:
+                    if (pointerLens) {
+                        pointerLens.visible = false;
+                    }
+                    if (!this._currentAngleMeasurement) {
+                        if (pointerLens) {
+                            pointerLens.snapped = false;
+                            pointerLens.visible = false;
+                        }
+                        this._touchState = TOUCH_FINDING_ORIGIN;
+                        // console.log("touchend: this._touchState= LONG_TOUCH_FINDING_ORIGIN (no measurement) -> TOUCH_FINDING_ORIGIN")
+                        break;
+                    } else {
+                        //    this.fire("measurementStart", this._currentAngleMeasurement);
+                        //  enableCameraMouseControl();
+                        this._touchState = TOUCH_FINDING_CORNER;
+                        // console.log("touchend: this._touchState= LONG_TOUCH_FINDING_ORIGIN (picked, begin measurement) -> TOUCH_FINDING_CORNER")
+                        break;
+                    }
+
+                case QUICK_TOUCH_MOUSE_FINDING_CORNER:
+                    if (currentNumTouches !== 1 ||
+                        touchEndCanvasPos[0] > touchStartCanvasPos[0] + clickTolerance ||
+                        touchEndCanvasPos[0] < touchStartCanvasPos[0] - clickTolerance ||
+                        touchEndCanvasPos[1] > touchStartCanvasPos[1] + clickTolerance ||
+                        touchEndCanvasPos[1] < touchStartCanvasPos[1] - clickTolerance) {
+                        // if (this._currentAngleMeasurement) {
+                        //     this._currentAngleMeasurement.destroy();
+                        //     this._currentAngleMeasurement = null;
+                        // }
+                        this._touchState = TOUCH_FINDING_CORNER;
+                        // console.log("touchend: (moved) this._touchState= QUICK_TOUCH_MOUSE_FINDING_CORNER -> TOUCH_FINDING_CORNER")
+                        break;
+                    } else {
+                        const pickResult = scene.pick({
+                            canvasPos: touchEndCanvasPos,
+                            pickSurface: true
+                        })
+                        if (pickResult && pickResult.worldPos) {
+                            if (pointerLens) {
+                                pointerLens.cursorPos = pickResult.canvasPos;
+                                pointerLens.snapped = false;
+                            }
+                            this._currentAngleMeasurement.corner.worldPos = pickResult.worldPos;
+                            this._currentAngleMeasurement.originVisible = true;
+                            this._currentAngleMeasurement.originWireVisible = true;
+                            this._currentAngleMeasurement.cornerVisible = true;
+                            this._currentAngleMeasurement.cornerWireVisible = false;
+                            this._currentAngleMeasurement.targetVisible = false;
+                            this._currentAngleMeasurement.targetWireVisible = false;
+                            this._currentAngleMeasurement.angleVisible = false;
+                            this._touchState = TOUCH_FINDING_TARGET;
+                            // console.log("touchend: this._touchState= QUICK_TOUCH_MOUSE_FINDING_CORNER (picked, begin measurement) -> TOUCH_FINDING_TARGET")
+                            break;
+                        } else {
+                            if (this._currentAngleMeasurement) {
+                                this._currentAngleMeasurement.destroy();
+                                this._currentAngleMeasurement = null;
+                            }
+                            this._touchState = TOUCH_FINDING_ORIGIN;
+                            // console.log("touchend: this._touchState= QUICK_TOUCH_FINDING_ORIGIN (nothing picked, destroy measurement) -> TOUCH_FINDING_ORIGIN")
+                            break;
+                        }
+                    }
+
+                case LONG_TOUCH_MOUSE_FINDING_CORNER: {
+                    if (pointerLens) {
+                        pointerLens.visible = false;
+                    }
+                    if (!this._currentAngleMeasurement || !this._currentAngleMeasurement.cornerVisible) {
+                        if (this._currentAngleMeasurement) {
+                            this._currentAngleMeasurement.destroy();
+                            this._currentAngleMeasurement = null;
+                        }
+                        this._touchState = TOUCH_FINDING_ORIGIN;
+                        // console.log("touchend: this._touchState= LONG_TOUCH_FINDING_ORIGIN (no measurement) -> TOUCH_FINDING_ORIGIN")
+                    } else {
+                        this._touchState = TOUCH_FINDING_TARGET;
+                        // console.log("touchend: this._touchState= LONG_TOUCH_MOUSE_FINDING_CORNER  -> TOUCH_FINDING_ORIGIN")
+                    }
+                    break;
+                }
+
+                case QUICK_TOUCH_FINDING_TARGET:
+                    if (currentNumTouches !== 1 ||
+                        touchEndCanvasPos[0] > touchStartCanvasPos[0] + clickTolerance ||
+                        touchEndCanvasPos[0] < touchStartCanvasPos[0] - clickTolerance ||
+                        touchEndCanvasPos[1] > touchStartCanvasPos[1] + clickTolerance ||
+                        touchEndCanvasPos[1] < touchStartCanvasPos[1] - clickTolerance) {
+                        // if (this._currentAngleMeasurement) {
+                        //     this._currentAngleMeasurement.destroy();
+                        //     this._currentAngleMeasurement = null;
+                        // }
+                        this._touchState = TOUCH_FINDING_TARGET;
+                        // console.log("touchend: (moved) this._touchState= QUICK_TOUCH_FINDING_TARGET -> TOUCH_FINDING_TARGET")
+                        break;
+                    } else {
+                        const pickResult = scene.pick({
+                            canvasPos: touchEndCanvasPos,
+                            pickSurface: true
+                        })
+                        if (pickResult && pickResult.worldPos) {
+                            if (pointerLens) {
+                                pointerLens.cursorPos = pickResult.canvasPos;
+                                pointerLens.snapped = false;
+                            }
+                            this._currentAngleMeasurement.target.worldPos = pickResult.worldPos;
+                            this._currentAngleMeasurement.originVisible = true;
+                            this._currentAngleMeasurement.originWireVisible = true;
+                            this._currentAngleMeasurement.cornerVisible = true;
+                            this._currentAngleMeasurement.cornerWireVisible = true;
+                            this._currentAngleMeasurement.targetVisible = true;
+                            this._currentAngleMeasurement.targetWireVisible = true;
+                            this._currentAngleMeasurement.angleVisible = true;
+                            this.fire("measurementEnd", this._currentAngleMeasurement);
+                            this._currentAngleMeasurement = null;
+                            this._touchState = TOUCH_FINDING_ORIGIN;
+                            // console.log("touchend: this._touchState= QUICK_TOUCH_FINDING_TARGET (picked, begin measurement) -> TOUCH_FINDING_ORIGIN")
+                            break;
+                        } else {
+                            if (this._currentAngleMeasurement) {
+                                this._currentAngleMeasurement.destroy();
+                                this._currentAngleMeasurement = null;
+                            }
+                            this._touchState = TOUCH_FINDING_ORIGIN;
+                            // console.log("touchend: this._touchState= QUICK_TOUCH_FINDING_ORIGIN (nothing picked, destroy measurement) -> TOUCH_FINDING_ORIGIN")
+                            break;
+                        }
+                    }
+
+                case LONG_TOUCH_FINDING_TARGET:
+                    if (pointerLens) {
+                        pointerLens.visible = false;
+                    }
+                    if (!this._currentAngleMeasurement || !this._currentAngleMeasurement.targetVisible) {
+                        if (this._currentAngleMeasurement) {
+                            this._currentAngleMeasurement.destroy();
+                            this._currentAngleMeasurement = null;
+                        }
+                        this._currentAngleMeasurement = null;
+                        this._touchState = TOUCH_FINDING_ORIGIN;
+                        // console.log("touchend: this._touchState= LONG_TOUCH_FINDING_TARGET (no target found) -> TOUCH_FINDING_ORIGIN")
+                    } else {
+                        this._currentAngleMeasurement.clickable = true;
+                        this.fire("measurementEnd", this._currentAngleMeasurement);
+                        this._currentAngleMeasurement = null;
+                        this._touchState = TOUCH_FINDING_ORIGIN;
+                        // console.log("touchend: this._touchState= LONG_TOUCH_FINDING_TARGET  -> TOUCH_FINDING_ORIGIN")
+                    }
+                    break;
+
+                default:
+                    if (pointerLens) {
+                        pointerLens.visible = false;
+                        pointerLens.snapped = false;
+                    }
+                    this._currentAngleMeasurement = null;
+                    this._touchState = TOUCH_FINDING_ORIGIN;
+                    // console.log("touchend: this._touchState= default -> TOUCH_FINDING_ORIGIN")
+                    break;
+            }
+
+        }, {passive: true});
+
+        this._active = true;
+    }
+
+    /**
+     * Deactivates this AngleMeasurementsControl, making it unresponsive to input.
+     *
+     * Destroys any {@link AngleMeasurement} under construction.
+     */
+    deactivate() {
+
+        if (!this._active) {
+            return;
+        }
+
+        if (this.pointerLens) {
+            this.pointerLens.visible = false;
+        }
+
+        this.reset();
+
+        const canvas = this.plugin.viewer.scene.canvas.canvas;
+        
+        canvas.removeEventListener("touchstart", this._onTouchStart);
+        canvas.removeEventListener("touchmove", this._onTouchMove);
+        canvas.removeEventListener("touchend", this._onTouchEnd);
+
+        this._currentAngleMeasurement = null;
+
+        this._active = false;
+    }
+
+    /**
+     * Resets this AngleMeasurementsControl.
+     *
+     * Destroys any {@link AngleMeasurement} under construction.
+     *
+     * Does nothing if the AngleMeasurementsControl is not active.
+     */
+    reset() {
+
+        if (!this._active) {
+            return;
+        }
+
+        if (this._currentAngleMeasurement) {
+            this._currentAngleMeasurement.destroy();
+            this._currentAngleMeasurement = null;
+        }
+
+        this._mouseState = MOUSE_FINDING_ORIGIN;
+        this._touchState = TOUCH_FINDING_ORIGIN;
+    }
+
+    /**
+     * @private
+     */
+    destroy() {
+        this.deactivate();
+        super.destroy();
+    }
+
+}

--- a/src/plugins/AngleMeasurementsPlugin/index.js
+++ b/src/plugins/AngleMeasurementsPlugin/index.js
@@ -1,3 +1,4 @@
 export * from "./AngleMeasurementsPlugin.js";
 export * from "./AngleMeasurementsControl.js";
 export * from "./AngleMeasurementsMouseControl.js";
+export * from "./AngleMeasurementsTouchControl.js";

--- a/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsTouchControl.js
+++ b/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsTouchControl.js
@@ -1,0 +1,819 @@
+import {Component} from "../../viewer/scene/Component.js";
+import {math} from "../../viewer/scene/math/math.js";
+import {DistanceMeasurementsControl} from "./DistanceMeasurementsControl.js";
+
+
+const TOUCH_FINDING_ORIGIN = 0;
+const QUICK_TOUCH_FINDING_ORIGIN = 1;
+const LONG_TOUCH_FINDING_ORIGIN = 2;
+const TOUCH_FINDING_TARGET = 3;
+const QUICK_TOUCH_FINDING_TARGET = 4;
+const LONG_TOUCH_FINDING_TARGET = 5;
+const TOUCH_CANCELING = 6;
+
+/**
+ * Creates {@link DistanceMeasurement}s from mouse and touch input.
+ *
+ * Belongs to a {@link DistanceMeasurementsPlugin}. Located at {@link DistanceMeasurementsPlugin#control}.
+ *
+ * Once the DistanceMeasurementControl is activated, the first click on any {@link Entity} begins constructing a {@link DistanceMeasurement}, fixing its origin to that Entity. The next click on any Entity will complete the DistanceMeasurement, fixing its target to that second Entity. The DistanceMeasurementControl will then wait for the next click on any Entity, to begin constructing another DistanceMeasurement, and so on, until deactivated.
+ *
+ * See {@link DistanceMeasurementsPlugin} for more info.
+ *
+ * @experimental
+ */
+export class DistanceMeasurementsTouchControl  extends DistanceMeasurementsControl {
+
+    /**
+     * Creates a DistanceMeasurementsTouchControl bound to the given DistanceMeasurementsPlugin.
+     */
+    constructor(distanceMeasurementsPlugin, cfg = {}) {
+
+        super(distanceMeasurementsPlugin.viewer.scene);
+
+        this.pointerLens = cfg.pointerLens;
+
+        this._active = false;
+
+        const markerDiv = document.createElement('div');
+        const canvas = this.scene.canvas.canvas;
+        canvas.parentNode.insertBefore(markerDiv, canvas);
+
+        markerDiv.style.background = "black";
+        markerDiv.style.border = "2px solid blue";
+        markerDiv.style.borderRadius = "10px";
+        markerDiv.style.width = "5px";
+        markerDiv.style.height = "5px";
+        markerDiv.style.margin = "-200px -200px";
+        markerDiv.style.zIndex = "100";
+        markerDiv.style.position = "absolute";
+        markerDiv.style.pointerEvents = "none";
+
+        this.markerDiv = markerDiv;
+
+        this._currentDistanceMeasurement = null;
+
+        this._currentDistanceMeasurementInitState = {
+            wireVisible: null,
+            axisVisible: null,
+            xAxisVisible: null,
+            yaxisVisible: null,
+            zAxisVisible: null,
+            targetVisible: null,
+        }
+
+        this._onCanvasTouchStart = null;
+        this._onCanvasTouchEnd = null;
+        this._mobileModeLongPressTimeMs = 500;
+        this._snapEdge = cfg.snapEdge !== false;
+        this._snapVertex = cfg.snapVertex !== false;
+        this._touchState = TOUCH_FINDING_ORIGIN;
+
+        this._attachPlugin(distanceMeasurementsPlugin, cfg);
+    }
+
+    _attachPlugin(distanceMeasurementsPlugin) {
+
+        /**
+         * The {@link DistanceMeasurementsPlugin} that owns this DistanceMeasurementsTouchControl.
+         * @type {DistanceMeasurementsPlugin}
+         */
+        this.distanceMeasurementsPlugin = distanceMeasurementsPlugin;
+
+        /**
+         * The {@link DistanceMeasurementsPlugin} that owns this DistanceMeasurementsTouchControl.
+         * @type {DistanceMeasurementsPlugin}
+         */
+        this.plugin = distanceMeasurementsPlugin;
+    }
+
+    /** Gets if this DistanceMeasurementsTouchControl is currently active, where it is responding to input.
+     *
+     * @returns {Boolean}
+     */
+    get active() {
+        return this._active;
+    }
+
+    /**
+     * Sets whether snap-to-vertex is enabled for this DistanceMeasurementsTouchControl.
+     * This is `true` by default.
+     * @param snapVertex
+     */
+    set snapVertex(snapVertex) {
+        this._snapVertex = snapVertex;
+    }
+
+    /**
+     * Gets whether snap-to-vertex is enabled for this DistanceMeasurementsTouchControl.
+     * This is `true` by default.
+     * @returns {*}
+     */
+    get snapVertex() {
+        return this._snapVertex;
+    }
+
+    /**
+     * Sets whether snap-to-edge is enabled for this DistanceMeasurementsTouchControl.
+     * This is `true` by default.
+     * @param snapEdge
+     */
+    set snapEdge(snapEdge) {
+        this._snapEdge = snapEdge;
+    }
+
+    /**
+     * Gets whether snap-to-edge is enabled for this DistanceMeasurementsTouchControl.
+     * This is `true` by default.
+     * @returns {*}
+     */
+    get snapEdge() {
+        return this._snapEdge;
+    }
+
+    /**
+     * Activates this DistanceMeasurementsTouchControl, ready to respond to input.
+     */
+    activate() {
+
+        if (this._active) {
+            return;
+        }
+
+        const plugin = this.plugin;
+        const scene = this.scene;
+        const canvas = scene.canvas.canvas;
+        const pointerLens = plugin.pointerLens;
+        const pointerWorldPos = math.vec3();
+
+        const touchTolerance = 20;
+
+        let longTouchTimeout = null;
+
+        const disableCameraMouseControl = () => {
+            this.plugin.viewer.cameraControl.active = false;
+        }
+
+        const enableCameraMouseControl = () => {
+            this.plugin.viewer.cameraControl.active = true;
+        }
+
+        this._touchState = TOUCH_FINDING_ORIGIN;
+
+        const touchStartCanvasPos = math.vec2();
+        const touchMoveCanvasPos = math.vec2();
+        const touchEndCanvasPos = math.vec2();
+
+        canvas.addEventListener("touchstart", this._onCanvasTouchStart = (event) => {
+
+            const currentNumTouches = event.touches.length;
+
+            if (currentNumTouches !== 1) {
+                return;
+            }
+
+            const touchX = event.touches[0].clientX;
+            const touchY = event.touches[0].clientY;
+
+            touchStartCanvasPos.set([touchX, touchY]);
+            touchMoveCanvasPos.set([touchX, touchY]);
+
+            switch (this._touchState) {
+
+                case TOUCH_FINDING_ORIGIN:
+                    if (currentNumTouches !== 1 && longTouchTimeout !== null) { // Two or more fingers down
+                        clearTimeout(longTouchTimeout);
+                        longTouchTimeout = null;
+                        this._touchState = TOUCH_CANCELING;
+                        // console.log("touchstart: this._touchState= TOUCH_FINDING_ORIGIN -> TOUCH_CANCELING")
+                        return;
+                    }
+                    longTouchTimeout = setTimeout(() => {
+                        if (currentNumTouches !== 1 ||
+                            touchMoveCanvasPos[0] > touchStartCanvasPos[0] + touchTolerance ||
+                            touchMoveCanvasPos[0] < touchStartCanvasPos[0] - touchTolerance ||
+                            touchMoveCanvasPos[1] > touchStartCanvasPos[1] + touchTolerance ||
+                            touchMoveCanvasPos[1] < touchStartCanvasPos[1] - touchTolerance) {
+                            return;   // Has moved
+                        }
+                        // Long touch
+                        disableCameraMouseControl();
+                        if (this.pointerLens) {
+                            this.pointerLens.visible = true;
+                            this.pointerLens.centerPos = touchStartCanvasPos;
+                            this.pointerLens.cursorPos = touchStartCanvasPos;
+                        }
+                        if (this.pointerLens) {
+                            this.pointerLens.centerPos = touchMoveCanvasPos;
+                            this.pointerLens.snapped = false;
+                        }
+                        const snapPickResult = scene.snapPick({
+                            canvasPos: touchMoveCanvasPos,
+                            snapVertex: this._snapVertex,
+                            snapEdge: this._snapEdge
+                        });
+                        if (snapPickResult && snapPickResult.snappedWorldPos) {
+                            if (this.pointerLens) {
+                                this.pointerLens.cursorPos = snapPickResult.snappedCanvasPos;
+                                this.pointerLens.snapped = true;
+                            }
+                            pointerWorldPos.set(snapPickResult.snappedWorldPos);
+                            if (!this._currentDistanceMeasurement) {
+                                this._currentDistanceMeasurement = plugin.createMeasurement({
+                                    id: math.createUUID(),
+                                    origin: {
+                                        worldPos: snapPickResult.snappedWorldPos
+                                    },
+                                    target: {
+                                        worldPos: snapPickResult.snappedWorldPos
+                                    }
+                                });
+                                this._currentDistanceMeasurement.labelsVisible = false;
+                                this._currentDistanceMeasurement.xAxisVisible = false;
+                                this._currentDistanceMeasurement.yAxisVisible = false;
+                                this._currentDistanceMeasurement.zAxisVisible = false;
+                                this._currentDistanceMeasurement.wireVisible = false;
+                                this._currentDistanceMeasurement.originVisible = true;
+                                this._currentDistanceMeasurement.targetVisible = false;
+                                this._currentDistanceMeasurement.clickable = false;
+                            } else {
+                                this._currentDistanceMeasurement.origin.worldPos = snapPickResult.snappedWorldPos;
+                            }
+                            this.distanceMeasurementsPlugin.fire("measurementStart", this._currentDistanceMeasurement);
+                        } else {
+                            const pickResult = scene.pick({
+                                canvasPos: touchMoveCanvasPos,
+                                pickSurface: true
+                            })
+                            if (pickResult && pickResult.worldPos) {
+                                if (this.pointerLens) {
+                                    this.pointerLens.cursorPos = pickResult.canvasPos;
+                                    this.pointerLens.snapped = false;
+                                }
+                                pointerWorldPos.set(pickResult.worldPos);
+                                if (!this._currentDistanceMeasurement) {
+                                    this._currentDistanceMeasurement = plugin.createMeasurement({
+                                        id: math.createUUID(),
+                                        origin: {
+                                            worldPos: pickResult.worldPos
+                                        },
+                                        target: {
+                                            worldPos: pickResult.worldPos
+                                        }
+                                    });
+                                    this._currentDistanceMeasurement.labelsVisible = false;
+                                    this._currentDistanceMeasurement.xAxisVisible = false;
+                                    this._currentDistanceMeasurement.yAxisVisible = false;
+                                    this._currentDistanceMeasurement.zAxisVisible = false;
+                                    this._currentDistanceMeasurement.wireVisible = false;
+                                    this._currentDistanceMeasurement.originVisible = true;
+                                    this._currentDistanceMeasurement.targetVisible = false;
+                                    this._currentDistanceMeasurement.clickable = false;
+                                } else {
+                                    this._currentDistanceMeasurement.origin.worldPos = pickResult.worldPos;
+                                }
+
+                                this.distanceMeasurementsPlugin.fire("measurementStart", this._currentDistanceMeasurement);
+                            } else {
+                                if (this.pointerLens) {
+                                    this.pointerLens.cursorPos = null;
+                                    this.pointerLens.snapped = false;
+                                }
+                            }
+                        }
+                        this._touchState = LONG_TOUCH_FINDING_ORIGIN;
+                        // console.log("touchstart: this._touchState= TOUCH_FINDING_ORIGIN -> LONG_TOUCH_FINDING_ORIGIN")
+                    }, this._mobileModeLongPressTimeMs);
+                    this._touchState = QUICK_TOUCH_FINDING_ORIGIN;
+                    // console.log("touchstart: this._touchState= TOUCH_FINDING_ORIGIN -> QUICK_TOUCH_FINDING_ORIGIN")
+                    break;
+
+                case TOUCH_FINDING_TARGET:
+                    if (currentNumTouches !== 1 && longTouchTimeout !== null) { // Two or more fingers down
+                        clearTimeout(longTouchTimeout);
+                        longTouchTimeout = null;
+                        return;
+                    }
+                    if (currentNumTouches === 1) { // One finger down
+                        longTouchTimeout = setTimeout(() => {
+                            longTouchTimeout = null;
+                            if (currentNumTouches !== 1 ||
+                                touchMoveCanvasPos[0] > touchStartCanvasPos[0] + touchTolerance ||
+                                touchMoveCanvasPos[0] < touchStartCanvasPos[0] - touchTolerance ||
+                                touchMoveCanvasPos[1] > touchStartCanvasPos[1] + touchTolerance ||
+                                touchMoveCanvasPos[1] < touchStartCanvasPos[1] - touchTolerance) {
+                                // Has moved
+                                return;
+                            }
+                            // Long touch
+                            disableCameraMouseControl();
+                            if (this.pointerLens) {
+                                this.pointerLens.visible = true;
+                                this.pointerLens.centerPos = touchStartCanvasPos;
+                                this.pointerLens.snapped = false;
+                            }
+
+                            const snapPickResult = scene.snapPick({
+                                canvasPos: touchMoveCanvasPos,
+                                snapVertex: this._snapVertex,
+                                snapEdge: this._snapEdge
+                            });
+                            if (snapPickResult && snapPickResult.snappedWorldPos) {
+                                if (this.pointerLens) {
+                                    this.pointerLens.cursorPos = snapPickResult.snappedCanvasPos;
+                                    this.pointerLens.snapped = true;
+                                }
+                                pointerWorldPos.set(snapPickResult.snappedWorldPos);
+                                this._currentDistanceMeasurement.target.worldPos = snapPickResult.snappedWorldPos;
+                                this._currentDistanceMeasurement.targetVisible = true;
+                                this._currentDistanceMeasurement.wireVisible = true;
+                                this._currentDistanceMeasurement.labelsVisible = true;
+                                this.distanceMeasurementsPlugin.fire("measurementStart", this._currentDistanceMeasurement);
+                            } else {
+                                const pickResult = scene.pick({
+                                    canvasPos: touchMoveCanvasPos,
+                                    pickSurface: true
+                                })
+                                if (pickResult && pickResult.worldPos) {
+                                    if (this.pointerLens) {
+                                        this.pointerLens.cursorPos = pickResult.canvasPos;
+                                        this.pointerLens.snapped = false;
+                                    }
+                                    pointerWorldPos.set(pickResult.worldPos);
+                                    this._currentDistanceMeasurement.target.worldPos = pickResult.worldPos;
+                                    this._currentDistanceMeasurement.targetVisible = true;
+                                    this._currentDistanceMeasurement.wireVisible = true;
+                                    this._currentDistanceMeasurement.labelsVisible = true;
+                                    this.distanceMeasurementsPlugin.fire("measurementStart", this._currentDistanceMeasurement);
+                                } else {
+                                    if (this.pointerLens) {
+                                        this.pointerLens.cursorPos = null;
+                                        this.pointerLens.snapped = false;
+                                    }
+                                }
+                            }
+                            this._touchState = LONG_TOUCH_FINDING_TARGET;
+                            // console.log("touchstart: this._touchState= TOUCH_FINDING_TARGET -> LONG_TOUCH_FINDING_TARGET")
+                        }, this._mobileModeLongPressTimeMs);
+                        this._touchState = QUICK_TOUCH_FINDING_TARGET;
+                        // console.log("touchstart: this._touchState= TOUCH_FINDING_TARGET -> QUICK_TOUCH_FINDING_TARGET")
+                    }
+                    break;
+
+                default:
+                    if (longTouchTimeout !== null) {
+                        clearTimeout(longTouchTimeout);
+                        longTouchTimeout = null;
+                    }
+                    enableCameraMouseControl();
+                    this._touchState = TOUCH_CANCELING;
+                    // console.log("touchstart: this._touchState= default -> TOUCH_CANCELING")
+                    return;
+            }
+
+        }, {passive: true});
+
+
+        canvas.addEventListener("touchmove", (event) => {
+
+            const currentNumTouches = event.touches.length;
+
+            if (currentNumTouches !== 1) {
+                return;
+            }
+
+            if (longTouchTimeout) {
+                clearTimeout(longTouchTimeout);
+                longTouchTimeout = null;
+            }
+
+            const touchX = event.touches[0].clientX;
+            const touchY = event.touches[0].clientY;
+
+            touchMoveCanvasPos.set([touchX, touchY]);
+
+            let snapPickResult;
+            let pickResult;
+
+            switch (this._touchState) {
+
+                case TOUCH_CANCELING:
+                    if (longTouchTimeout) {
+                        clearTimeout(longTouchTimeout);
+                        longTouchTimeout = null;
+                    }
+                    if (this._currentDistanceMeasurement) {
+                        this._currentDistanceMeasurement.destroy();
+                        this._currentDistanceMeasurement = null;
+                    }
+                    break;
+
+                case TOUCH_FINDING_ORIGIN:
+                    this._touchState = TOUCH_FINDING_ORIGIN;
+                    // console.log("touchmove: this._touchState= TOUCH_FINDING_ORIGIN -> TOUCH_FINDING_ORIGIN")
+                    break;
+
+                case QUICK_TOUCH_FINDING_ORIGIN:
+                    this._touchState = QUICK_TOUCH_FINDING_ORIGIN;
+                    // console.log("touchmove: this._touchState= QUICK_TOUCH_FINDING_ORIGIN -> QUICK_TOUCH_FINDING_ORIGIN")
+                    break;
+
+                case LONG_TOUCH_FINDING_ORIGIN:
+                    if (this.pointerLens) {
+                        this.pointerLens.centerPos = touchMoveCanvasPos;
+                    }
+                    snapPickResult = scene.snapPick({
+                        canvasPos: touchMoveCanvasPos,
+                        snapVertex: this._snapVertex,
+                        snapEdge: this._snapEdge
+                    });
+                    if (snapPickResult && snapPickResult.snappedWorldPos) {
+                        if (this.pointerLens) {
+                            this.pointerLens.cursorPos = snapPickResult.snappedCanvasPos;
+                            this.pointerLens.snapped = true;
+                        }
+                        pointerWorldPos.set(snapPickResult.snappedWorldPos);
+                        if (!this._currentDistanceMeasurement) {
+                            this._currentDistanceMeasurement = plugin.createMeasurement({
+                                id: math.createUUID(),
+                                origin: {
+                                    worldPos: snapPickResult.snappedWorldPos
+                                },
+                                target: {
+                                    worldPos: snapPickResult.snappedWorldPos
+                                }
+                            });
+                            this._currentDistanceMeasurement.labelsVisible = false;
+                            this._currentDistanceMeasurement.xAxisVisible = false;
+                            this._currentDistanceMeasurement.yAxisVisible = false;
+                            this._currentDistanceMeasurement.zAxisVisible = false;
+                            this._currentDistanceMeasurement.wireVisible = false;
+                            this._currentDistanceMeasurement.originVisible = true;
+                            this._currentDistanceMeasurement.targetVisible = false;
+                            this._currentDistanceMeasurement.clickable = false;
+                        } else {
+                            this._currentDistanceMeasurement.origin.worldPos = snapPickResult.snappedWorldPos;
+                        }
+
+                        this.distanceMeasurementsPlugin.fire("measurementStart", this._currentDistanceMeasurement);
+                    } else {
+                        pickResult = scene.pick({
+                            canvasPos: touchMoveCanvasPos,
+                            pickSurface: true
+                        })
+                        if (pickResult && pickResult.worldPos) {
+                            if (this.pointerLens) {
+                                this.pointerLens.cursorPos = pickResult.canvasPos;
+                                this.pointerLens.snapped = false;
+                            }
+                            pointerWorldPos.set(pickResult.worldPos);
+                            if (!this._currentDistanceMeasurement) {
+                                this._currentDistanceMeasurement = plugin.createMeasurement({
+                                    id: math.createUUID(),
+                                    origin: {
+                                        worldPos: pickResult.worldPos
+                                    },
+                                    target: {
+                                        worldPos: pickResult.worldPos
+                                    }
+                                });
+                                this._currentDistanceMeasurement.labelsVisible = false;
+                                this._currentDistanceMeasurement.xAxisVisible = false;
+                                this._currentDistanceMeasurement.yAxisVisible = false;
+                                this._currentDistanceMeasurement.zAxisVisible = false;
+                                this._currentDistanceMeasurement.wireVisible = false;
+                                this._currentDistanceMeasurement.originVisible = true;
+                                this._currentDistanceMeasurement.targetVisible = false;
+                                this._currentDistanceMeasurement.clickable = false;
+                            } else {
+                                this._currentDistanceMeasurement.origin.worldPos = pickResult.worldPos;
+                            }
+
+                            this.distanceMeasurementsPlugin.fire("measurementStart", this._currentDistanceMeasurement);
+                        } else {
+                            if (this.pointerLens) {
+                                this.pointerLens.cursorPos = null;
+                                this.pointerLens.snapped = false;
+                            }
+                        }
+                    }
+                    this._touchState = LONG_TOUCH_FINDING_ORIGIN;
+                    // console.log("touchmove: this._touchState= LONG_TOUCH_FINDING_ORIGIN -> LONG_TOUCH_FINDING_ORIGIN")
+                    break;
+
+                case TOUCH_FINDING_TARGET:
+                    this._touchState = TOUCH_FINDING_TARGET;
+                    // console.log("touchmove: this._touchState= TOUCH_FINDING_TARGET -> TOUCH_FINDING_TARGET")
+                    break;
+
+                case QUICK_TOUCH_FINDING_TARGET:
+                    this._touchState = QUICK_TOUCH_FINDING_TARGET;
+                    // console.log("touchmove: this._touchState= QUICK_TOUCH_FINDING_TARGET -> QUICK_TOUCH_FINDING_TARGET")
+                    break;
+
+                case LONG_TOUCH_FINDING_TARGET:
+                    if (currentNumTouches !== 1 && longTouchTimeout !== null) { // Two or more fingers down
+                        clearTimeout(longTouchTimeout);
+                        longTouchTimeout = null;
+                        if (this.pointerLens) {
+                            this.pointerLens.visible = false;
+                        }
+                        enableCameraMouseControl();
+                        this._touchState = TOUCH_CANCELING;
+                        // console.log("touchmove: this._touchState= QUICK_TOUCH_FINDING_TARGET -> TOUCH_CANCELING")
+                        return;
+                    }
+                    if (this.pointerLens) {
+                        this.pointerLens.centerPos = touchMoveCanvasPos;
+                    }
+                    snapPickResult = scene.snapPick({
+                        canvasPos: touchMoveCanvasPos,
+                        snapVertex: this._snapVertex,
+                        snapEdge: this._snapEdge
+                    });
+                    if (snapPickResult && snapPickResult.snappedWorldPos) {
+                        if (this.pointerLens) {
+                            this.pointerLens.cursorPos = snapPickResult.snappedCanvasPos;
+                            this.pointerLens.snapped = true;
+                        }
+                        this._currentDistanceMeasurement.target.worldPos = snapPickResult.snappedWorldPos;
+                        this._currentDistanceMeasurement.targetVisible = true;
+                        this._currentDistanceMeasurement.wireVisible = true;
+                        this._currentDistanceMeasurement.labelsVisible = true;
+                    } else {
+                        pickResult = scene.pick({
+                            canvasPos: touchMoveCanvasPos,
+                            pickSurface: true
+                        })
+                        if (pickResult && pickResult.worldPos) {
+                            if (this.pointerLens) {
+                                this.pointerLens.cursorPos = pickResult.canvasPos;
+                                this.pointerLens.snapped = false;
+                            }
+                            this._currentDistanceMeasurement.target.worldPos = pickResult.worldPos;
+                            this._currentDistanceMeasurement.targetVisible = true;
+                            this._currentDistanceMeasurement.wireVisible = true;
+                            this._currentDistanceMeasurement.labelsVisible = true;
+
+                        }
+                    }
+                    this._touchState = LONG_TOUCH_FINDING_TARGET;
+                    break;
+
+                default:
+                    this._touchState = TOUCH_FINDING_ORIGIN;
+                    // console.log("touchmove: this._touchState= default -> TOUCH_FINDING_ORIGIN")
+                    break;
+            }
+        }, {passive: true});
+
+        canvas.addEventListener("touchend", this._onCanvasTouchEnd = (event) => {
+
+            const currentNumTouches = event.changedTouches.length;
+
+            if (currentNumTouches !== 1) {
+                return;
+            }
+
+            enableCameraMouseControl();
+
+            if (longTouchTimeout) {
+                clearTimeout(longTouchTimeout);
+                longTouchTimeout = null;
+            }
+
+            const touchX = event.changedTouches[0].clientX;
+            const touchY = event.changedTouches[0].clientY;
+
+            touchEndCanvasPos.set([touchX, touchY]);
+
+            switch (this._touchState) {
+
+                case TOUCH_CANCELING:
+                    if (longTouchTimeout) {
+                        clearTimeout(longTouchTimeout);
+                        longTouchTimeout = null;
+                    }
+                    if (this._currentDistanceMeasurement) {
+                        this._currentDistanceMeasurement.destroy();
+                        this._currentDistanceMeasurement = null;
+                    }
+                    this._touchState = TOUCH_FINDING_ORIGIN;
+                    // console.log("touchend: this._touchState= TOUCH_CANCELING -> TOUCH_FINDING_ORIGIN")
+                    break;
+
+                case TOUCH_FINDING_ORIGIN:
+                    this._touchState = TOUCH_FINDING_ORIGIN;
+                    // console.log("touchend: this._touchState= TOUCH_FINDING_ORIGIN -> TOUCH_FINDING_ORIGIN")
+                    break;
+
+                case TOUCH_FINDING_TARGET:
+                    this._touchState = TOUCH_FINDING_TARGET;
+                    // console.log("touchend: this._touchState= TOUCH_FINDING_TARGET -> TOUCH_FINDING_TARGET")
+                    break;
+
+                case QUICK_TOUCH_FINDING_ORIGIN:
+                    if (currentNumTouches !== 1 ||
+                        touchEndCanvasPos[0] > touchStartCanvasPos[0] + touchTolerance ||
+                        touchEndCanvasPos[0] < touchStartCanvasPos[0] - touchTolerance ||
+                        touchEndCanvasPos[1] > touchStartCanvasPos[1] + touchTolerance ||
+                        touchEndCanvasPos[1] < touchStartCanvasPos[1] - touchTolerance) {
+                        if (this._currentDistanceMeasurement) {
+                            this._currentDistanceMeasurement.destroy();
+                            this._currentDistanceMeasurement = null;
+                        }
+                        this._touchState = TOUCH_FINDING_ORIGIN;
+                        // console.log("touchend: this._touchState= QUICK_TOUCH_FINDING_ORIGIN (pointer moved, destroy measurement) -> TOUCH_FINDING_ORIGIN")
+                        break;
+                    } else {
+                        const pickResult = scene.pick({
+                            canvasPos: touchEndCanvasPos,
+                            pickSurface: true
+                        })
+                        if (pickResult && pickResult.worldPos) {
+                            if (this.pointerLens) {
+                                this.pointerLens.cursorPos = pickResult.canvasPos;
+                                this.pointerLens.snapped = false;
+                            }
+                            this._currentDistanceMeasurement = plugin.createMeasurement({
+                                id: math.createUUID(),
+                                origin: {
+                                    worldPos: pickResult.worldPos
+                                },
+                                target: {
+                                    worldPos: pickResult.worldPos
+                                }
+                            });
+                            this._currentDistanceMeasurement.labelsVisible = false;
+                            this._currentDistanceMeasurement.xAxisVisible = false;
+                            this._currentDistanceMeasurement.yAxisVisible = false;
+                            this._currentDistanceMeasurement.zAxisVisible = false;
+                            this._currentDistanceMeasurement.originVisible = true;
+                            this._currentDistanceMeasurement.targetVisible = false;
+                            this._currentDistanceMeasurement.clickable = false;
+                            this._currentDistanceMeasurement.wireVisible = false;
+                            this.distanceMeasurementsPlugin.fire("measurementStart", this._currentDistanceMeasurement);
+                            //      enableCameraMouseControl();
+                            this._touchState = TOUCH_FINDING_TARGET;
+                            // console.log("touchend: this._touchState= QUICK_TOUCH_FINDING_ORIGIN (picked, begin measurement) -> TOUCH_FINDING_TARGET")
+                            break;
+                        } else {
+                            if (this._currentDistanceMeasurement) { // Not likely needed, but safe
+                                this._currentDistanceMeasurement.destroy();
+                                this._currentDistanceMeasurement = null;
+                            }
+                            this._touchState = TOUCH_FINDING_ORIGIN;
+                            // console.log("touchend: this._touchState= QUICK_TOUCH_FINDING_ORIGIN (nothing picked)  -> TOUCH_FINDING_ORIGIN")
+                            break;
+                        }
+                    }
+
+                case LONG_TOUCH_FINDING_ORIGIN:
+                    if (this.pointerLens) {
+                        this.pointerLens.visible = false;
+                    }
+                    if (!this._currentDistanceMeasurement) {
+                        if (this.pointerLens) {
+                            this.pointerLens.snapped = false;
+                            this.pointerLens.visible = false;
+                        }
+                        this._touchState = TOUCH_FINDING_ORIGIN;
+                        // console.log("touchend: this._touchState= LONG_TOUCH_FINDING_ORIGIN (no measurement) -> TOUCH_FINDING_ORIGIN")
+                    } else {
+                        this._touchState = TOUCH_FINDING_TARGET;
+                        // console.log("touchend: this._touchState= LONG_TOUCH_FINDING_ORIGIN (picked, begin measurement) -> TOUCH_FINDING_TARGET")
+                    }
+                    break;
+
+                case QUICK_TOUCH_FINDING_TARGET:
+                    if (currentNumTouches !== 1 ||
+                        touchEndCanvasPos[0] > touchStartCanvasPos[0] + touchTolerance ||
+                        touchEndCanvasPos[0] < touchStartCanvasPos[0] - touchTolerance ||
+                        touchEndCanvasPos[1] > touchStartCanvasPos[1] + touchTolerance ||
+                        touchEndCanvasPos[1] < touchStartCanvasPos[1] - touchTolerance) {
+                        if (this._currentDistanceMeasurement) {
+                            this._currentDistanceMeasurement.destroy();
+                            this._currentDistanceMeasurement = null;
+                        }
+                        this._touchState = TOUCH_FINDING_TARGET;
+                        // console.log("touchend: (moved) this._touchState= QUICK_TOUCH_FINDING_TARGET -> TOUCH_FINDING_TARGET")
+                    } else {
+                        const pickResult = scene.pick({
+                            canvasPos: touchEndCanvasPos,
+                            pickSurface: true
+                        })
+                        if (pickResult && pickResult.worldPos) {
+                            if (this.pointerLens) {
+                                this.pointerLens.cursorPos = pickResult.canvasPos;
+                                this.pointerLens.snapped = false;
+                            }
+                            this._currentDistanceMeasurement.xAxisVisible = false;
+                            this._currentDistanceMeasurement.yAxisVisible = false;
+                            this._currentDistanceMeasurement.zAxisVisible = false;
+                            this._currentDistanceMeasurement.wireVisible = true;
+                            this._currentDistanceMeasurement.originVisible = true;
+                            this._currentDistanceMeasurement.targetVisible = true;
+                            this._currentDistanceMeasurement.target.worldPos = pickResult.worldPos;
+                            this._currentDistanceMeasurement.labelsVisible = true;
+                            this._currentDistanceMeasurement.clickable = false;
+                            this.distanceMeasurementsPlugin.fire("measurementEnd", this._currentDistanceMeasurement);
+                            this._currentDistanceMeasurement = null;
+                            this._touchState = TOUCH_FINDING_ORIGIN;
+                            // console.log("touchend: this._touchState= QUICK_TOUCH_FINDING_TARGET (picked, begin measurement) -> TOUCH_FINDING_ORIGIN")
+                        } else {
+                            if (this._currentDistanceMeasurement) {
+                                this._currentDistanceMeasurement.destroy();
+                                this._currentDistanceMeasurement = null;
+                            }
+                            this._touchState = TOUCH_FINDING_ORIGIN;
+                            // console.log("touchend: this._touchState= QUICK_TOUCH_FINDING_ORIGIN (nothing picked, destroy measurement) -> TOUCH_FINDING_ORIGIN")
+
+                        }
+                    }
+                    break;
+
+                case LONG_TOUCH_FINDING_TARGET:
+                    if (this.pointerLens) {
+                        this.pointerLens.visible = false;
+                    }
+                    if (!this._currentDistanceMeasurement || !this._currentDistanceMeasurement.targetVisible) {
+                        if (this._currentDistanceMeasurement) {
+                            this._currentDistanceMeasurement.destroy();
+                            this._currentDistanceMeasurement = null;
+                        }
+                        this._touchState = TOUCH_FINDING_ORIGIN;
+                        // console.log("touchend: this._touchState= LONG_TOUCH_FINDING_TARGET (no target found) -> TOUCH_FINDING_ORIGIN")
+                    } else {
+                        this._currentDistanceMeasurement.clickable = true;
+                        this.distanceMeasurementsPlugin.fire("measurementEnd", this._currentDistanceMeasurement);
+                        this._currentDistanceMeasurement = null;
+                        this._touchState = TOUCH_FINDING_ORIGIN;
+                        // console.log("touchend: this._touchState= LONG_TOUCH_FINDING_TARGET  -> TOUCH_FINDING_ORIGIN")
+                    }
+                    break;
+
+                // case  TOUCH_CANCELING:
+                //      if (this.pointerLens) {
+                //          this.pointerLens.visible = false;
+                //      }
+                //      this._currentDistanceMeasurement = null;
+                //      this._touchState = TOUCH_FINDING_ORIGIN;
+                //     // console.log("touchend: this._touchState= default -> TOUCH_FINDING_ORIGIN")
+                //      break;
+            }
+
+        }, {passive: true});
+
+        this._active = true;
+    }
+
+    /**
+     * Deactivates this DistanceMeasurementsTouchControl, making it unresponsive to input.
+     *
+     * Destroys any {@link DistanceMeasurement} under construction.
+     */
+    deactivate() {
+        if (!this._active) {
+            return;
+        }
+        if (this.plugin.pointerLens) {
+            this.plugin.pointerLens.visible = false;
+        }
+        this.reset();
+        const canvas = this.plugin.viewer.scene.canvas.canvas;
+        canvas.removeEventListener("touchstart", this._onCanvasTouchStart);
+        canvas.removeEventListener("touchend", this._onCanvasTouchEnd);
+        if (this._currentDistanceMeasurement) {
+            this.distanceMeasurementsPlugin.fire("measurementCancel", this._currentDistanceMeasurement);
+            this._currentDistanceMeasurement.destroy();
+            this._currentDistanceMeasurement = null;
+        }
+        this._active = false;
+    }
+
+    /**
+     * Resets this DistanceMeasurementsTouchControl.
+     *
+     * Destroys any {@link DistanceMeasurement} under construction.
+     *
+     * Does nothing if the DistanceMeasurementsTouchControl is not active.
+     */
+    reset() {
+        if (!this._active) {
+            return;
+        }
+        if (this._currentDistanceMeasurement) {
+            this.distanceMeasurementsPlugin.fire("measurementCancel", this._currentDistanceMeasurement);
+            this._currentDistanceMeasurement.destroy();
+            this._currentDistanceMeasurement = null;
+        }
+    }
+
+    /**
+     * Destroys this DistanceMeasurementsTouchControl.
+     */
+    destroy() {
+        this.deactivate();
+        super.destroy();
+    }
+}

--- a/src/plugins/DistanceMeasurementsPlugin/index.js
+++ b/src/plugins/DistanceMeasurementsPlugin/index.js
@@ -1,3 +1,4 @@
 export * from "./DistanceMeasurementsPlugin.js";
 export * from "./DistanceMeasurementsControl.js";
 export * from "./DistanceMeasurementsMouseControl.js";
+export * from "./DistanceMeasurementsTouchControl.js";


### PR DESCRIPTION
This PR adds two controls to create measurements with touch input. 

These controls don't work perfectly yet; in the interval between setting points for a measurement, some touch input from camera movements will still interfere with the construction of a measurement.  Also, sometimes there is an error when the measurement under construction is undefined.

### DistanceMeasurementsTouchControl 

Short touch to set distance start and end points anywhere without snapping, long-touch to set each points using snapping and a pointer lens.

Run example:

* /examples/measurement/#distance_createWithTouch_snapping

### AngleMeasurementsTouchControl

Short touch to set angle start, corner and end points anywhere without snapping, long-touch to set each point using snapping and a pointer lens.

Run example: 

* /examples/measurement/#angle_createWithTouch_snapping