### PR TITLE
Expose configs to experiment with SceneModel buffer sizes

### DIFF
--- a/examples/buildings/index.html
+++ b/examples/buildings/index.html
@@ -347,7 +347,14 @@
         ],
 
         "Misc": [
-            ["jitter_singlePrecision_MAP", "Demonstrates rounding jitter"]
+            "# Simulate single-precision rendering jitter",
+
+            ["jitter_singlePrecision_MAP", "Demonstrates rounding jitter"],
+
+            "# Configuring custom buffer sizes to experiment with loading stability",
+
+            ["xkt_dtx_maxDataTextureHeight", "Configuring max data texture size"],
+            ["xkt_vbo_maxGeometryBatchSize", "Configuring max VBO geometry batch size"]
         ]
 
     };

--- a/examples/buildings/xkt_dtx_maxDataTextureHeight.html
+++ b/examples/buildings/xkt_dtx_maxDataTextureHeight.html
@@ -1,0 +1,137 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>xeokit Example</title>
+    <link href="../css/pageStyle.css" rel="stylesheet"/>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
+    <style>
+
+        /* ----------------------------------------------------------------------------------------------------------*/
+        /* NavCubePlugin */
+        /* ----------------------------------------------------------------------------------------------------------*/
+
+        #myNavCubeCanvas {
+            position: absolute;
+            width: 250px;
+            height: 250px;
+            bottom: 50px;
+            right: 10px;
+            z-index: 200000;
+        }
+
+    </style>
+</head>
+<body>
+<input type="checkbox" id="info-button"/>
+<label for="info-button" class="info-button"><i class="far fa-3x fa-question-circle"></i></label>
+<canvas id="myCanvas"></canvas>
+<canvas id="myNavCubeCanvas"></canvas>
+<div class="slideout-sidebar">
+    <img class="info-icon" src="../../assets/images/bim_icon.png"/>
+    <h1>XKTLoaderPlugin and Data Textures</h1>
+    <h2>Loading a BIM model from an XKT file into a data texture model representation</h2>
+    <h3>Stats</h3>
+    <ul>
+        <li>
+            <div id="time">Loading JavaScript modules...</div>
+        </li>
+    </ul>
+    <h3>Components Used</h3>
+    <ul>
+        <li>
+            <a href="../../docs/class/src/viewer/Viewer.js~Viewer.html"
+               target="_other">Viewer</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js~XKTLoaderPlugin.html"
+               target="_other">XKTLoaderPlugin</a>
+        </li>
+    </ul>
+    <h3>Tutorials</h3>
+    <ul>
+        <li>
+            <a href="https://www.notion.so/xeokit/Compact-Model-Representation-using-Data-Textures-e8093ae372fa47bf9995c26dc24ccd53?pvs=4"
+               target="_other">Compact Model Representation using Data Textures</a>
+        </li>
+    </ul>
+    <h3>Assets</h3>
+    <ul>
+        <li>
+            <a href="http://openifcmodel.cs.auckland.ac.nz/Model/Details/322"
+               target="_other">Model source</a>
+        </li>
+
+    </ul>
+</div>
+</body>
+
+<script type="module">
+
+    import {Viewer, FastNavPlugin, NavCubePlugin, XKTLoaderPlugin, Configs} from "../../dist/xeokit-sdk.min.es.js";
+
+    //--------------------------------------------------------------------------------
+    // Set the maximum size of a texture for SceneModel's data texture scene
+    // representation, which we'll load our XKT file into. Larger values mean less
+    // draw calls, ie. more responsive rendering.
+    //
+    // Only applies when dtxEnabled: true is configured on the Viewer.
+    //--------------------------------------------------------------------------------
+
+    const configs = new Configs();
+
+    configs.maxDataTextureHeight = 1024; // Multiple of 1024, max value is 4096
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas",
+        transparent: true,
+        dtxEnabled: true, // Enable data textures
+        saoEnabled: true
+    });
+
+    viewer.camera.eye = [-23.68, 96.85, 30.65];
+    viewer.camera.look = [60.59, 42.37, -25.39];
+    viewer.camera.up = [0.39, 0.88, -0.26];
+
+    new NavCubePlugin(viewer, {
+        canvasId: "myNavCubeCanvas",
+        visible: true,
+        size: 250,
+        alignment: "bottomRight",
+        bottomMargin: 100,
+        rightMargin: 10
+    });
+
+    new FastNavPlugin(viewer, {
+        hideEdges: true,
+        hideSAO: true,
+        hideColorTexture: true,
+        hidePBR: true,
+        hideTransparentObjects: false,
+        scaleCanvasResolution: false,
+        scaleCanvasResolutionFactor: 0.5,
+        delayBeforeRestore: true,
+        delayBeforeRestoreSeconds: 0.4
+    });
+
+    const xktLoader = new XKTLoaderPlugin(viewer);
+
+    const sceneModel = xktLoader.load({
+        id: "myModel",
+        src: "../../assets/models/xkt/v6/APHS/APHS.xkt",
+        //metaModelSrc: "../../assets/models/xkt/v6/APHS/APHS.json", // Creates a MetaObject instances in scene.metaScene.metaObjects
+        edges: true,
+        saoEnabled: false
+    });
+
+    const t0 = performance.now();
+    document.getElementById("time").innerHTML = "Loading model...";
+    sceneModel.on("loaded", function () {
+        const t1 = performance.now();
+        document.getElementById("time").innerHTML = "Model loaded in " + Math.floor(t1 - t0) / 1000.0 + " seconds<br>Objects: " + sceneModel.numEntities;
+    });
+
+</script>
+</html>

