### PR TITLE
Fix race condtion and optimize `PickControler.js`

### DIFF
--- a/src/viewer/scene/CameraControl/lib/controllers/PickController.js
+++ b/src/viewer/scene/CameraControl/lib/controllers/PickController.js
@@ -70,12 +70,28 @@ class PickController {
         this._lastPickedEntityId = null;
 
         this._needFireEvents = 0;
+
+        this._needToUpdate = false;
+
+        this._tickSub = this._scene.on("tick", () => {
+            this.runUpdate();
+        });
+    }
+
+    update() {
+        this._needToUpdate = true;
     }
 
     /**
      * Immediately attempts a pick, if scheduled.
      */
-    update() {
+    runUpdate() {
+
+        if (!this._needToUpdate) {
+            return;
+        }
+
+        this._needToUpdate = false;
 
         if (!this._configs.pointerEnabled) {
             return;
@@ -258,6 +274,7 @@ class PickController {
     }
 
     destroy() {
+        this._scene.off(this._tickSub);
     }
 }
 

--- a/src/viewer/scene/CameraControl/lib/controllers/PickController.js
+++ b/src/viewer/scene/CameraControl/lib/controllers/PickController.js
@@ -69,7 +69,7 @@ class PickController {
 
         this._lastPickedEntityId = null;
 
-        this._needFireEvents = false;
+        this._needFireEvents = 0;
     }
 
     /**
@@ -90,7 +90,7 @@ class PickController {
         this.snappedOrPicked = false;
         this.hoveredSnappedOrSurfaceOff = false;
 
-        this._needFireEvents = false;
+        // this._needFireEvents = false;
 
         const hasHoverSurfaceSubs = this._cameraControl.hasSubs("hoverSurface");
 
@@ -104,7 +104,7 @@ class PickController {
             if (snapPickResult && snapPickResult.snappedWorldPos) {
                 this.snapPickResult = snapPickResult;
                 this.snappedOrPicked = true;
-                this._needFireEvents = true;
+                this._needFireEvents++;
             } else {
                 this.schedulePickSurface = true; // Fallback
                 this.snapPickResult = null;
@@ -117,7 +117,7 @@ class PickController {
                 if (pickResultCanvasPos[0] === this.pickCursorPos[0] && pickResultCanvasPos[1] === this.pickCursorPos[1]) {
                     this.picked = true;
                     this.pickedSurface = true;
-                    this._needFireEvents = hasHoverSurfaceSubs;
+                    this._needFireEvents += hasHoverSurfaceSubs ? 1 : 0;
                     this.schedulePickEntity = false;
                     this.schedulePickSurface = false;
                     if (this.scheduleSnapOrPick) {
@@ -137,7 +137,7 @@ class PickController {
                 if (pickResultCanvasPos[0] === this.pickCursorPos[0] && pickResultCanvasPos[1] === this.pickCursorPos[1]) {
                     this.picked = true;
                     this.pickedSurface = false;
-                    this._needFireEvents = false;
+                    // this._needFireEvents = false;
                     this.schedulePickEntity = false;
                     this.schedulePickSurface = false;
                     return;
@@ -158,10 +158,10 @@ class PickController {
                 } else {
                     this.pickedSurface = true;
                 }
-                this._needFireEvents = true;
+                this._needFireEvents++;
             } else if (this.scheduleSnapOrPick) {
                 this.hoveredSnappedOrSurfaceOff = true;
-                this._needFireEvents = true;
+                this._needFireEvents++;
             }
 
         } else { // schedulePickEntity == true
@@ -173,7 +173,7 @@ class PickController {
             if (this.pickResult) {
                 this.picked = true;
                 this.pickedSurface = false;
-                this._needFireEvents = true;
+                this._needFireEvents++;
             }
         }
 
@@ -184,7 +184,7 @@ class PickController {
 
     fireEvents() {
 
-        if (!this._needFireEvents) {
+        if (this._needFireEvents == 0) {
             return;
         }
 
@@ -254,7 +254,7 @@ class PickController {
 
         this.pickResult = null;
 
-        this._needFireEvents = false;
+        this._needFireEvents = 0;
     }
 
     destroy() {


### PR DESCRIPTION
## Description

This PR solves two problems:

**a) Race condition in `PickController.js`**

Today, the `PickController`class will track if it needs to fire events with the `this._needFireEvents` boolean.

This has one problem: traditionally Javascript is a single-threaded language, but that is not completely true when using input listeners such as mouse-events, which in some cases their callbacks seem to have interleaved code execution with main Javascript thread.

In this case, during the creation of measurements, there are two "execution flows" (which seem to interleave and cause race conditions):

- 1st, is that during distance-measurements, there is a continuous stream of `mousemove` events being processed. Down the stack-trace, the callback for `mousemove` is changing the state of `PickController._needFireEvents.

- 2nd, is that `PickController.fireEvents()` will make use, and also read+write the state of the variable `PickController._needFireEvents` variable.

**The solution**: the solution to this problem, is conver `_needFireEvents` from a `boolean` into a `number`, which acts as counter of the number of times it is considered needed to "fire the events". This simple change avoids the code related to input processing to re-set it (it will only be able to mark it as dirty by increasing the counter, and it's the job of the `fireEvents()` method to actually reset the counter). So, there is only one reset-write path, which avoids the race condition.

**b) massive amount of picks performed due to `mousemove` events**

Again during the creation of distance measurments, and due to what looks like there is a storm of concurrent event callbacks executed at once (looks like the JS event handler will ingest new `mousemove` events even though the previous handler has not finished executing), and that results in a tremendous amount of picking invocations per-second.

This causes a very noticeable jitter effect when adding snapped distance-measurements even in the case of the very simple `Duplex.ifc` model.

The solution to this, is that now the `PickController` will do a maximum of one pick per-scene-tick.

The idea is that the (invoked by other classes) `update()` method is changed to set a flag indicating that it will do the real `update()` (now called `runUpdate()`) at most once per-scene-tick, effectively avoiding more than one pick per tick.

## The result

The result is that the race conditio is gone, and also that the viewer performance during the creation of distance measurements is smooth as silk.