### PR TITLE
Fix `_subPortionSetMatrix` in `TrianglesDataTextureLayer`

### DIFF
--- a/src/viewer/scene/model/dtx/triangles/TrianglesDataTextureLayer.js
+++ b/src/viewer/scene/model/dtx/triangles/TrianglesDataTextureLayer.js
@@ -1092,9 +1092,9 @@ export class TrianglesDataTextureLayer {
             gl.TEXTURE_2D,
             0, // level
             (subPortionId % 512) * 4, // xoffset
-            //Math.floor(subPortionId / 512), // yoffset
-            1,
-            1, // width
+            Math.floor(subPortionId / 512), // yoffset
+            // 1,
+            4, // width
             1, // height
             gl.RGBA,
             gl.FLOAT,


### PR DESCRIPTION
## Description

- fix in `y` coordinate: it must correspond to the one for the sub-portion
- fix in `width`: as a 4x4 matrix is made of 4 pixels (`4 pixels` x `4 components in RGBA32F`), the update width must be 4