--- a/examples/buildings/xkt_vbo_maxGeometryBatchSize.html
+++ b/examples/buildings/xkt_vbo_maxGeometryBatchSize.html
@@ -1,0 +1,135 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>xeokit Example</title>
+    <link href="../css/pageStyle.css" rel="stylesheet"/>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
+    <style>
+
+        /* ----------------------------------------------------------------------------------------------------------*/
+        /* NavCubePlugin */
+        /* ----------------------------------------------------------------------------------------------------------*/
+
+        #myNavCubeCanvas {
+            position: absolute;
+            width: 250px;
+            height: 250px;
+            bottom: 50px;
+            right: 10px;
+            z-index: 200000;
+        }
+
+    </style>
+</head>
+<body>
+<input type="checkbox" id="info-button"/>
+<label for="info-button" class="info-button"><i class="far fa-3x fa-question-circle"></i></label>
+<canvas id="myCanvas"></canvas>
+<canvas id="myNavCubeCanvas"></canvas>
+<div class="slideout-sidebar">
+    <img class="info-icon" src="../../assets/images/bim_icon.png"/>
+    <h1>XKTLoaderPlugin and Data Textures</h1>
+    <h2>Loading a BIM model from an XKT file into a VBO model representation</h2>
+    <h3>Stats</h3>
+    <ul>
+        <li>
+            <div id="time">Loading JavaScript modules...</div>
+        </li>
+    </ul>
+    <h3>Components Used</h3>
+    <ul>
+        <li>
+            <a href="../../docs/class/src/viewer/Viewer.js~Viewer.html"
+               target="_other">Viewer</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js~XKTLoaderPlugin.html"
+               target="_other">XKTLoaderPlugin</a>
+        </li>
+    </ul>
+    <h3>Tutorials</h3>
+    <ul>
+        <li>
+            <a href="https://www.notion.so/xeokit/Compact-Model-Representation-using-Data-Textures-e8093ae372fa47bf9995c26dc24ccd53?pvs=4"
+               target="_other">Compact Model Representation using Data Textures</a>
+        </li>
+    </ul>
+    <h3>Assets</h3>
+    <ul>
+        <li>
+            <a href="http://openifcmodel.cs.auckland.ac.nz/Model/Details/322"
+               target="_other">Model source</a>
+        </li>
+
+    </ul>
+</div>
+</body>
+
+<script type="module">
+
+    import {Viewer, FastNavPlugin, NavCubePlugin, XKTLoaderPlugin, Configs} from "../../dist/xeokit-sdk.min.es.js";
+
+    //--------------------------------------------------------------------------------
+    // Sets the maximum batched geometry VBO size. Default value is 5000000, which is
+    // the maximum size. Minimum size is 100000. Larger values mean less draw calls,
+    // ie. more responsive rendering.
+    //
+    // Only applies when the Viewer is NOT configured with dtxEnabled: true.
+    //--------------------------------------------------------------------------------
+
+    const configs = new Configs();
+
+    configs.maxGeometryBatchSize = 1000000;
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas",
+        transparent: true,
+        saoEnabled: true
+    });
+
+    viewer.camera.eye = [-23.68, 96.85, 30.65];
+    viewer.camera.look = [60.59, 42.37, -25.39];
+    viewer.camera.up = [0.39, 0.88, -0.26];
+
+    new NavCubePlugin(viewer, {
+        canvasId: "myNavCubeCanvas",
+        visible: true,
+        size: 250,
+        alignment: "bottomRight",
+        bottomMargin: 100,
+        rightMargin: 10
+    });
+
+    new FastNavPlugin(viewer, {
+        hideEdges: true,
+        hideSAO: true,
+        hideColorTexture: true,
+        hidePBR: true,
+        hideTransparentObjects: false,
+        scaleCanvasResolution: false,
+        scaleCanvasResolutionFactor: 0.5,
+        delayBeforeRestore: true,
+        delayBeforeRestoreSeconds: 0.4
+    });
+
+    const xktLoader = new XKTLoaderPlugin(viewer);
+
+    const sceneModel = xktLoader.load({
+        id: "myModel",
+        src: "../../assets/models/xkt/v6/APHS/APHS.xkt",
+       edges: true,
+        saoEnabled: false
+    });
+
+    const t0 = performance.now();
+    document.getElementById("time").innerHTML = "Loading model...";
+    sceneModel.on("loaded", function () {
+        const t1 = performance.now();
+        document.getElementById("time").innerHTML = "Model loaded in " + Math.floor(t1 - t0) / 1000.0 + " seconds<br>Objects: " + sceneModel.numEntities;
+    });
+
+</script>
+</html>

