### PR TITLE
Fire `"activated"` events from `DistanceMeasurementsMouseControl`

### DIFF
--- a/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsMouseControl.js
+++ b/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsMouseControl.js
@@ -161,6 +161,8 @@ export class DistanceMeasurementsMouseControl extends DistanceMeasurementsContro
             return;
         }
 
+        this.fire("activated", true);
+
         const distanceMeasurementsPlugin = this.distanceMeasurementsPlugin;
         const scene = this.scene;
         const cameraControl = distanceMeasurementsPlugin.viewer.cameraControl;
@@ -307,6 +309,9 @@ export class DistanceMeasurementsMouseControl extends DistanceMeasurementsContro
         if (!this._active) {
             return;
         }
+
+        this.fire("activated", false);
+
         if (this.pointerLens) {
             this.pointerLens.visible = false;
         }


### PR DESCRIPTION
## Description

In some cases, it's interesting to act reactively when the measurement controller is (de)activated (for example to update the UI in applications made on top of `xeokit-sdk`).

This PR makes the measurement controller fire the `"activated"` event both when it's activated and when it's deactivated.