### PR TITLE
FIX: force triangle instancing pick normals flat renderer

### DIFF
--- a/src/viewer/scene/model/vbo/trianglesInstancing/TrianglesInstancingLayer.js
+++ b/src/viewer/scene/model/vbo/trianglesInstancing/TrianglesInstancingLayer.js
@@ -976,9 +976,19 @@ class TrianglesInstancingLayer {
             return;
         }
         this._updateBackfaceCull(renderFlags, frameCtx);
-        if (this._instancingRenderers.pickNormalsRenderer) {
-            this._instancingRenderers.pickNormalsRenderer.drawLayer(frameCtx, this, RENDER_PASSES.PICK);
-        }
+
+        ////////////////////////////////////////////////////////////////////////////////////////////////////
+        // TODO
+        // if (this._state.normalsBuf) {
+        //     if (this._instancingRenderers.pickNormalsRenderer) {
+        //         this._instancingRenderers.pickNormalsRenderer.drawLayer(frameCtx, this, RENDER_PASSES.PICK);
+        //     }
+        ////////////////////////////////////////////////////////////////////////////////////////////////////
+        // } else {
+            if (this._instancingRenderers.pickNormalsFlatRenderer) {
+                this._instancingRenderers.pickNormalsFlatRenderer.drawLayer(frameCtx, this, RENDER_PASSES.PICK);
+            }
+        // }
     }
 
     drawSnapInitDepthBuf(renderFlags, frameCtx) {


### PR DESCRIPTION
In the **triangle batching layer**, the pick normals renderer is [forced to the flat renderer](https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/scene/model/vbo/trianglesBatching/TrianglesBatchingLayer.js#L1142-L1160).

In the **triangle instancing layer**, there is [only](https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/scene/model/vbo/trianglesInstancing/TrianglesInstancingLayer.js#L974-L982) the 'standard' (not flat) pick normal renderer. However, the code responsible to set the `state.normalsBuf` [is commented](https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/scene/model/vbo/trianglesInstancing/TrianglesInstancingLayer.js#L332-L335). That is why it is not possible to pick normals on instanced models. In [this example](https://xeokit.github.io/xeokit-sdk/examples/slicing/#SectionPlanesPlugin_createWithMouse), it is possible to add section plane with mouse on the wall because it is batching, but it does not work on the couch because it is instancing.

This PR fixes the issue https://github.com/xeokit/xeokit-sdk/issues/1141.

Node that this PR add the same TODO as the one in the batching layer. I assume this TODO was added because the standard pick normal renderer may not work with the provided normals. In my case, it does not...