### PR TITLE
fix: make sure to weld vertices when `index-bucketting` is enabled

### DIFF
--- a/src/viewer/scene/model/SceneModel.js
+++ b/src/viewer/scene/model/SceneModel.js
@@ -3733,7 +3733,7 @@ export class SceneModel extends Component {
  */
 function createDTXBuckets(geometry, enableVertexWelding, enableIndexBucketing) {
     let uniquePositionsCompressed, uniqueIndices, uniqueEdgeIndices;
-    if (enableVertexWelding) { // Expensive - careful!
+    if (enableVertexWelding || enableIndexBucketing) { // Expensive - careful!
         [
             uniquePositionsCompressed,
             uniqueIndices,


### PR DESCRIPTION
## Description

Solves https://github.com/xeokit/xeokit-sdk/issues/1204

This fix, consists of making sure to weld vertices if index-bucketting is enabled.

## The reason

Index re-bucketting expects vertices' indices to be the same for the same vertex (so, only having unique vertices in the `positions` arrays).

This is due to how the how the re-bucketting code is designed in the original DTX's PR.

The fix consists is making sure the assumption holds.
