### PR TITLE
FEATURE: More vibrant default Selection and Highlight materials

### DIFF
--- a/src/viewer/scene/materials/EmphasisMaterial.js
+++ b/src/viewer/scene/materials/EmphasisMaterial.js
@@ -87,7 +87,7 @@ const PRESETS = {
         fillColor: [1.0, 1.0, 0.0],
         fillAlpha: 0.5,
         edges: true,
-        edgeColor: [0.529411792755127, 0.4577854573726654, 0.4100345969200134],
+        edgeColor: [1.0, 1.0, 1.0],
         edgeAlpha: 1.0,
         edgeWidth: 1
     },
@@ -96,7 +96,7 @@ const PRESETS = {
         fillColor: [0.0, 1.0, 0.0],
         fillAlpha: 0.5,
         edges: true,
-        edgeColor: [0.4577854573726654, 0.529411792755127, 0.4100345969200134],
+        edgeColor: [1.0, 1.0, 1.0],
         edgeAlpha: 1.0,
         edgeWidth: 1
     },


### PR DESCRIPTION
Make the edges of default Selection and highlight materials white, so they have more visual pop. 

![Screenshot from 2023-11-20 20-08-42](https://github.com/xeokit/xeokit-sdk/assets/83100/bfde6820-8a1b-4112-905a-55fff7fd27eb)

![Screenshot from 2023-11-20 20-12-48](https://github.com/xeokit/xeokit-sdk/assets/83100/0027e7d9-2482-4a9c-abee-562002b88cd4)