--- a/src/viewer/Configs.js
+++ b/src/viewer/Configs.js
@@ -1,5 +1,8 @@
 import {math} from "./scene/math/math.js";
 
+let maxDataTextureHeight = 1 << 16;
+let maxGeometryBatchSize = 4096
+
 /**
  * Manages global configurations for all {@link Viewer}s.
  *
@@ -73,6 +76,52 @@ class Configs {
      */
     get doublePrecisionEnabled() {
         return math.getDoublePrecisionEnabled();
+    }
+
+    /**
+     * Sets the maximum data texture height.
+     *
+     * Should be a multiple of 1024. Default is 4096, which is the maximum allowed value.
+     */
+    set maxDataTextureHeight(value) {
+        value = Math.ceil(value / 1024) * 1024;
+        if (value > 4096) {
+            value = 4096;
+        } else if (value < 1024) {
+            value = 1024;
+        }
+        maxDataTextureHeight = value;
+    }
+
+    /**
+     * Sets maximum data texture height.
+     * @returns {*|number}
+     */
+    get maxDataTextureHeight() {
+        return maxDataTextureHeight;
+    }
+
+    /**
+     * Sets the maximum batched geometry VBO size.
+     *
+     * Default value is 5000000, which is the maximum size.
+     *
+     * Minimum size is 100000.
+     */
+    set maxGeometryBatchSize(value) {
+        if (value < 100000) {
+            value = 100000;
+        } else if (value > 5000000) {
+            value = 5000000;
+        }
+        maxGeometryBatchSize = value;
+    }
+
+    /**
+     * Gets the maximum batched geometry VBO size.
+     */
+    get maxGeometryBatchSize() {
+        return maxGeometryBatchSize;
     }
 }
 

--- a/src/viewer/scene/model/dtx/triangles/TrianglesDataTextureLayer.js
+++ b/src/viewer/scene/model/dtx/triangles/TrianglesDataTextureLayer.js
@@ -7,6 +7,9 @@ import {TrianglesDataTextureBuffer} from "./TrianglesDataTextureBuffer.js";
 import {DataTextureState} from "./DataTextureState.js"
 import {DataTextureGenerator} from "./DataTextureGenerator.js";
 import {dataTextureRamStats} from "./dataTextureRamStats.js";
+import {Configs} from "../../../../Configs";
+
+const configs = new Configs();
 
 /**
  * 12-bits allowed for object ids.
@@ -18,7 +21,7 @@ const MAX_NUMBER_OF_OBJECTS_IN_LAYER = (1 << 16);
  * 4096 is max data texture height.
  * Limits the aggregated geometry texture height in the layer.
  */
