### PR TITLE
Fix: also unserialize `metaObject.external` when generating the `MetaModel`

### DIFF
--- a/src/viewer/metadata/MetaModel.js
+++ b/src/viewer/metadata/MetaModel.js
@@ -205,7 +205,8 @@ class MetaModel {
                         type,
                         name: metaObjectData.name,
                         attributes: metaObjectData.attributes,
-                        propertySetIds
+                        propertySetIds,
+                        external: metaObjectData.external,
                     });
                     this.metaScene.metaObjects[id] = metaObject;
                 }

--- a/src/viewer/metadata/MetaObject.js
+++ b/src/viewer/metadata/MetaObject.js
@@ -102,18 +102,18 @@ class MetaObject {
          */
         this.attributes = params.attributes || {};
 
-        // if (external !== undefined && external !== null) {
-        //
-        //     /**
-        //      * External application-specific metadata
-        //      *
-        //      * Undefined when there are is no external application-specific metadata.
-        //      *
-        //      * @property external
-        //      * @type {*}
-        //      */
-        //     this.external = external;
-        // }
+        if (params.external !== undefined && params.external !== null) {
+        
+            /**
+             * External application-specific metadata
+             *
+             * Undefined when there are is no external application-specific metadata.
+             *
+             * @property external
+             * @type {*}
+             */
+            this.external = params.external;
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/xeokit/xeokit-sdk/issues/1232