### PR TITLE
PickController cache pick results

### DIFF
--- a/src/viewer/scene/CameraControl/lib/controllers/PickController.js
+++ b/src/viewer/scene/CameraControl/lib/controllers/PickController.js
@@ -71,27 +71,19 @@ class PickController {
 
         this._needFireEvents = 0;
 
-        this._needToUpdate = false;
+        this._lastHash = null;
 
-        this._tickSub = this._scene.on("tick", () => {
-            this.runUpdate();
+        this._tickSub = this._scene.on("rendered", () => {
+            this._lastHash = null;
         });
     }
 
     update() {
-        this._needToUpdate = true;
-    }
-
-    /**
-     * Immediately attempts a pick, if scheduled.
-     */
-    runUpdate() {
-
-        if (!this._needToUpdate) {
+        const hash = `${~~this.pickCursorPos[0]}-${~~this.pickCursorPos[1]}-${this.scheduleSnapOrPick}-${this.schedulePickSurface}-${this.schedulePickEntity}`;
+        if (this._lastHash === hash) {
             return;
         }
-
-        this._needToUpdate = false;
+        this._lastHash = hash;
 
         if (!this._configs.pointerEnabled) {
             return;


### PR DESCRIPTION
Just a PR for demonstration purposes. Shows how we could cache pick results on pickController.

This could be improved:

* Cache and return results against the hash 
* Blow away cached results, along with the hash, on each Scene "rendered"