-const MAX_DATA_TEXTURE_HEIGHT = (1 << 12);
+const MAX_DATA_TEXTURE_HEIGHT = configs.maxDataTextureHeight;
 
 /**
  * Align `indices` and `edgeIndices` memory layout to 8 elements.

--- a/src/viewer/scene/model/vbo/trianglesBatching/TrianglesBatchingBuffer.js
+++ b/src/viewer/scene/model/vbo/trianglesBatching/TrianglesBatchingBuffer.js
@@ -1,16 +1,15 @@
+import {Configs} from "../../../../Configs";
+
+const configs = new Configs();
+
 /**
  * @private
  */
 class TrianglesBatchingBuffer {
 
-    constructor(maxGeometryBatchSize = 5000000) {
-
-        if (maxGeometryBatchSize > 5000000) {
-            maxGeometryBatchSize = 5000000;
-        }
-
-        this.maxVerts = maxGeometryBatchSize;
-        this.maxIndices = maxGeometryBatchSize * 3; // Rough rule-of-thumb
+    constructor() {
+        this.maxVerts = configs.maxGeometryBatchSize;
+        this.maxIndices = configs.maxGeometryBatchSize * 3; // Rough rule-of-thumb
         this.positions = [];
         this.colors = [];
         this.uv = [];


### PR DESCRIPTION
Sometimes the browser crashes when loading a large model. This is possibly due to memory stress causing the browser to run out of memory.

This PR adds configurations to experiment with custom buffer sizes that are used internally by the `Viewer` when storing model representations. We expose these configs so we can experiment to find the optimal values for the most stable loading experience in terms of browser memory stability. 

## Vertex Buffer Objects (VBO)

The `Configs` component manages some global configurations for xeokit's `Viewer`. The `Configs.maxGeometryBatchSize` sets the maximum allowed size of WebGL vertex buffer objects (VBOs) used by the `SceneModel`'s default scene representation mode.

The default value is `5000000`, which is the maximum size. The minimum vale is `100000`. 

Large values of this number result in larger VBOs, resulting in fewer draw calls when the `Viewer` renders each frame, which results in more responsive interaction. 

A small value may be desirable, however, if the `Viewer` seems unstable while loading a model, since that *may* result in less browser memory stress while loading.

* Run this example: https://xeokit.github.io/xeokit-sdk/examples/buildings/#xkt_dtx_maxDataTextureHeight

````javascript
import {Viewer, XKTLoaderPlugin, Configs} from "../../dist/xeokit-sdk.min.es.js";

const configs = new Configs();

configs.maxGeometryBatchSize = 1000000;

const viewer = new Viewer({
    canvasId: "myCanvas",
    transparent: true
});

viewer.camera.eye = [-23.68, 96.85, 30.65];
viewer.camera.look = [60.59, 42.37, -25.39];
viewer.camera.up = [0.39, 0.88, -0.26];

const xktLoader = new XKTLoaderPlugin(viewer);

const sceneModel = xktLoader.load({
    id: "myModel",
    src: "../../assets/models/xkt/v6/APHS/APHS.xkt"
});
````

## Data Textures (DTX)

Data textures (DTX) are xeokit's innovative option for representing models in memory. These use textures to store geometry and materials in GPU memory, and are designed to use less GPU memory than the conventional VBO technique, which was used in the previous example.

To enable data textures for a `Viewer` we must configure the `Viewer` with `dtxEnabled: true`.

Using `Configs.maxDataTextureHeight` we can configure the maximum size that DTX will allocate for each data texture. 

The default value is `4096`, which is the maximum size. The minimum vale is `1024`. Values should be a multiple of `1024`. 

As before, large values of this number result in larger data textures, resulting in fewer draw calls when the `Viewer` renders each frame, which results in more responsive interaction. 

As before. a smaller value may be desirable, however, if the `Viewer` seems unstable while loading a model, since that *may* result in less browser memory stress while loading.

* Run this example: https://xeokit.github.io/xeokit-sdk/examples/buildings/#xkt_vbo_maxGeometryBatchSize

````javascript
  import {Viewer, XKTLoaderPlugin, Configs} from "../../dist/xeokit-sdk.min.es.js";

const configs = new Configs();

configs.maxDataTextureHeight = 1024; // Multiple of 1024, max value is 4096

const viewer = new Viewer({
    canvasId: "myCanvas",
    transparent: true,
    dtxEnabled: true // Enable data textures
});

viewer.camera.eye = [-23.68, 96.85, 30.65];
viewer.camera.look = [60.59, 42.37, -25.39];
viewer.camera.up = [0.39, 0.88, -0.26];

const xktLoader = new XKTLoaderPlugin(viewer);

const sceneModel = xktLoader.load({
    id: "myModel",
    src: "../../assets/models/xkt/v6/APHS/APHS.xkt"
});
````