### PR TITLE
OPTIMIZATION: tickify `mousemove` and `mousewheel` events

### DIFF
--- a/src/viewer/scene/CameraControl/lib/controllers/PickController.js
+++ b/src/viewer/scene/CameraControl/lib/controllers/PickController.js
@@ -70,29 +70,12 @@ class PickController {
         this._lastPickedEntityId = null;
 
         this._needFireEvents = 0;
-
-        this._needToUpdate = false;
-
-        this._tickSub = this._scene.on("tick", () => {
-            this.runUpdate();
-        });
-    }
-
-    update() {
-        this._needToUpdate = true;
     }
 
     /**
      * Immediately attempts a pick, if scheduled.
      */
-    runUpdate() {
-
-        if (!this._needToUpdate) {
-            return;
-        }
-
-        this._needToUpdate = false;
-
+    update() {
         if (!this._configs.pointerEnabled) {
             return;
         }
@@ -268,10 +251,6 @@ class PickController {
         this.pickResult = null;
 
         this._needFireEvents = 0;
-    }
-
-    destroy() {
-        this._scene.off(this._tickSub);
     }
 }
 

--- a/src/viewer/scene/input/Input.js
+++ b/src/viewer/scene/input/Input.js
@@ -1175,12 +1175,16 @@ class Input extends Component {
             }
         });
 
+        const tickifedMouseMoveFn = this.scene.tickify(
+            () => this.fire("mousemove", this.mouseCanvasPos, true)
+        );
+
         this.element.addEventListener("mousemove", this._mouseMoveListener = (e) => {
             if (!this.enabled) {
                 return;
             }
             this._getMouseCanvasPos(e);
-            this.fire("mousemove", this.mouseCanvasPos, true);
+            tickifedMouseMoveFn();  
             if (this.mouseover) {
                 e.preventDefault();
             }

--- a/src/viewer/scene/input/Input.js
+++ b/src/viewer/scene/input/Input.js
@@ -1190,12 +1190,16 @@ class Input extends Component {
             }
         });
 
+        const tickifiedMouseWheelFn = this.scene.tickify(
+            (delta) => { this.fire("mousewheel", delta, true); }
+        );
+
         this.element.addEventListener("wheel", this._mouseWheelListener = (e, d) => {
             if (!this.enabled) {
                 return;
             }
             const delta = Math.max(-1, Math.min(1, -e.deltaY * 40));
-            this.fire("mousewheel", delta, true);
+            tickifiedMouseWheelFn(delta);
         }, {passive: true});
 
         // mouseclicked


### PR DESCRIPTION
## Description

TLDS; this PR solves the bug introduced in #1261 plus it keeps providing a way to "debounce" `mousemove` and `mousewheel` events

## The problem with #1261 

The PR #1261 tried to fix two problems:

- i) ✅ a bug where some kind of "race condition" happened while taking distance measurements. This bug was solved in https://github.com/xeokit/xeokit-sdk/pull/1261/commits/a92b88a75f83705860a9996c8f79ef0056d6d0ac. **This fix is still valid**. ✅ 

- ii) ❌ a problem where a massive amount of `mousemove` events handled by the event handler in `MousePickHandler` was causing a huge lag for example when creating distance measurements (https://github.com/xeokit/xeokit-sdk/pull/1261/commits/0fc7266fc6aaa6ecc53a365af19c93dfa170e033). This is what introduced the bug discovered by @Amoki in https://github.com/xeokit/xeokit-sdk/issues/1263 ❌ 

## The reason for the bug introduced in #1261 

That PR assumed that the state of the `PickController` was consumed in an async way. What the PR did was to delay the execution of the `PickController.update()` method until next tick frame.

But, turns out certain functionalities like the input-zoom-handler was doing a sync consumption of the `PickController`. So, as the PR refactored the `PickController` in such a way that the pick result was available only after next-scene tick, clients of `PickController`that expected an immediate picking result stopped working. Those are the two bugs found by @Amoki, and could be more out there hidden caused by that PR! 😱 

## What performance problem did #1261 try to fix

To show what was that problem, here I include an instrumented version of `Renderer.js`.

It will console-log the number of GPU-picks per scene-tick:

[Renderer.js.patch (in diff format)](https://github.com/xeokit/xeokit-sdk/files/13466321/Renderer.js.patch)

This video shows the console output when this patched renderer runs while creating distance measurments. And the model is the really simple `Duplex` model!

https://github.com/xeokit/xeokit-sdk/assets/2405414/03dd7469-08f2-4d86-8aa3-fda3566b4046

As you can see, in some scene ticks (this is, in a single frame update) more than 200 GPU-pickings were triggered!

The result of this was really laggy measurement creation. And, #1261 tried to fix it in the wrong way.

## How this PR approaches the same problem

The problem with the previous PR, is that it assumed that the consumers of `PickController` were consuming it in an async way. But, this assumption is not true either for async or sync consumption. It should be respected just any possible way it's consumed to avoid specific code refactors.

Instead, this PR starting point is the following: **what we need to run maximum once per-tick, is now any internal piece of code but the handlers themselves**!

This is, the problem in the first place is that during a single scene tick a big number of mouse-move events are consumed by the same handler.

So...

## Introducing `tickify`-cation

This PR introduces a new `Scene.tickify(function)` method!

The core idea, is that any function can be passed to this method will be wrapped so it's run a maximum of ONE time per scene tick.

```js
// Tickify the function
const tickified = scene.tickify(
    /* some function */
);

// Now, when we invoke tickified...
tickified();

// ... we are sure that the code in the original function
// will be invoked maximum once per scene tick!

// e.g. no matter the loop, this will be invoked just once in next scene tick
for (let i = 0; i < 1000; i++) {
    tickified();
}
```

## Intented usage

Today, some event handlers do the following:

```js
canvas.addEventListener("mousemove", /* some function */);
```

Using `tickify(...)`, this would be converted into:

```js
const tickified = scene.tickify(/* some function */);

canvas.addEventListener("mousemove", tickified);
```

## How this differs from PR #1261 

This approach does not change in any way how the `PickController`, or any other method interally used by event handlers, work. So, does not touch on any async/sync assumption. This also removes the bug surface of #1261.

Instead, it just adds a trigger-condition to the handlers. And the trigger-condition just makes sure they're invoked once per time at maximum. And, it allows the event handlers to use same internal code and in same way.

Or course, it introduces a delay of one scene tick for when the handlers will be executed. But that should not matter as mouse event triggering is asynchronous in nature until it reaches the Js code!

## The result

Running same patched `Renderer.js` on this PR's branch, the result is now a much lower number of picks per scene-tick:

Notice how now the number of picks-per-tick is constant and way lower than in the original scenario 🚀 

https://github.com/xeokit/xeokit-sdk/assets/2405414/5491968c-5c09-4c68-905a-161dee13c403

## What is missing in this PR

The `tickify`method in `Scene` class keeps track of the tickified functions, so it's possible to `untickify` the functions later. And this should be done also when unsubscribing the DOM event listeners.

This clean-up part is not implemented yet by the consumers of `Scene.tickify()` that have been refactored in this PR.