### PR TITLE
Add type definitions for `measurementEnd` and `measurementCancel` in `DistanceMeasurementsPlugin.d.ts`

### DIFF
--- a/types/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsPlugin.d.ts
+++ b/types/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsPlugin.d.ts
@@ -126,6 +126,20 @@ export declare class DistanceMeasurementsPlugin extends Plugin {
   on(event: "measurementCreated", callback: (measurement: DistanceMeasurement)=> void): void;
 
   /**
+   * Fires when a measurement is completed.
+   * @param {String} event The measurementEnd event
+   * @param {Function} callback Callback fired on the event
+   */
+  on(event: "measurementEnd", callback: (measurement: DistanceMeasurement)=> void): void;
+
+  /**
+   * Fires when a measurement is cancelled.
+   * @param {String} event The measurementCancel event
+   * @param {Function} callback Callback fired on the event
+   */
+  on(event: "measurementCancel", callback: (measurement: DistanceMeasurement)=> void): void;
+
+  /**
    * Fires when a measurement is destroyed.
    * @param {String} event The measurementDestroyed event
    * @param {Function} callback Callback fired on the event


### PR DESCRIPTION
## Description

The following piece of code...

https://github.com/xeokit/xeokit-sdk/blob/1bfdfff9dd3115813c2b9fc9eba86104834bf004/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsMouseControl.js#L247-L255

... is firing `"measurementEnd"` and `"measurementCancel"` events on `DistanceMeasurementsPlugin`, but the `.d.ts` file is missing those event definitions.

This PR adds their definition so Typescript consumers can subscribe to them 🙂.