### PR TITLE
Make measurements sliced by SectionPlanes #1217

### DIFF
--- a/src/plugins/AngleMeasurementsPlugin/AngleMeasurement.js
+++ b/src/plugins/AngleMeasurementsPlugin/AngleMeasurement.js
@@ -68,7 +68,7 @@ class AngleMeasurement extends Component {
 
         this._originDot = new Dot(this._container, {
             fillColor: this._color,
-            zIndex: plugin.zIndex !== undefined ? plugin.zIndex + 2: undefined,
+            zIndex: plugin.zIndex !== undefined ? plugin.zIndex + 2 : undefined,
             onMouseOver,
             onMouseLeave,
             onMouseWheel,
@@ -76,7 +76,7 @@ class AngleMeasurement extends Component {
         });
         this._cornerDot = new Dot(this._container, {
             fillColor: this._color,
-            zIndex: plugin.zIndex !== undefined ? plugin.zIndex + 2: undefined,
+            zIndex: plugin.zIndex !== undefined ? plugin.zIndex + 2 : undefined,
             onMouseOver,
             onMouseLeave,
             onMouseWheel,
@@ -84,7 +84,7 @@ class AngleMeasurement extends Component {
         });
         this._targetDot = new Dot(this._container, {
             fillColor: this._color,
-            zIndex: plugin.zIndex !== undefined ? plugin.zIndex + 2: undefined,
+            zIndex: plugin.zIndex !== undefined ? plugin.zIndex + 2 : undefined,
             onMouseOver,
             onMouseLeave,
             onMouseWheel,
@@ -103,7 +103,7 @@ class AngleMeasurement extends Component {
         this._targetWire = new Wire(this._container, {
             color: this._color || "red",
             thickness: 1,
-            zIndex: plugin.zIndex !== undefined ? plugin.zIndex + 1: undefined,
+            zIndex: plugin.zIndex !== undefined ? plugin.zIndex + 1 : undefined,
             onMouseOver,
             onMouseLeave,
             onMouseWheel,
@@ -170,7 +170,7 @@ class AngleMeasurement extends Component {
             this._needUpdate(0); // No lag
         });
 
-        this._onSectionPlaneUpdated = scene.on("sectionPlaneUpdated", () =>{
+        this._onSectionPlaneUpdated = scene.on("sectionPlaneUpdated", () => {
             this._sectionPlanesDirty = true;
             this._needUpdate();
         });
@@ -341,7 +341,8 @@ class AngleMeasurement extends Component {
     _isSliced(positions) {
         const sectionPlanes = this.scene._sectionPlanesState.sectionPlanes;
         for (let i = 0, len = sectionPlanes.length; i < len; i++) {
-            if (sectionPlanes[i].clipsPositions3(positions, 4)) {
+            const sectionPlane = sectionPlanes[i];
+            if (math.planeClipsPositions3(sectionPlane.pos, sectionPlane.dir, positions, 4)) {
                 return true
             }
         }

--- a/src/plugins/AngleMeasurementsPlugin/AngleMeasurement.js
+++ b/src/plugins/AngleMeasurementsPlugin/AngleMeasurement.js
@@ -170,6 +170,11 @@ class AngleMeasurement extends Component {
             this._needUpdate(0); // No lag
         });
 
+        this._onSectionPlaneUpdated = scene.on("sectionPlaneUpdated", () =>{
+            this._sectionPlanesDirty = true;
+            this._needUpdate();
+        });
+
         this.approximate = cfg.approximate;
         this.visible = cfg.visible;
 
@@ -223,6 +228,28 @@ class AngleMeasurement extends Component {
 
             this._vpDirty = false;
             this._cpDirty = true;
+        }
+
+        if (this._sectionPlanesDirty) {
+
+            if (this._isSliced(this._wp)) {
+                this._angleLabel.setCulled(true);
+                this._originWire.setCulled(true);
+                this._targetWire.setCulled(true);
+                this._originDot.setCulled(true);
+                this._cornerDot.setCulled(true);
+                this._targetDot.setCulled(true);
+                return;
+            } else {
+                this._angleLabel.setCulled(false);
+                this._originWire.setCulled(false);
+                this._targetWire.setCulled(false);
+                this._originDot.setCulled(false);
+                this._cornerDot.setCulled(false);
+                this._targetDot.setCulled(false);
+            }
+
+            this._sectionPlanesDirty = true;
         }
 
         if (this._cpDirty) {
@@ -309,6 +336,16 @@ class AngleMeasurement extends Component {
 
             this._cpDirty = false;
         }
+    }
+
+    _isSliced(positions) {
+        const sectionPlanes = this.scene._sectionPlanesState.sectionPlanes;
+        for (let i = 0, len = sectionPlanes.length; i < len; i++) {
+            if (sectionPlanes[i].clipsPositions3(positions, 4)) {
+                return true
+            }
+        }
+        return false;
     }
 
     /**
@@ -640,6 +677,9 @@ class AngleMeasurement extends Component {
         }
         if (this._onCanvasBoundary) {
             scene.canvas.off(this._onCanvasBoundary);
+        }
+        if (this._onSectionPlaneUpdated) {
+            scene.off(this._onSectionPlaneUpdated);
         }
 
         this._originDot.destroy();

--- a/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
+++ b/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
@@ -470,7 +470,8 @@ class DistanceMeasurement extends Component {
     _isSliced(positions) {
        const sectionPlanes = this.scene._sectionPlanesState.sectionPlanes;
         for (let i = 0, len = sectionPlanes.length; i < len; i++) {
-            if (sectionPlanes[i].clipsPositions3(positions, 4)) {
+            const sectionPlane = sectionPlanes[i];
+            if (math.planeClipsPositions3(sectionPlane.pos, sectionPlane.dir, positions, 4)) {
                 return true
             }
         }

--- a/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
+++ b/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
@@ -185,6 +185,7 @@ class DistanceMeasurement extends Component {
         this._wpDirty = false;
         this._vpDirty = false;
         this._cpDirty = false;
+        this._sectionPlanesDirty = true;
 
         this._visible = false;
         this._originVisible = false;
@@ -237,6 +238,11 @@ class DistanceMeasurement extends Component {
 
         this._onMetricsOrigin = scene.metrics.on("origin", () => {
             this._cpDirty = true;
+            this._needUpdate();
+        });
+
+        this._onSectionPlaneUpdated = scene.on("sectionPlaneUpdated", () =>{
+            this._sectionPlanesDirty = true;
             this._needUpdate();
         });
 
@@ -297,6 +303,36 @@ class DistanceMeasurement extends Component {
 
             this._vpDirty = false;
             this._cpDirty = true;
+        }
+
+        if (this._sectionPlanesDirty) {
+
+            if (this._isSliced(this._wp)) {
+                this._xAxisLabel.setCulled(true);
+                this._yAxisLabel.setCulled(true);
+                this._zAxisLabel.setCulled(true);
+                this._lengthLabel.setCulled(true);
+                this._xAxisWire.setCulled(true);
+                this._yAxisWire.setCulled(true);
+                this._zAxisWire.setCulled(true);
+                this._lengthWire.setCulled(true);
+                this._originDot.setCulled(true);
+                this._targetDot.setCulled(true);
+                return;
+            } else {
+                this._xAxisLabel.setCulled(false);
+                this._yAxisLabel.setCulled(false);
+                this._zAxisLabel.setCulled(false);
+                this._lengthLabel.setCulled(false);
+                this._xAxisWire.setCulled(false);
+                this._yAxisWire.setCulled(false);
+                this._zAxisWire.setCulled(false);
+                this._lengthWire.setCulled(false);
+                this._originDot.setCulled(false);
+                this._targetDot.setCulled(false);
+            }
+
+            this._sectionPlanesDirty = true;
         }
 
         const near = -0.3;
@@ -429,6 +465,16 @@ class DistanceMeasurement extends Component {
 
             this._cpDirty = false;
         }
+    }
+
+    _isSliced(positions) {
+       const sectionPlanes = this.scene._sectionPlanesState.sectionPlanes;
+        for (let i = 0, len = sectionPlanes.length; i < len; i++) {
+            if (sectionPlanes[i].clipsPositions3(positions, 4)) {
+                return true
+            }
+        }
+        return false;
     }
 
     /**
@@ -841,7 +887,6 @@ class DistanceMeasurement extends Component {
         if (this._onCanvasBoundary) {
             scene.canvas.off(this._onCanvasBoundary);
         }
-
         if (this._onMetricsUnits) {
             metrics.off(this._onMetricsUnits);
         }
@@ -850,6 +895,9 @@ class DistanceMeasurement extends Component {
         }
         if (this._onMetricsOrigin) {
             metrics.off(this._onMetricsOrigin);
+        }
+        if (this._onSectionPlaneUpdated) {
+            scene.off(this._onSectionPlaneUpdated);
         }
 
         this._originDot.destroy();

--- a/src/plugins/lib/html/Dot.js
+++ b/src/plugins/lib/html/Dot.js
@@ -15,6 +15,9 @@ class Dot {
         this._dotClickable = document.createElement('div');
         this._dotClickable.className += this._dotClickable.className ? ' viewer-ruler-dot-clickable' : 'viewer-ruler-dot-clickable';
 
+        this._visible = true;
+        this._culled = false;
+
         var dot = this._dot;
         var dotStyle = dot.style;
         dotStyle["border-radius"] = 25 + "px";
@@ -112,7 +115,15 @@ class Dot {
             return;
         }
         this._visible = !!visible;
-        this._dot.style.visibility = this._visible ? "visible" : "hidden";
+        this._dot.style.visibility = this._visible && !this._culled ? "visible" : "hidden";
+    }
+
+    setCulled(culled) {
+        if (this._culled === culled) {
+            return;
+        }
+        this._culled = !!culled;
+        this._dot.style.visibility = this._visible && !this._culled ? "visible" : "hidden";
     }
 
     setClickable(clickable) {

--- a/src/plugins/lib/html/Wire.js
+++ b/src/plugins/lib/html/Wire.js
@@ -15,6 +15,9 @@ class Wire {
         this._thickness = cfg.thickness || 1.0;
         this._thicknessClickable = cfg.thicknessClickable || 6.0;
 
+        this._visible = true;
+        this._culled = false;
+
         var wire = this._wire;
         var wireStyle = wire.style;
 
@@ -107,7 +110,7 @@ class Wire {
         this._update();
     }
 
-    get _visible() {
+    get visible() {
         return this._wire.style.visibility === "visible";
     }
 
@@ -155,11 +158,19 @@ class Wire {
     }
 
     setVisible(visible) {
-        visible = !!visible;
         if (this._visible === visible) {
             return;
         }
-        this._wire.style.visibility = visible ? "visible" : "hidden";
+        this._visible = !!visible;
+        this._wire.style.visibility = this._visible && !this._culled ? "visible" : "hidden";
+    }
+
+    setCulled(culled) {
+        if (this._culled === culled) {
+            return;
+        }
+        this._culled = !!culled;
+        this._wire.style.visibility = this._visible && !this._culled ? "visible" : "hidden";
     }
 
     setClickable(clickable) {

--- a/src/viewer/scene/math/math.js
+++ b/src/viewer/scene/math/math.js
@@ -3,6 +3,8 @@
 let doublePrecision = true;
 let FloatArrayType = doublePrecision ? Float64Array : Float32Array;
 
+const tempVec3a = new FloatArrayType(3);
+
 const tempMat1 = new FloatArrayType(16);
 const tempMat2 = new FloatArrayType(16);
 const tempVec4 = new FloatArrayType(4);
@@ -5359,5 +5361,26 @@ math.buildEdgeIndices = (function () {
     };
 })();
 
+
+/**
+ * Returns `true` if a plane clips the given 3D positions.
+ * @param {Number[]} pos Position in plane
+ * @param {Number[]} dir Direction of plane
+ * @param {number} positions Flat array of 3D positions.
+ * @param {number} numElementsPerPosition Number of elements perposition - usually either 3 or 4.
+ * @returns {boolean}
+ */
+math.planeClipsPositions3 = function(pos, dir, positions, numElementsPerPosition=3) {
+    for (let i = 0, len = positions.length; i < len; i += numElementsPerPosition) {
+        tempVec3a[0] = positions[i + 0] - pos[0];
+        tempVec3a[1] = positions[i + 1] - pos[1];
+        tempVec3a[2] = positions[i + 2] - pos[2];
+        let dotProduct = tempVec3a[0] * dir[0] + tempVec3a[1] * dir[1] + tempVec3a[2] * dir[2];
+        if (dotProduct < 0) {
+            return true;
+        }
+    }
+    return false;
+}
 
 export {math};

--- a/src/viewer/scene/model/dtx/triangles/renderers/TrianglesDataTextureColorRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/TrianglesDataTextureColorRenderer.js
@@ -172,6 +172,7 @@ export class TrianglesDataTextureColorRenderer {
 
         if (this._program.errors) {
             this.errors = this._program.errors;
+            console.error(this.errors);
             return;
         }
 

--- a/src/viewer/scene/model/dtx/triangles/renderers/TrianglesDataTextureOcclusionRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/TrianglesDataTextureOcclusionRenderer.js
@@ -226,7 +226,7 @@ export class TrianglesDataTextureOcclusionRenderer {
         const clipping = scene._sectionPlanesState.sectionPlanes.length > 0;
         const src = [];
         src.push("#version 300 es");
-        src.push("// TrianglesDataTextureColorRenderer vertex shader");
+        src.push("// TrianglesDataTextureOcclusionRenderer vertex shader");
 
         src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
         src.push("precision highp float;");
@@ -273,7 +273,7 @@ export class TrianglesDataTextureOcclusionRenderer {
         src.push("}");
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
-            src.push("out vec4 vFlags2;");
+            src.push("flat out uint vFlags2;");
         }
         src.push("void main(void) {");
 
@@ -358,10 +358,6 @@ export class TrianglesDataTextureOcclusionRenderer {
         src.push("vec4 offset = vec4(texelFetch (uTexturePerObjectIdOffsets, objectIndexCoords, 0).rgb, 0.0);");
         src.push("worldPosition.xyz = worldPosition.xyz + offset.xyz;");
         src.push("vec4 viewPosition = viewMatrix * worldPosition; ");
-        if (clipping) {
-            src.push("      vWorldPosition = worldPosition;");
-            src.push("      vFlags2 = flags2;");
-        }
         src.push("vec4 clipPos = projMatrix * viewPosition;");
         if (ENABLE_LOG_DEPTH_BUF && scene.logarithmicDepthBufferEnabled) {
             src.push("vFragDepth = 1.0 + clipPos.w;");
@@ -398,7 +394,7 @@ export class TrianglesDataTextureOcclusionRenderer {
         }
         if (clipping) {
             src.push("in vec4 vWorldPosition;");
-            src.push("in vec4 vFlags2;");
+            src.push("flat in uint vFlags2;");
             for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
                 src.push("uniform bool sectionPlaneActive" + i + ";");
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
@@ -408,7 +404,7 @@ export class TrianglesDataTextureOcclusionRenderer {
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
-            src.push("  bool clippable = (float(vFlags2.x) > 0.0);");
+            src.push("  bool clippable = (float(vFlags2) > 0.0);");
             src.push("  if (clippable) {");
             src.push("      float dist = 0.0;");
             for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {

--- a/src/viewer/scene/sectionPlane/SectionPlane.js
+++ b/src/viewer/scene/sectionPlane/SectionPlane.js
@@ -2,6 +2,8 @@ import {Component} from '../Component.js';
 import {RenderState} from '../webgl/RenderState.js';
 import {math} from "../math/math.js";
 
+const tempVec3a = math.vec3();
+
 /**
  *  @desc An arbitrarily-aligned World-space clipping plane.
  *
@@ -118,6 +120,7 @@ class SectionPlane extends Component {
         this._state.pos.set(value || [0, 0, 0]);
         this._state.dist = (-math.dotVec3(this._state.pos, this._state.dir));
         this.fire("pos", this._state.pos);
+        this.scene.fire("sectionPlaneUpdated", this);
     }
 
     /**
@@ -143,6 +146,7 @@ class SectionPlane extends Component {
         this._state.dist = (-math.dotVec3(this._state.pos, this._state.dir));
         this.glRedraw();
         this.fire("dir", this._state.dir);
+        this.scene.fire("sectionPlaneUpdated", this);
     }
 
     /**
@@ -179,6 +183,27 @@ class SectionPlane extends Component {
         this._state.dist = (-math.dotVec3(this._state.pos, this._state.dir));
         this.fire("dir", this._state.dir);
         this.glRedraw();
+    }
+
+    /**
+     * Returns `true` if this Section plane clips the given 3D positions.
+     * @param {number} positions Flat array of 3D positions.
+     * @param {number} numElementsPerPosition Number of elements perposition - usually either 3 or 4.
+     * @returns {boolean}
+     */
+    clipsPositions3(positions, numElementsPerPosition=3) {
+        const pos = this._state.pos;
+        const dir = this._state.dir;
+        for (let i = 0, len = positions.length; i < len; i += numElementsPerPosition) {
+            tempVec3a[0] = positions[i + 0] - pos[0];
+            tempVec3a[1] = positions[i + 1] - pos[1];
+            tempVec3a[2] = positions[i + 2] - pos[2];
+            let dotProduct = tempVec3a[0] * dir[0] + tempVec3a[1] * dir[1] + tempVec3a[2] * dir[2];
+            if (dotProduct < 0) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/viewer/scene/sectionPlane/SectionPlane.js
+++ b/src/viewer/scene/sectionPlane/SectionPlane.js
@@ -186,27 +186,6 @@ class SectionPlane extends Component {
     }
 
     /**
-     * Returns `true` if this Section plane clips the given 3D positions.
-     * @param {number} positions Flat array of 3D positions.
-     * @param {number} numElementsPerPosition Number of elements perposition - usually either 3 or 4.
-     * @returns {boolean}
-     */
-    clipsPositions3(positions, numElementsPerPosition=3) {
-        const pos = this._state.pos;
-        const dir = this._state.dir;
-        for (let i = 0, len = positions.length; i < len; i += numElementsPerPosition) {
-            tempVec3a[0] = positions[i + 0] - pos[0];
-            tempVec3a[1] = positions[i + 1] - pos[1];
-            tempVec3a[2] = positions[i + 2] - pos[2];
-            let dotProduct = tempVec3a[0] * dir[0] + tempVec3a[1] * dir[1] + tempVec3a[2] * dir[2];
-            if (dotProduct < 0) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
      * @destroy
      */
     destroy() {


### PR DESCRIPTION
This PR ensures that each distance or angle measurement is invisible when any part of it is sliced by a `SectionPlane`.

## Before

[Screencast from 10.11.2023 00:13:28.webm](https://github.com/xeokit/xeokit-sdk/assets/83100/ee0701dd-14b5-4728-a67a-f55562ba9cab)

## After

[Screencast from 10.11.2023 00:09:29.webm](https://github.com/xeokit/xeokit-sdk/assets/83100/b9a5c618-47f6-4d9c-a1c7-57dafe44febd)
