### PR TITLE
Add multi output Renderbuffer feature and snap pick normals with it

### DIFF
--- a/src/viewer/scene/model/dtx/triangles/renderers/TrianglesDataTextureSnapDepthBufInitRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/TrianglesDataTextureSnapDepthBufInitRenderer.js
@@ -280,8 +280,8 @@ export class TrianglesDataTextureSnapDepthBufInitRenderer {
         src.push("    return vec2(x, y);")
         src.push("}");
 
+        src.push("out vec4 vWorldPosition;");
         if (clipping) {
-            src.push("out vec4 vWorldPosition;");
             src.push("flat out uint vFlags2;");
         }
         src.push("out highp vec3 relativeToOriginPosition;");
@@ -363,8 +363,8 @@ export class TrianglesDataTextureSnapDepthBufInitRenderer {
         src.push("relativeToOriginPosition = worldPosition.xyz;")
         src.push("vec4 viewPosition  = viewMatrix * worldPosition; ");
 
+        src.push("vWorldPosition = worldPosition;");
         if (clipping) {
-            src.push("vWorldPosition = worldPosition;");
             src.push("vFlags2 = flags2.r;");
         }
         src.push("vec4 clipPos = projMatrix * viewPosition;");
@@ -403,8 +403,8 @@ export class TrianglesDataTextureSnapDepthBufInitRenderer {
         }
         src.push("uniform int uLayerNumber;");
         src.push("uniform vec3 uCoordinateScaler;");
+        src.push("in vec4 vWorldPosition;");
         if (clipping) {
-            src.push("in vec4 vWorldPosition;");
             src.push("flat in uint vFlags2;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
@@ -413,7 +413,8 @@ export class TrianglesDataTextureSnapDepthBufInitRenderer {
             }
         }
         src.push("in highp vec3 relativeToOriginPosition;");
-        src.push("out highp ivec4 outCoords;");
+        src.push("layout(location = 0) out highp ivec4 outCoords;");
+        src.push("layout(location = 1) out highp ivec4 outNormal;");
         src.push("void main(void) {");
         if (clipping) {
             src.push("  bool clippable = vFlags2 > 0u;");
@@ -434,6 +435,11 @@ export class TrianglesDataTextureSnapDepthBufInitRenderer {
             src.push("    gl_FragDepth = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth + diff ) * logDepthBufFC * 0.5;");
         }
         src.push("outCoords = ivec4(relativeToOriginPosition.xyz * uCoordinateScaler.xyz, - uLayerNumber);")
+
+        src.push("vec3 xTangent = dFdx( vWorldPosition.xyz );");
+        src.push("vec3 yTangent = dFdy( vWorldPosition.xyz );");
+        src.push("vec3 worldNormal = normalize( cross( xTangent, yTangent ) );");
+        src.push(`outNormal = ivec4(worldNormal * float(${math.MAX_INT}), 1.0);`);
         src.push("}");
         return src;
     }

--- a/src/viewer/scene/model/vbo/snapInstancing/SnapInstancingDepthBufInitRenderer.js
+++ b/src/viewer/scene/model/vbo/snapInstancing/SnapInstancingDepthBufInitRenderer.js
@@ -222,8 +222,8 @@ class SnapInstancingDepthBufInitRenderer extends VBOSceneModelRenderer {
         src.push("    float y = (clipPos.y - snapVectorA.y) * snapInvVectorAB.y;");
         src.push("    return vec2(x, y);")
         src.push("}");
+        src.push("out vec4 vWorldPosition;");
         if (clipping) {
-            src.push("out vec4 vWorldPosition;");
             src.push("out float vFlags;");
         }
         src.push("out highp vec3 relativeToOriginPosition;");
@@ -241,8 +241,8 @@ class SnapInstancingDepthBufInitRenderer extends VBOSceneModelRenderer {
         }
         src.push("relativeToOriginPosition = worldPosition.xyz;")
         src.push("  vec4 viewPosition  = viewMatrix * worldPosition; ");
+        src.push("  vWorldPosition = worldPosition;");
         if (clipping) {
-            src.push("  vWorldPosition = worldPosition;");
             src.push("  vFlags = flags;");
         }
         src.push("vec4 clipPos = projMatrix * viewPosition;");
@@ -281,8 +281,8 @@ class SnapInstancingDepthBufInitRenderer extends VBOSceneModelRenderer {
         }
         src.push("uniform int layerNumber;");
         src.push("uniform vec3 coordinateScaler;");
+        src.push("in vec4 vWorldPosition;");
         if (clipping) {
-            src.push("in vec4 vWorldPosition;");
             src.push("in float vFlags;");
             for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
@@ -291,7 +291,8 @@ class SnapInstancingDepthBufInitRenderer extends VBOSceneModelRenderer {
             }
         }
         src.push("in highp vec3 relativeToOriginPosition;");
-        src.push("out highp ivec4 outCoords;");
+        src.push("layout(location = 0) out highp ivec4 outCoords;");
+        src.push("layout(location = 1) out highp ivec4 outNormal;");
         src.push("void main(void) {");
         if (clipping) {
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
@@ -312,6 +313,11 @@ class SnapInstancingDepthBufInitRenderer extends VBOSceneModelRenderer {
             src.push("    gl_FragDepth = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth + diff ) * logDepthBufFC * 0.5;");
         }
         src.push("outCoords = ivec4(relativeToOriginPosition.xyz*coordinateScaler.xyz, -layerNumber);")
+
+        src.push("vec3 xTangent = dFdx( vWorldPosition.xyz );");
+        src.push("vec3 yTangent = dFdy( vWorldPosition.xyz );");
+        src.push("vec3 worldNormal = normalize( cross( xTangent, yTangent ) );");
+        src.push(`outNormal = ivec4(worldNormal * float(${math.MAX_INT}), 1.0);`);
         src.push("}");
         return src;
     }


### PR DESCRIPTION
I am developing a custom measurement plugin but to do so, I need normals information on `SnapPickResult`. Unfortunately there is only `worldPosition` available...

This PR includes two main changes:
- `RenderBuffer` multi output API with no breaking changes ! Only new feature 🎉
- `SnapPickResult` normals : `snappedWorldNormal` & `worldNormal`

**Implementation:**

The snap pick normals are computed using partiale derivatives like the flat normal pick renderers. Also, instead of doing another render pass, normals are computed on the same pass as the depth init pass of the snap pick. The multi output RenderBuffer API update allows drawing `outCoords` on color attachment 0 and `outNormal` on color attachment 1.

**Impact:**

Normals on `SnapPickResult` may also be used on other use cases like adding section plan using snap picking or other measurement plugin like spacing measurement...