### PR TITLE
FEATURE: add entity to snap pick result

### DIFF
--- a/src/viewer/scene/model/dtx/triangles/renderers/TrianglesDataTextureSnapDepthBufInitRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/TrianglesDataTextureSnapDepthBufInitRenderer.js
@@ -280,6 +280,7 @@ export class TrianglesDataTextureSnapDepthBufInitRenderer {
         src.push("    return vec2(x, y);")
         src.push("}");
 
+        src.push("flat out vec4 vPickColor;");
         src.push("out vec4 vWorldPosition;");
         if (clipping) {
             src.push("flat out uint vFlags2;");
@@ -367,6 +368,7 @@ export class TrianglesDataTextureSnapDepthBufInitRenderer {
         if (clipping) {
             src.push("vFlags2 = flags2.r;");
         }
+        src.push("vPickColor = vec4(texelFetch (uTexturePerObjectIdColorsAndFlags, ivec2(objectIndexCoords.x*8+1, objectIndexCoords.y), 0));");
         src.push("vec4 clipPos = projMatrix * viewPosition;");
         src.push("float tmp = clipPos.w;")
         src.push("clipPos.xyzw /= tmp;")
@@ -404,6 +406,7 @@ export class TrianglesDataTextureSnapDepthBufInitRenderer {
         src.push("uniform int uLayerNumber;");
         src.push("uniform vec3 uCoordinateScaler;");
         src.push("in vec4 vWorldPosition;");
+        src.push("flat in vec4 vPickColor;");
         if (clipping) {
             src.push("flat in uint vFlags2;");
             for (let i = 0, len = sectionPlanesState.sectionPlanes.length; i < len; i++) {
@@ -415,6 +418,7 @@ export class TrianglesDataTextureSnapDepthBufInitRenderer {
         src.push("in highp vec3 relativeToOriginPosition;");
         src.push("layout(location = 0) out highp ivec4 outCoords;");
         src.push("layout(location = 1) out highp ivec4 outNormal;");
+        src.push("layout(location = 2) out lowp uvec4 outPickColor;");
         src.push("void main(void) {");
         if (clipping) {
             src.push("  bool clippable = vFlags2 > 0u;");
@@ -440,6 +444,7 @@ export class TrianglesDataTextureSnapDepthBufInitRenderer {
         src.push("vec3 yTangent = dFdy( vWorldPosition.xyz );");
         src.push("vec3 worldNormal = normalize( cross( xTangent, yTangent ) );");
         src.push(`outNormal = ivec4(worldNormal * float(${math.MAX_INT}), 1.0);`);
+        src.push("outPickColor = uvec4(vPickColor);");
         src.push("}");
         return src;
     }

--- a/src/viewer/scene/model/vbo/snapBatching/SnapBatchingDepthBufInitRenderer.js
+++ b/src/viewer/scene/model/vbo/snapBatching/SnapBatchingDepthBufInitRenderer.js
@@ -166,7 +166,9 @@ export class SnapBatchingDepthBufInitRenderer extends VBOSceneModelRenderer {
         src.push("precision mediump sampler2D;");
         src.push("#endif");
         src.push("uniform int renderPass;");
+        src.push("in vec4 pickColor;");
         src.push("in vec3 position;");
+
         if (scene.entityOffsetsEnabled) {
             src.push("in vec3 offset;");
         }
@@ -191,6 +193,7 @@ export class SnapBatchingDepthBufInitRenderer extends VBOSceneModelRenderer {
         src.push("    float y = (clipPos.y - snapVectorA.y) * snapInvVectorAB.y;");
         src.push("    return vec2(x, y);")
         src.push("}");
+        src.push("flat out vec4 vPickColor;");
         src.push("out vec4 vWorldPosition;");
         if (clipping) {
             src.push("out float vFlags;");
@@ -213,6 +216,7 @@ export class SnapBatchingDepthBufInitRenderer extends VBOSceneModelRenderer {
         if (clipping) {
             src.push("      vFlags = flags;");
         }
+        src.push("vPickColor = pickColor;");
         src.push("vec4 clipPos = projMatrix * viewPosition;");
         src.push("float tmp = clipPos.w;")
         src.push("clipPos.xyzw /= tmp;")
@@ -250,6 +254,7 @@ export class SnapBatchingDepthBufInitRenderer extends VBOSceneModelRenderer {
         src.push("uniform int layerNumber;");
         src.push("uniform vec3 coordinateScaler;");
         src.push("in vec4 vWorldPosition;");
+        src.push("flat in vec4 vPickColor;");
         if (clipping) {
             src.push("in float vFlags;");
             for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
@@ -261,6 +266,7 @@ export class SnapBatchingDepthBufInitRenderer extends VBOSceneModelRenderer {
         src.push("in highp vec3 relativeToOriginPosition;");
         src.push("layout(location = 0) out highp ivec4 outCoords;");
         src.push("layout(location = 1) out highp ivec4 outNormal;");
+        src.push("layout(location = 2) out lowp uvec4 outPickColor;");
         src.push("void main(void) {");
         if (clipping) {
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
@@ -286,6 +292,7 @@ export class SnapBatchingDepthBufInitRenderer extends VBOSceneModelRenderer {
         src.push("vec3 yTangent = dFdy( vWorldPosition.xyz );");
         src.push("vec3 worldNormal = normalize( cross( xTangent, yTangent ) );");
         src.push(`outNormal = ivec4(worldNormal * float(${math.MAX_INT}), 1.0);`);
+        src.push("outPickColor = uvec4(vPickColor);");
         src.push("}");
         return src;
     }

--- a/src/viewer/scene/model/vbo/snapInstancing/SnapInstancingDepthBufInitRenderer.js
+++ b/src/viewer/scene/model/vbo/snapInstancing/SnapInstancingDepthBufInitRenderer.js
@@ -194,6 +194,7 @@ class SnapInstancingDepthBufInitRenderer extends VBOSceneModelRenderer {
         src.push("precision mediump sampler2D;");
         src.push("#endif");
         src.push("uniform int renderPass;");
+        src.push("in vec4 pickColor;");
         src.push("in vec3 position;");
         if (scene.entityOffsetsEnabled) {
             src.push("in vec3 offset;");
@@ -222,6 +223,7 @@ class SnapInstancingDepthBufInitRenderer extends VBOSceneModelRenderer {
         src.push("    float y = (clipPos.y - snapVectorA.y) * snapInvVectorAB.y;");
         src.push("    return vec2(x, y);")
         src.push("}");
+        src.push("flat out vec4 vPickColor;");
         src.push("out vec4 vWorldPosition;");
         if (clipping) {
             src.push("out float vFlags;");
@@ -245,6 +247,7 @@ class SnapInstancingDepthBufInitRenderer extends VBOSceneModelRenderer {
         if (clipping) {
             src.push("  vFlags = flags;");
         }
+        src.push("vPickColor = pickColor;");
         src.push("vec4 clipPos = projMatrix * viewPosition;");
         src.push("float tmp = clipPos.w;")
         src.push("clipPos.xyzw /= tmp;")
@@ -282,6 +285,7 @@ class SnapInstancingDepthBufInitRenderer extends VBOSceneModelRenderer {
         src.push("uniform int layerNumber;");
         src.push("uniform vec3 coordinateScaler;");
         src.push("in vec4 vWorldPosition;");
+        src.push("flat in vec4 vPickColor;");
         if (clipping) {
             src.push("in float vFlags;");
             for (let i = 0; i < sectionPlanesState.sectionPlanes.length; i++) {
@@ -293,6 +297,7 @@ class SnapInstancingDepthBufInitRenderer extends VBOSceneModelRenderer {
         src.push("in highp vec3 relativeToOriginPosition;");
         src.push("layout(location = 0) out highp ivec4 outCoords;");
         src.push("layout(location = 1) out highp ivec4 outNormal;");
+        src.push("layout(location = 2) out lowp uvec4 outPickColor;");
         src.push("void main(void) {");
         if (clipping) {
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
@@ -318,6 +323,7 @@ class SnapInstancingDepthBufInitRenderer extends VBOSceneModelRenderer {
         src.push("vec3 yTangent = dFdy( vWorldPosition.xyz );");
         src.push("vec3 worldNormal = normalize( cross( xTangent, yTangent ) );");
         src.push(`outNormal = ivec4(worldNormal * float(${math.MAX_INT}), 1.0);`);
+        src.push("outPickColor = uvec4(vPickColor);");
         src.push("}");
         return src;
     }


### PR DESCRIPTION
This PR adds `snappedEntity` & `entity` to the `scene.snapPick()` result.

**Use case:**
While snap picking with a custom measurement plugin, it may be interesting to link the snap pick (surface/edge/vertex) to an entity to hide/show the corresponding measure when the entity is hidden/shown.

**To go further:**
The PR closes a little bit more the differences between the standard `scene.pick`  and the snap pick `scene.snapPick`. Maybe later, both can be merged into one with sone parameters to allow both behaviours on the same API.