### PR TITLE
Return `string` instead of `void` to `DistanceMeasurementsPlugin`'s subscribers

### DIFF
--- a/types/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsPlugin.d.ts
+++ b/types/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsPlugin.d.ts
@@ -123,27 +123,27 @@ export declare class DistanceMeasurementsPlugin extends Plugin {
    * @param {String} event The measurementCreated event
    * @param {Function} callback Callback fired on the event
    */
-  on(event: "measurementCreated", callback: (measurement: DistanceMeasurement)=> void): void;
+  on(event: "measurementCreated", callback: (measurement: DistanceMeasurement)=> void): string;
 
   /**
    * Fires when a measurement is completed.
    * @param {String} event The measurementEnd event
    * @param {Function} callback Callback fired on the event
    */
-  on(event: "measurementEnd", callback: (measurement: DistanceMeasurement)=> void): void;
+  on(event: "measurementEnd", callback: (measurement: DistanceMeasurement)=> void): string;
 
   /**
    * Fires when a measurement is cancelled.
    * @param {String} event The measurementCancel event
    * @param {Function} callback Callback fired on the event
    */
-  on(event: "measurementCancel", callback: (measurement: DistanceMeasurement)=> void): void;
+  on(event: "measurementCancel", callback: (measurement: DistanceMeasurement)=> void): string;
 
   /**
    * Fires when a measurement is destroyed.
    * @param {String} event The measurementDestroyed event
    * @param {Function} callback Callback fired on the event
    */
-   on(event: "measurementDestroyed", callback: (measurement: DistanceMeasurement)=> void): void;
+   on(event: "measurementDestroyed", callback: (measurement: DistanceMeasurement)=> void): string;
   
 }


### PR DESCRIPTION
## Description

Otherwise we couldn't later un-subscribe current listeners 🙂 