### PR TITLE
Make measurements click-though

### DIFF
--- a/examples/measurement/angle_createWithMouse_nosnapping.html
+++ b/examples/measurement/angle_createWithMouse_nosnapping.html
@@ -7,6 +7,77 @@
     <title>xeokit Example</title>
     <link href="../css/pageStyle.css" rel="stylesheet"/>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
+
+    <style>
+
+        .viewer-ruler-wire-highlighted {
+            border: 2px solid white !important;
+        }
+
+        .viewer-ruler-label-highlighted {
+            border: 2px solid white !important;
+        }
+
+        .viewer-ruler-dot-highlighted {
+            border: 2px solid white !important;
+        }
+
+        .xeokit-context-menu {
+            font-family: 'Roboto', sans-serif;
+            font-size: 15px;
+            display: none;
+            z-index: 300000;
+            background: rgba(255, 255, 255, 0.46);
+            border: 1px solid black;
+            border-radius: 6px;
+            padding: 0;
+            width: 200px;
+        }
+
+        .xeokit-context-menu ul {
+            list-style: none;
+            margin-left: 0;
+            padding: 0;
+        }
+
+        .xeokit-context-menu ul li {
+            list-style-type: none;
+            padding-left: 10px;
+            padding-right: 20px;
+            padding-top: 4px;
+            padding-bottom: 4px;
+            color: black;
+            border-bottom: 1px solid gray;
+            background: rgba(255, 255, 255, 0.46);
+            cursor: pointer;
+            width: calc(100% - 30px);
+        }
+
+        .xeokit-context-menu ul li:hover {
+            background: black;
+            color: white;
+            font-weight: normal;
+        }
+
+        .xeokit-context-menu ul li span {
+            display: inline-block;
+        }
+
+        .xeokit-context-menu .disabled {
+            display: inline-block;
+            color: gray;
+            cursor: default;
+            font-weight: normal;
+        }
+
+        .xeokit-context-menu .disabled:hover {
+            color: gray;
+            cursor: default;
+            background: #eeeeee;
+            font-weight: normal;
+        }
+
+    </style>
 </head>
 <body>
 <input type="checkbox" id="info-button"/>
@@ -15,7 +86,7 @@
 <div class="slideout-sidebar">
     <img class="info-icon" src="../../assets/images/measure_angle_icon.png"/>
     <h1>AngleMeasurementPlugin with AngleMeasurementsMouseControl and PointerLens</h1>
-    <h2>Click on the model to create angle measurements, with vertex and edge snapping</h2>
+    <h2>Click on the model to create angle measurements, with vertex and no snapping</h2>
     <p>In this example, we're loading a BIM model from the file system, then creating angle measurements wherever the
         user clicks on the model with the mouse.</p>
     <h3>Components Used</h3>
@@ -49,7 +120,7 @@
 </body>
 <script type="module">
 
-    import {Viewer, XKTLoaderPlugin, AngleMeasurementsPlugin, AngleMeasurementsMouseControl, PointerLens} from "../../dist/xeokit-sdk.es.js";
+    import {Viewer, XKTLoaderPlugin, AngleMeasurementsPlugin, ContextMenu, AngleMeasurementsMouseControl, PointerLens} from "../../dist/xeokit-sdk.es.js";
 
     const viewer = new Viewer({
         canvasId: "myCanvas",
@@ -68,15 +139,621 @@
         edges: true
     });
 
-    const angleMeasurements = new AngleMeasurementsPlugin(viewer);
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a context menu to delete and configure measurements
+    //------------------------------------------------------------------------------------------------------------------
 
-    const angleMeasurementsMouseControl  = new AngleMeasurementsMouseControl(angleMeasurements, {
+    const angleMeasurementsContextMenu = new ContextMenu({
+        items: [
+
+            [
+                {
+                    getTitle: (context) => {
+                        return context.measurement.labelsVisible ? "Hide Labels" : "Show Labels";
+                    },
+                    doAction: function (context) {
+                        context.measurement.labelsVisible = !context.measurement.labelsVisible;
+                    }
+                }
+            ], [
+                {
+                    title: "Delete Measurement",
+                    doAction: function (context) {
+                        context.measurement.destroy();
+                    }
+                }
+            ]
+
+        ]
+    });
+
+    angleMeasurementsContextMenu.on("hidden", () => {
+        if (angleMeasurementsContextMenu.context.measurement) {
+            angleMeasurementsContextMenu.context.measurement.setHighlighted(false);
+        }
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a AngleMeasurementsPlugin, with which we'll create AngleMeasurements
+    //------------------------------------------------------------------------------------------------------------------
+
+    const angleMeasurementsPlugin = new AngleMeasurementsPlugin(viewer, {
+        zIndex: 100000 // If set, the wires, dots and labels will have this zIndex (+1 for dots and +2 for labels).
+    });
+
+    const angleMeasurementsMouseControl  = new AngleMeasurementsMouseControl(angleMeasurementsPlugin, {
         pointerLens : new PointerLens(viewer)
     })
 
     angleMeasurementsMouseControl.snapping = false;
 
     angleMeasurementsMouseControl.activate();
+
+    angleMeasurementsPlugin.on("mouseOver", (e) => {
+        e.measurement.setHighlighted(true);
+    });
+
+    angleMeasurementsPlugin.on("mouseLeave", (e) => {
+        if (angleMeasurementsContextMenu.shown && angleMeasurementsContextMenu.context.measurement.id === e.measurement.id) {
+            return;
+        }
+        e.measurement.setHighlighted(false);
+    });
+
+    angleMeasurementsPlugin.on("contextMenu", (e) => {
+        angleMeasurementsContextMenu.context = { // Must set context before showing menu
+            viewer: viewer,
+            angleMeasurementsPlugin: angleMeasurementsPlugin,
+            measurement: e.measurement
+        };
+        angleMeasurementsContextMenu.show(e.event.clientX, e.event.clientY);
+        e.event.preventDefault();
+    });
+
+    sceneModel.on("loaded", () => {
+
+        //------------------------------------------------------------------------------------------------------------------
+        // Create some AngleMeasurements
+        //------------------------------------------------------------------------------------------------------------------
+
+        angleMeasurementsPlugin.createMeasurement({
+            id: "angleMeasurement1",
+            origin: {
+                entity: viewer.scene.objects["1CZILmCaHETO8tf3SgGEXu"],
+                worldPos: [0.4158603637281142, 2.5193106917110457, 17.79972838299403]
+            },
+            corner: {
+                entity: viewer.scene.objects["1CZILmCaHETO8tf3SgGEXu"],
+                worldPos: [0.41857741956197625,0.0987169929481646,17.799763071093395]
+            },
+            target: {
+                entity: viewer.scene.objects["1CZILmCaHETO8tf3SgGEXu"],
+                worldPos: [5.235526066859247, 0.11580773869801986, 17.824891550941565]
+            },
+            visible: true
+        });
+
+        angleMeasurementsPlugin.createMeasurement({
+            id: "angleMeasurement2",
+            origin: {
+                entity: viewer.scene.objects["2O2Fr$t4X7Zf8NOew3FNr2"],
+                worldPos: [-0.00003814187850181838, 5.9996748076205115,17.79996871551525]
+            },
+            corner: {
+                entity: viewer.scene.objects["2O2Fr$t4X7Zf8NOew3FNqI"],
+                worldPos: [-0.0005214119318139865, 3.1010044228517595, 17.787656604483363]
+
+            },
+            target: {
+                entity: viewer.scene.objects["1s1jVhK8z0pgKYcr9jt7AB"],
+                worldPos: [ 8.380657312957396, 3.1055697628459553, 17.799220108187185]
+            },
+            visible: true
+        });
+    });
+
+    const objectContextMenu = new ContextMenu({
+        items: [
+            [
+                {
+                    getTitle: function (context) {
+                        return (!context.entity.xrayed) ? "X-Ray" : "Undo X-Ray";
+                    },
+                    doAction: function (context) {
+                        context.entity.xrayed = !context.entity.xrayed;
+                    }
+                },
+                {
+                    title: "X-Ray Others",
+                    doAction: function (context) {
+                        const viewer = context.viewer;
+                        const scene = viewer.scene;
+                        const entity = context.entity;
+                        const metaObject = viewer.metaScene.metaObjects[entity.id];
+                        if (!metaObject) {
+                            return;
+                        }
+                        scene.setObjectsVisible(scene.objectIds, true);
+                        scene.setObjectsXRayed(scene.objectIds, true);
+                        scene.setObjectsSelected(scene.selectedObjectIds, false);
+                        scene.setObjectsHighlighted(scene.highlightedObjectIds, false);
+                        metaObject.withMetaObjectsInSubtree((metaObject) => {
+                            const entity = scene.objects[metaObject.id];
+                            if (entity) {
+                                entity.xrayed = false;
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "X-Ray All",
+                    getEnabled: function (context) {
+                        const scene = context.viewer.scene;
+                        return (scene.numXRayedObjects < scene.numObjects);
+                    },
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        scene.setObjectsXRayed(scene.objectIds, true);
+                    }
+                },
+                {
+                    title: "X-Ray None",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.numXRayedObjects > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsXRayed(context.viewer.scene.xrayedObjectIds, false);
+                    }
+                }
+            ],
+            [
+                {
+                    title: "Hide",
+                    getEnabled: function (context) {
+                        return context.entity.visible;
+                    },
+                    doAction: function (context) {
+                        context.entity.visible = false;
+                    }
+                },
+                {
+                    title: "Hide Others",
+                    doAction: function (context) {
+                        const viewer = context.viewer;
+                        const scene = viewer.scene;
+                        const entity = context.entity;
+                        const metaObject = viewer.metaScene.metaObjects[entity.id];
+                        if (!metaObject) {
+                            return;
+                        }
+                        scene.setObjectsVisible(scene.visibleObjectIds, false);
+                        scene.setObjectsXRayed(scene.xrayedObjectIds, false);
+                        scene.setObjectsSelected(scene.selectedObjectIds, false);
+                        scene.setObjectsHighlighted(scene.highlightedObjectIds, false);
+                        metaObject.withMetaObjectsInSubtree((metaObject) => {
+                            const entity = scene.objects[metaObject.id];
+                            if (entity) {
+                                entity.visible = true;
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "Hide All",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.numVisibleObjects > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsVisible(context.viewer.scene.visibleObjectIds, false);
+                    }
+                },
+                {
+                    title: "Show All",
+                    getEnabled: function (context) {
+                        const scene = context.viewer.scene;
+                        return (scene.numVisibleObjects < scene.numObjects);
+                    },
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        scene.setObjectsVisible(scene.objectIds, true);
+                    }
+                }
+            ],
+            [
+                {
+                    getTitle: function (context) {
+                        return (!context.entity.selected) ? "Select" : "Undo Select";
+                    },
+                    doAction: function (context) {
+                        context.entity.selected = !context.entity.selected;
+                    }
+                },
+                {
+                    title: "Select All",
+                    getEnabled: function (context) {
+                        const scene = context.viewer.scene;
+                        return (scene.numSelectedObjects < scene.numObjects);
+                    },
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        scene.setObjectsSelected(scene.objectIds, true);
+                    }
+                },
+                {
+                    title: "Select None",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.numSelectedObjects > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsSelected(context.viewer.scene.selectedObjectIds, false);
+                    }
+                }
+            ],
+
+            [
+                {
+                    title: "Camera..",
+                    items: [
+                        [
+                            {
+                                title: "View Fit",
+                                doAction: function (context) {
+                                    const viewer = context.viewer;
+                                    const scene = viewer.scene;
+                                    const entity = context.entity;
+                                    viewer.cameraFlight.flyTo({
+                                        aabb: entity.aabb,
+                                        duration: 0.5
+                                    }, () => {
+                                        setTimeout(function () {
+                                            scene.setObjectsHighlighted(scene.highlightedObjectIds, false);
+                                        }, 500);
+                                    });
+                                }
+                            },
+                            {
+                                title: "View Fit All",
+                                doAction: function (context) {
+                                    const scene = context.viewer.scene;
+                                    context.viewer.cameraFlight.flyTo({
+                                        projection: "perspective",
+                                        aabb: scene.getAABB(),
+                                        duration: 0.5
+                                    });
+                                }
+                            }
+                        ],
+                        [
+                            {
+                                title: "Perspective",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.camera.projection !== "perspective");
+                                },
+                                doAction: function (context) {
+                                    context.viewer.cameraFlight.flyTo({
+                                        projection: "perspective"
+                                    });
+                                }
+                            },
+                            {
+                                title: "Orthographic",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.camera.projection !== "ortho");
+                                },
+                                doAction: function (context) {
+                                    context.viewer.cameraFlight.flyTo({
+                                        projection: "ortho"
+                                    });
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ],
+
+            [
+                {
+                    title: "Effects..",
+                    items: [
+                        [
+                            {
+                                getTitle: (context) => {
+                                    return context.viewer.scene.edgeMaterial.edges ? "Disable Edges" : "Enable Edges";
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.edgeMaterial.edges = !context.viewer.scene.edgeMaterial.edges;
+                                }
+                            },
+                            {
+                                getTitle: (context) => {
+                                    return context.viewer.scene.sao.enabled ? "Disable SAO" : "Enable SAO";
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.sao.enabled = !context.viewer.scene.sao.enabled;
+                                }
+                            },
+                            {
+                                getTitle: (context) => {
+                                    return context.viewer.scene.pbrEnabled ? "Disable PBR" : "Enable PBR";
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.pbrEnabled = !context.viewer.scene.pbrEnabled;
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ],
+
+            [
+                {
+                    title: "Measurements..",
+                    getEnabled: function (context) {
+                        return (Object.keys(angleMeasurementsPlugin.measurements).length > 0);
+                    },
+                    items: [
+                        [
+                            {
+                                getTitle: function (context) {
+                                    return (Object.keys(angleMeasurementsPlugin.measurements).length > 0) ? "Show All Labels" : "Hide All Labels";
+                                },
+                                getEnabled: function (context) {
+                                    return (Object.keys(angleMeasurementsPlugin.measurements).length > 0);
+                                },
+                                doAction: function (context) {
+                                    //angleMeasurementsPlugin.clear();
+                                }
+                            },
+                            {
+                                getTitle: function (context) {
+                                    return (Object.keys(angleMeasurementsPlugin.measurements).length > 0) ? "Show All Axis" : "Hide All Axis";
+                                },
+                                getEnabled: function (context) {
+                                    return (Object.keys(angleMeasurementsPlugin.measurements).length > 0);
+                                },
+                                doAction: function (context) {
+                                    //angleMeasurementsPlugin.clear();
+                                }
+                            },
+                            {
+                                title: "Delete All",
+                                getEnabled: function (context) {
+                                    return (Object.keys(angleMeasurementsPlugin.measurements).length > 0);
+                                },
+                                doAction: function (context) {
+                                    angleMeasurementsPlugin.clear();
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ]
+        ],
+        enabled: true
+    });
+
+    const canvasContextMenu = new ContextMenu({
+        enabled: true,
+        context: {
+            viewer: viewer
+        },
+        items: [
+            [
+                {
+                    title: "Objects..",
+                    items: [
+                        [
+                            {
+                                title: "X-Ray All",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.numXRayedObjects < scene.numObjects);
+                                },
+                                doAction: function (context) {
+                                    const scene = context.viewer.scene;
+                                    scene.setObjectsXRayed(scene.objectIds, true);
+                                }
+                            },
+                            {
+                                title: "X-Ray None",
+                                getEnabled: function (context) {
+                                    return (context.viewer.scene.numXRayedObjects > 0);
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.setObjectsXRayed(context.viewer.scene.xrayedObjectIds, false);
+                                }
+                            }
+                        ],
+                        [
+                            {
+                                title: "Hide All",
+                                getEnabled: function (context) {
+                                    return (context.viewer.scene.numVisibleObjects > 0);
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.setObjectsVisible(context.viewer.scene.visibleObjectIds, false);
+                                }
+                            },
+                            {
+                                title: "Show All",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.numVisibleObjects < scene.numObjects);
+                                },
+                                doAction: function (context) {
+                                    const scene = context.viewer.scene;
+                                    scene.setObjectsVisible(scene.objectIds, true);
+                                    scene.setObjectsXRayed(scene.xrayedObjectIds, false);
+                                    scene.setObjectsSelected(scene.selectedObjectIds, false);
+                                }
+                            }
+                        ],
+
+                        [
+                            {
+                                title: "Select All",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.numSelectedObjects < scene.numObjects);
+                                },
+                                doAction: function (context) {
+                                    const scene = context.viewer.scene;
+                                    scene.setObjectsSelected(scene.objectIds, true);
+                                }
+                            },
+                            {
+                                title: "Select None",
+                                getEnabled: function (context) {
+                                    return (context.viewer.scene.numSelectedObjects > 0);
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.setObjectsSelected(context.viewer.scene.selectedObjectIds, false);
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ],
+            [
+                {
+                    title: "Camera..",
+                    items: [
+                        [
+                            {
+                                title: "View Fit All",
+                                doAction: function (context) {
+                                    context.viewer.cameraFlight.flyTo({
+                                        aabb: context.viewer.scene.getAABB()
+                                    });
+                                }
+                            }
+                        ],
+                        [
+                            {
+                                title: "Perspective",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.camera.projection !== "perspective");
+                                },
+                                doAction: function (context) {
+                                    context.viewer.cameraFlight.flyTo({
+                                        projection: "perspective"
+                                    });
+                                }
+                            },
+                            {
+                                title: "Orthographic",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.camera.projection !== "ortho");
+                                },
+                                doAction: function (context) {
+                                    context.viewer.cameraFlight.flyTo({
+                                        projection: "ortho"
+                                    });
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ],
+
+            [
+                {
+                    title: "Effects..",
+                    items: [
+                        [
+                            {
+                                getTitle: (context) => {
+                                    return context.viewer.scene.edgeMaterial.edges ? "Disable Edges" : "Enable Edges";
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.edgeMaterial.edges = !context.viewer.scene.edgeMaterial.edges;
+                                }
+                            },
+                            {
+                                getTitle: (context) => {
+                                    return context.viewer.scene.sao.enabled ? "Disable SAO" : "Enable SAO";
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.sao.enabled = !context.viewer.scene.sao.enabled;
+                                }
+                            },
+                            {
+                                getTitle: (context) => {
+                                    return context.viewer.scene.pbrEnabled ? "Disable PBR" : "Enable PBR";
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.pbrEnabled = !context.viewer.scene.pbrEnabled;
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ],
+            [
+                {
+                    title: "Measurements..",
+                    getEnabled: function (context) {
+                        return (Object.keys(angleMeasurementsPlugin.measurements).length > 0);
+                    },
+                    items: [
+                        [
+                            {
+                                getTitle: function (context) {
+                                    return (Object.keys(angleMeasurementsPlugin.measurements).length > 0) ? "Show All Labels" : "Hide All Labels";
+                                },
+                                getEnabled: function (context) {
+                                    return (Object.keys(angleMeasurementsPlugin.measurements).length > 0);
+                                },
+                                doAction: function (context) {
+                                    //angleMeasurementsPlugin.clear();
+                                }
+                            },
+                            {
+                                title: "Delete All",
+                                getEnabled: function (context) {
+                                    return (Object.keys(angleMeasurementsPlugin.measurements).length > 0);
+                                },
+                                doAction: function (context) {
+                                    angleMeasurementsPlugin.clear();
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ]
+        ]
+    });
+
+    viewer.cameraControl.on("rightClick", (e) => {
+
+        const hit = viewer.scene.pick({
+            canvasPos: e.canvasPos
+        });
+
+        if (hit && hit.entity.isObject) {
+
+            objectContextMenu.context = { // Must set context before showing menu
+                viewer: viewer,
+                entity: hit.entity
+            };
+
+            objectContextMenu.show(e.pagePos[0], e.pagePos[1]);
+        } else {
+
+            canvasContextMenu.context = { // Must set context before showing menu
+                viewer: viewer
+            };
+
+            canvasContextMenu.show(e.pagePos[0], e.pagePos[1]);
+        }
+
+        e.event.preventDefault();
+    });
+
 
 </script>
 </html>

--- a/examples/measurement/angle_createWithMouse_snapping.html
+++ b/examples/measurement/angle_createWithMouse_snapping.html
@@ -7,6 +7,77 @@
     <title>xeokit Example</title>
     <link href="../css/pageStyle.css" rel="stylesheet"/>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
+
+    <style>
+
+        .viewer-ruler-wire-highlighted {
+            border: 2px solid white !important;
+        }
+
+        .viewer-ruler-label-highlighted {
+            border: 2px solid white !important;
+        }
+
+        .viewer-ruler-dot-highlighted {
+            border: 2px solid white !important;
+        }
+
+        .xeokit-context-menu {
+            font-family: 'Roboto', sans-serif;
+            font-size: 15px;
+            display: none;
+            z-index: 300000;
+            background: rgba(255, 255, 255, 0.46);
+            border: 1px solid black;
+            border-radius: 6px;
+            padding: 0;
+            width: 200px;
+        }
+
+        .xeokit-context-menu ul {
+            list-style: none;
+            margin-left: 0;
+            padding: 0;
+        }
+
+        .xeokit-context-menu ul li {
+            list-style-type: none;
+            padding-left: 10px;
+            padding-right: 20px;
+            padding-top: 4px;
+            padding-bottom: 4px;
+            color: black;
+            border-bottom: 1px solid gray;
+            background: rgba(255, 255, 255, 0.46);
+            cursor: pointer;
+            width: calc(100% - 30px);
+        }
+
+        .xeokit-context-menu ul li:hover {
+            background: black;
+            color: white;
+            font-weight: normal;
+        }
+
+        .xeokit-context-menu ul li span {
+            display: inline-block;
+        }
+
+        .xeokit-context-menu .disabled {
+            display: inline-block;
+            color: gray;
+            cursor: default;
+            font-weight: normal;
+        }
+
+        .xeokit-context-menu .disabled:hover {
+            color: gray;
+            cursor: default;
+            background: #eeeeee;
+            font-weight: normal;
+        }
+
+    </style>
 </head>
 <body>
 <input type="checkbox" id="info-button"/>
@@ -15,7 +86,7 @@
 <div class="slideout-sidebar">
     <img class="info-icon" src="../../assets/images/measure_angle_icon.png"/>
     <h1>AngleMeasurementPlugin with AngleMeasurementsMouseControl and PointerLens</h1>
-    <h2>Click on the model to create angle measurements, with vertex and edge snapping</h2>
+    <h2>Click on the model to create angle measurements, with vertex and snapping</h2>
     <p>In this example, we're loading a BIM model from the file system, then creating angle measurements wherever the
         user clicks on the model with the mouse.</p>
     <h3>Components Used</h3>
@@ -37,13 +108,7 @@
                target="_other">PointerLens</a>
         </li>
     </ul>
-    <h3>Tutorials</h3>
-    <ul>
-        <li>
-            <a href="https://www.notion.so/xeokit/Accurate-Measurements-with-Snapping-5e6606afef20428f9b319ea0e82270f9"
-               target="_other">Accurate Measurements with Snapping</a>
-        </li>
-    </ul>
+
     <h3>Assets</h3>
     <ul>
         <li>
@@ -55,13 +120,7 @@
 </body>
 <script type="module">
 
-    import {
-        Viewer,
-        XKTLoaderPlugin,
-        AngleMeasurementsPlugin,
-        AngleMeasurementsMouseControl,
-        PointerLens
-    } from "../../dist/xeokit-sdk.es.js";
+    import {Viewer, XKTLoaderPlugin, AngleMeasurementsPlugin, ContextMenu, AngleMeasurementsMouseControl, PointerLens} from "../../dist/xeokit-sdk.es.js";
 
     const viewer = new Viewer({
         canvasId: "myCanvas",
@@ -80,7 +139,55 @@
         edges: true
     });
 
-    const angleMeasurementsPlugin = new AngleMeasurementsPlugin(viewer);
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a context menu to delete and configure measurements
+    //------------------------------------------------------------------------------------------------------------------
+
+    const angleMeasurementsContextMenu = new ContextMenu({
+        items: [
+
+            [
+                {
+                    getTitle: (context) => {
+                        return context.measurement.labelsVisible ? "Hide Labels" : "Show Labels";
+                    },
+                    doAction: function (context) {
+                        context.measurement.labelsVisible = !context.measurement.labelsVisible;
+                    }
+                }
+            ], [
+                {
+                    title: "Delete Measurement",
+                    doAction: function (context) {
+                        context.measurement.destroy();
+                    }
+                }
+            ]
+
+        ]
+    });
+
+    angleMeasurementsContextMenu.on("hidden", () => {
+        if (angleMeasurementsContextMenu.context.measurement) {
+            angleMeasurementsContextMenu.context.measurement.setHighlighted(false);
+        }
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a AngleMeasurementsPlugin, with which we'll create AngleMeasurements
+    //------------------------------------------------------------------------------------------------------------------
+
+    const angleMeasurementsPlugin = new AngleMeasurementsPlugin(viewer, {
+        zIndex: 100000 // If set, the wires, dots and labels will have this zIndex (+1 for dots and +2 for labels).
+    });
+
+    const angleMeasurementsMouseControl  = new AngleMeasurementsMouseControl(angleMeasurementsPlugin, {
+        pointerLens : new PointerLens(viewer)
+    })
+
+    angleMeasurementsMouseControl.snapping = true;
+
+    angleMeasurementsMouseControl.activate();
 
     angleMeasurementsPlugin.on("mouseOver", (e) => {
         e.measurement.setHighlighted(true);
@@ -93,13 +200,560 @@
         e.measurement.setHighlighted(false);
     });
 
-    const angleMeasurementsMouseControl = new AngleMeasurementsMouseControl(angleMeasurementsPlugin, {
-        pointerLens: new PointerLens(viewer)
+    angleMeasurementsPlugin.on("contextMenu", (e) => {
+        angleMeasurementsContextMenu.context = { // Must set context before showing menu
+            viewer: viewer,
+            angleMeasurementsPlugin: angleMeasurementsPlugin,
+            measurement: e.measurement
+        };
+        angleMeasurementsContextMenu.show(e.event.clientX, e.event.clientY);
+        e.event.preventDefault();
     });
 
-    angleMeasurementsMouseControl.snapping = true;
+    sceneModel.on("loaded", () => {
 
-    angleMeasurementsMouseControl.activate();
+        //------------------------------------------------------------------------------------------------------------------
+        // Create some AngleMeasurements
+        //------------------------------------------------------------------------------------------------------------------
+
+        angleMeasurementsPlugin.createMeasurement({
+            id: "angleMeasurement1",
+            origin: {
+                entity: viewer.scene.objects["1CZILmCaHETO8tf3SgGEXu"],
+                worldPos: [0.4158603637281142, 2.5193106917110457, 17.79972838299403]
+            },
+            corner: {
+                entity: viewer.scene.objects["1CZILmCaHETO8tf3SgGEXu"],
+                worldPos: [0.41857741956197625,0.0987169929481646,17.799763071093395]
+            },
+            target: {
+                entity: viewer.scene.objects["1CZILmCaHETO8tf3SgGEXu"],
+                worldPos: [5.235526066859247, 0.11580773869801986, 17.824891550941565]
+            },
+            visible: true
+        });
+
+        angleMeasurementsPlugin.createMeasurement({
+            id: "angleMeasurement2",
+            origin: {
+                entity: viewer.scene.objects["2O2Fr$t4X7Zf8NOew3FNr2"],
+                worldPos: [-0.00003814187850181838, 5.9996748076205115,17.79996871551525]
+            },
+            corner: {
+                entity: viewer.scene.objects["2O2Fr$t4X7Zf8NOew3FNqI"],
+                worldPos: [-0.0005214119318139865, 3.1010044228517595, 17.787656604483363]
+
+            },
+            target: {
+                entity: viewer.scene.objects["1s1jVhK8z0pgKYcr9jt7AB"],
+                worldPos: [ 8.380657312957396, 3.1055697628459553, 17.799220108187185]
+            },
+            visible: true
+        });
+    });
+
+    const objectContextMenu = new ContextMenu({
+        items: [
+            [
+                {
+                    getTitle: function (context) {
+                        return (!context.entity.xrayed) ? "X-Ray" : "Undo X-Ray";
+                    },
+                    doAction: function (context) {
+                        context.entity.xrayed = !context.entity.xrayed;
+                    }
+                },
+                {
+                    title: "X-Ray Others",
+                    doAction: function (context) {
+                        const viewer = context.viewer;
+                        const scene = viewer.scene;
+                        const entity = context.entity;
+                        const metaObject = viewer.metaScene.metaObjects[entity.id];
+                        if (!metaObject) {
+                            return;
+                        }
+                        scene.setObjectsVisible(scene.objectIds, true);
+                        scene.setObjectsXRayed(scene.objectIds, true);
+                        scene.setObjectsSelected(scene.selectedObjectIds, false);
+                        scene.setObjectsHighlighted(scene.highlightedObjectIds, false);
+                        metaObject.withMetaObjectsInSubtree((metaObject) => {
+                            const entity = scene.objects[metaObject.id];
+                            if (entity) {
+                                entity.xrayed = false;
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "X-Ray All",
+                    getEnabled: function (context) {
+                        const scene = context.viewer.scene;
+                        return (scene.numXRayedObjects < scene.numObjects);
+                    },
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        scene.setObjectsXRayed(scene.objectIds, true);
+                    }
+                },
+                {
+                    title: "X-Ray None",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.numXRayedObjects > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsXRayed(context.viewer.scene.xrayedObjectIds, false);
+                    }
+                }
+            ],
+            [
+                {
+                    title: "Hide",
+                    getEnabled: function (context) {
+                        return context.entity.visible;
+                    },
+                    doAction: function (context) {
+                        context.entity.visible = false;
+                    }
+                },
+                {
+                    title: "Hide Others",
+                    doAction: function (context) {
+                        const viewer = context.viewer;
+                        const scene = viewer.scene;
+                        const entity = context.entity;
+                        const metaObject = viewer.metaScene.metaObjects[entity.id];
+                        if (!metaObject) {
+                            return;
+                        }
+                        scene.setObjectsVisible(scene.visibleObjectIds, false);
+                        scene.setObjectsXRayed(scene.xrayedObjectIds, false);
+                        scene.setObjectsSelected(scene.selectedObjectIds, false);
+                        scene.setObjectsHighlighted(scene.highlightedObjectIds, false);
+                        metaObject.withMetaObjectsInSubtree((metaObject) => {
+                            const entity = scene.objects[metaObject.id];
+                            if (entity) {
+                                entity.visible = true;
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "Hide All",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.numVisibleObjects > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsVisible(context.viewer.scene.visibleObjectIds, false);
+                    }
+                },
+                {
+                    title: "Show All",
+                    getEnabled: function (context) {
+                        const scene = context.viewer.scene;
+                        return (scene.numVisibleObjects < scene.numObjects);
+                    },
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        scene.setObjectsVisible(scene.objectIds, true);
+                    }
+                }
+            ],
+            [
+                {
+                    getTitle: function (context) {
+                        return (!context.entity.selected) ? "Select" : "Undo Select";
+                    },
+                    doAction: function (context) {
+                        context.entity.selected = !context.entity.selected;
+                    }
+                },
+                {
+                    title: "Select All",
+                    getEnabled: function (context) {
+                        const scene = context.viewer.scene;
+                        return (scene.numSelectedObjects < scene.numObjects);
+                    },
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        scene.setObjectsSelected(scene.objectIds, true);
+                    }
+                },
+                {
+                    title: "Select None",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.numSelectedObjects > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsSelected(context.viewer.scene.selectedObjectIds, false);
+                    }
+                }
+            ],
+
+            [
+                {
+                    title: "Camera..",
+                    items: [
+                        [
+                            {
+                                title: "View Fit",
+                                doAction: function (context) {
+                                    const viewer = context.viewer;
+                                    const scene = viewer.scene;
+                                    const entity = context.entity;
+                                    viewer.cameraFlight.flyTo({
+                                        aabb: entity.aabb,
+                                        duration: 0.5
+                                    }, () => {
+                                        setTimeout(function () {
+                                            scene.setObjectsHighlighted(scene.highlightedObjectIds, false);
+                                        }, 500);
+                                    });
+                                }
+                            },
+                            {
+                                title: "View Fit All",
+                                doAction: function (context) {
+                                    const scene = context.viewer.scene;
+                                    context.viewer.cameraFlight.flyTo({
+                                        projection: "perspective",
+                                        aabb: scene.getAABB(),
+                                        duration: 0.5
+                                    });
+                                }
+                            }
+                        ],
+                        [
+                            {
+                                title: "Perspective",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.camera.projection !== "perspective");
+                                },
+                                doAction: function (context) {
+                                    context.viewer.cameraFlight.flyTo({
+                                        projection: "perspective"
+                                    });
+                                }
+                            },
+                            {
+                                title: "Orthographic",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.camera.projection !== "ortho");
+                                },
+                                doAction: function (context) {
+                                    context.viewer.cameraFlight.flyTo({
+                                        projection: "ortho"
+                                    });
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ],
+
+            [
+                {
+                    title: "Effects..",
+                    items: [
+                        [
+                            {
+                                getTitle: (context) => {
+                                    return context.viewer.scene.edgeMaterial.edges ? "Disable Edges" : "Enable Edges";
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.edgeMaterial.edges = !context.viewer.scene.edgeMaterial.edges;
+                                }
+                            },
+                            {
+                                getTitle: (context) => {
+                                    return context.viewer.scene.sao.enabled ? "Disable SAO" : "Enable SAO";
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.sao.enabled = !context.viewer.scene.sao.enabled;
+                                }
+                            },
+                            {
+                                getTitle: (context) => {
+                                    return context.viewer.scene.pbrEnabled ? "Disable PBR" : "Enable PBR";
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.pbrEnabled = !context.viewer.scene.pbrEnabled;
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ],
+
+            [
+                {
+                    title: "Measurements..",
+                    getEnabled: function (context) {
+                        return (Object.keys(angleMeasurementsPlugin.measurements).length > 0);
+                    },
+                    items: [
+                        [
+                            {
+                                getTitle: function (context) {
+                                    return (Object.keys(angleMeasurementsPlugin.measurements).length > 0) ? "Show All Labels" : "Hide All Labels";
+                                },
+                                getEnabled: function (context) {
+                                    return (Object.keys(angleMeasurementsPlugin.measurements).length > 0);
+                                },
+                                doAction: function (context) {
+                                    //angleMeasurementsPlugin.clear();
+                                }
+                            },
+                            {
+                                getTitle: function (context) {
+                                    return (Object.keys(angleMeasurementsPlugin.measurements).length > 0) ? "Show All Axis" : "Hide All Axis";
+                                },
+                                getEnabled: function (context) {
+                                    return (Object.keys(angleMeasurementsPlugin.measurements).length > 0);
+                                },
+                                doAction: function (context) {
+                                    //angleMeasurementsPlugin.clear();
+                                }
+                            },
+                            {
+                                title: "Delete All",
+                                getEnabled: function (context) {
+                                    return (Object.keys(angleMeasurementsPlugin.measurements).length > 0);
+                                },
+                                doAction: function (context) {
+                                    angleMeasurementsPlugin.clear();
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ]
+        ],
+        enabled: true
+    });
+
+    const canvasContextMenu = new ContextMenu({
+        enabled: true,
+        context: {
+            viewer: viewer
+        },
+        items: [
+            [
+                {
+                    title: "Objects..",
+                    items: [
+                        [
+                            {
+                                title: "X-Ray All",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.numXRayedObjects < scene.numObjects);
+                                },
+                                doAction: function (context) {
+                                    const scene = context.viewer.scene;
+                                    scene.setObjectsXRayed(scene.objectIds, true);
+                                }
+                            },
+                            {
+                                title: "X-Ray None",
+                                getEnabled: function (context) {
+                                    return (context.viewer.scene.numXRayedObjects > 0);
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.setObjectsXRayed(context.viewer.scene.xrayedObjectIds, false);
+                                }
+                            }
+                        ],
+                        [
+                            {
+                                title: "Hide All",
+                                getEnabled: function (context) {
+                                    return (context.viewer.scene.numVisibleObjects > 0);
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.setObjectsVisible(context.viewer.scene.visibleObjectIds, false);
+                                }
+                            },
+                            {
+                                title: "Show All",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.numVisibleObjects < scene.numObjects);
+                                },
+                                doAction: function (context) {
+                                    const scene = context.viewer.scene;
+                                    scene.setObjectsVisible(scene.objectIds, true);
+                                    scene.setObjectsXRayed(scene.xrayedObjectIds, false);
+                                    scene.setObjectsSelected(scene.selectedObjectIds, false);
+                                }
+                            }
+                        ],
+
+                        [
+                            {
+                                title: "Select All",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.numSelectedObjects < scene.numObjects);
+                                },
+                                doAction: function (context) {
+                                    const scene = context.viewer.scene;
+                                    scene.setObjectsSelected(scene.objectIds, true);
+                                }
+                            },
+                            {
+                                title: "Select None",
+                                getEnabled: function (context) {
+                                    return (context.viewer.scene.numSelectedObjects > 0);
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.setObjectsSelected(context.viewer.scene.selectedObjectIds, false);
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ],
+            [
+                {
+                    title: "Camera..",
+                    items: [
+                        [
+                            {
+                                title: "View Fit All",
+                                doAction: function (context) {
+                                    context.viewer.cameraFlight.flyTo({
+                                        aabb: context.viewer.scene.getAABB()
+                                    });
+                                }
+                            }
+                        ],
+                        [
+                            {
+                                title: "Perspective",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.camera.projection !== "perspective");
+                                },
+                                doAction: function (context) {
+                                    context.viewer.cameraFlight.flyTo({
+                                        projection: "perspective"
+                                    });
+                                }
+                            },
+                            {
+                                title: "Orthographic",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.camera.projection !== "ortho");
+                                },
+                                doAction: function (context) {
+                                    context.viewer.cameraFlight.flyTo({
+                                        projection: "ortho"
+                                    });
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ],
+
+            [
+                {
+                    title: "Effects..",
+                    items: [
+                        [
+                            {
+                                getTitle: (context) => {
+                                    return context.viewer.scene.edgeMaterial.edges ? "Disable Edges" : "Enable Edges";
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.edgeMaterial.edges = !context.viewer.scene.edgeMaterial.edges;
+                                }
+                            },
+                            {
+                                getTitle: (context) => {
+                                    return context.viewer.scene.sao.enabled ? "Disable SAO" : "Enable SAO";
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.sao.enabled = !context.viewer.scene.sao.enabled;
+                                }
+                            },
+                            {
+                                getTitle: (context) => {
+                                    return context.viewer.scene.pbrEnabled ? "Disable PBR" : "Enable PBR";
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.pbrEnabled = !context.viewer.scene.pbrEnabled;
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ],
+            [
+                {
+                    title: "Measurements..",
+                    getEnabled: function (context) {
+                        return (Object.keys(angleMeasurementsPlugin.measurements).length > 0);
+                    },
+                    items: [
+                        [
+                            {
+                                getTitle: function (context) {
+                                    return (Object.keys(angleMeasurementsPlugin.measurements).length > 0) ? "Show All Labels" : "Hide All Labels";
+                                },
+                                getEnabled: function (context) {
+                                    return (Object.keys(angleMeasurementsPlugin.measurements).length > 0);
+                                },
+                                doAction: function (context) {
+                                    //angleMeasurementsPlugin.clear();
+                                }
+                            },
+                            {
+                                title: "Delete All",
+                                getEnabled: function (context) {
+                                    return (Object.keys(angleMeasurementsPlugin.measurements).length > 0);
+                                },
+                                doAction: function (context) {
+                                    angleMeasurementsPlugin.clear();
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ]
+        ]
+    });
+
+    viewer.cameraControl.on("rightClick", (e) => {
+
+        const hit = viewer.scene.pick({
+            canvasPos: e.canvasPos
+        });
+
+        if (hit && hit.entity.isObject) {
+
+            objectContextMenu.context = { // Must set context before showing menu
+                viewer: viewer,
+                entity: hit.entity
+            };
+
+            objectContextMenu.show(e.pagePos[0], e.pagePos[1]);
+        } else {
+
+            canvasContextMenu.context = { // Must set context before showing menu
+                viewer: viewer
+            };
+
+            canvasContextMenu.show(e.pagePos[0], e.pagePos[1]);
+        }
+
+        e.event.preventDefault();
+    });
+
 
 </script>
 </html>

--- a/examples/measurement/angle_modelWithMeasurements.html
+++ b/examples/measurement/angle_modelWithMeasurements.html
@@ -120,7 +120,7 @@
     // Import the modules we need for this example
     //------------------------------------------------------------------------------------------------------------------
 
-    import {Viewer, XKTLoaderPlugin, ContextMenu, AngleMeasurementsPlugin} from "../../dist/xeokit-sdk.min.es.js";
+    import {Viewer, XKTLoaderPlugin, ContextMenu, AngleMeasurementsPlugin} from "../../dist/xeokit-sdk.es.js";
 
     //------------------------------------------------------------------------------------------------------------------
     // Create a Viewer and arrange the camera

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@xeokit/xeokit-sdk",
-  "version": "2.4.2-beta-14",
+  "version": "2.5.0-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xeokit/xeokit-sdk",
-      "version": "2.4.2-beta-14",
+      "version": "2.5.0-beta",
       "license": "See LICENSE.txt",
       "dependencies": {
         "@loaders.gl/core": "^3.2.6",

--- a/src/plugins/AngleMeasurementsPlugin/AngleMeasurement.js
+++ b/src/plugins/AngleMeasurementsPlugin/AngleMeasurement.js
@@ -52,10 +52,12 @@ class AngleMeasurement extends Component {
 
         const onMouseOver = cfg.onMouseOver ? (event) => {
             cfg.onMouseOver(event, this);
+            this.plugin.viewer.scene.canvas.canvas.dispatchEvent(new MouseEvent('mouseover', event));
         } : null;
 
         const onMouseLeave = cfg.onMouseLeave ? (event) => {
             cfg.onMouseLeave(event, this);
+            this.plugin.viewer.scene.canvas.canvas.dispatchEvent(new MouseEvent('mouseleave', event));
         } : null;
 
         const onContextMenu = cfg.onContextMenu ? (event) => {
@@ -66,12 +68,27 @@ class AngleMeasurement extends Component {
             this.plugin.viewer.scene.canvas.canvas.dispatchEvent(new WheelEvent('wheel', event));
         };
 
+        const onMouseDown = (event) => {
+            this.plugin.viewer.scene.canvas.canvas.dispatchEvent(new MouseEvent('mousedown', event));
+        } ;
+
+        const onMouseUp =  (event) => {
+            this.plugin.viewer.scene.canvas.canvas.dispatchEvent(new MouseEvent('mouseup', event));
+        };
+
+        const onMouseMove =  (event) => {
+            this.plugin.viewer.scene.canvas.canvas.dispatchEvent(new MouseEvent('mousemove', event));
+        };
+
         this._originDot = new Dot(this._container, {
             fillColor: this._color,
             zIndex: plugin.zIndex !== undefined ? plugin.zIndex + 2 : undefined,
             onMouseOver,
             onMouseLeave,
             onMouseWheel,
+            onMouseDown,
+            onMouseUp,
+            onMouseMove,
             onContextMenu
         });
         this._cornerDot = new Dot(this._container, {
@@ -80,6 +97,9 @@ class AngleMeasurement extends Component {
             onMouseOver,
             onMouseLeave,
             onMouseWheel,
+            onMouseDown,
+            onMouseUp,
+            onMouseMove,
             onContextMenu
         });
         this._targetDot = new Dot(this._container, {
@@ -88,6 +108,9 @@ class AngleMeasurement extends Component {
             onMouseOver,
             onMouseLeave,
             onMouseWheel,
+            onMouseDown,
+            onMouseUp,
+            onMouseMove,
             onContextMenu
         });
 
@@ -98,6 +121,9 @@ class AngleMeasurement extends Component {
             onMouseOver,
             onMouseLeave,
             onMouseWheel,
+            onMouseDown,
+            onMouseUp,
+            onMouseMove,
             onContextMenu
         });
         this._targetWire = new Wire(this._container, {
@@ -107,6 +133,9 @@ class AngleMeasurement extends Component {
             onMouseOver,
             onMouseLeave,
             onMouseWheel,
+            onMouseDown,
+            onMouseUp,
+            onMouseMove,
             onContextMenu
         });
 
@@ -118,6 +147,9 @@ class AngleMeasurement extends Component {
             onMouseOver,
             onMouseLeave,
             onMouseWheel,
+            onMouseDown,
+            onMouseUp,
+            onMouseMove,
             onContextMenu
         });
 

--- a/src/plugins/AngleMeasurementsPlugin/AngleMeasurementsPlugin.js
+++ b/src/plugins/AngleMeasurementsPlugin/AngleMeasurementsPlugin.js
@@ -352,6 +352,7 @@ export class AngleMeasurementsPlugin extends Plugin {
         measurement.on("destroyed", () => {
             delete this._measurements[measurement.id];
         });
+        measurement.clickable = true;
         this.fire("measurementCreated", measurement);
         return measurement;
     }

--- a/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
+++ b/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
@@ -62,11 +62,25 @@ class DistanceMeasurement extends Component {
 
         const onMouseOver = cfg.onMouseOver ? (event) => {
             cfg.onMouseOver(event, this);
+            this.plugin.viewer.scene.canvas.canvas.dispatchEvent(new MouseEvent('mouseover', event));
         } : null;
 
         const onMouseLeave = cfg.onMouseLeave ? (event) => {
             cfg.onMouseLeave(event, this);
+            this.plugin.viewer.scene.canvas.canvas.dispatchEvent(new MouseEvent('mouseleave', event));
         } : null;
+
+        const onMouseDown = (event) => {
+            this.plugin.viewer.scene.canvas.canvas.dispatchEvent(new MouseEvent('mousedown', event));
+        } ;
+
+        const onMouseUp =  (event) => {
+            this.plugin.viewer.scene.canvas.canvas.dispatchEvent(new MouseEvent('mouseup', event));
+        };
+
+        const onMouseMove =  (event) => {
+            this.plugin.viewer.scene.canvas.canvas.dispatchEvent(new MouseEvent('mousemove', event));
+        };
 
         const onContextMenu = cfg.onContextMenu ? (event) => {
             cfg.onContextMenu(event, this);
@@ -82,6 +96,9 @@ class DistanceMeasurement extends Component {
             onMouseOver,
             onMouseLeave,
             onMouseWheel,
+            onMouseDown,
+            onMouseUp,
+            onMouseMove,
             onContextMenu
         });
 
@@ -91,6 +108,9 @@ class DistanceMeasurement extends Component {
             onMouseOver,
             onMouseLeave,
             onMouseWheel,
+            onMouseDown,
+            onMouseUp,
+            onMouseMove,
             onContextMenu
         });
 
@@ -102,6 +122,9 @@ class DistanceMeasurement extends Component {
             onMouseOver,
             onMouseLeave,
             onMouseWheel,
+            onMouseDown,
+            onMouseUp,
+            onMouseMove,
             onContextMenu
         });
 
@@ -113,6 +136,9 @@ class DistanceMeasurement extends Component {
             onMouseOver,
             onMouseLeave,
             onMouseWheel,
+            onMouseDown,
+            onMouseUp,
+            onMouseMove,
             onContextMenu
         });
 
@@ -124,6 +150,9 @@ class DistanceMeasurement extends Component {
             onMouseOver,
             onMouseLeave,
             onMouseWheel,
+            onMouseDown,
+            onMouseUp,
+            onMouseMove,
             onContextMenu
         });
 
@@ -135,6 +164,9 @@ class DistanceMeasurement extends Component {
             onMouseOver,
             onMouseLeave,
             onMouseWheel,
+            onMouseDown,
+            onMouseUp,
+            onMouseMove,
             onContextMenu
         });
 
@@ -146,6 +178,9 @@ class DistanceMeasurement extends Component {
             onMouseOver,
             onMouseLeave,
             onMouseWheel,
+            onMouseDown,
+            onMouseUp,
+            onMouseMove,
             onContextMenu
         });
 
@@ -157,6 +192,9 @@ class DistanceMeasurement extends Component {
             onMouseOver,
             onMouseLeave,
             onMouseWheel,
+            onMouseDown,
+            onMouseUp,
+            onMouseMove,
             onContextMenu
         });
 
@@ -168,6 +206,9 @@ class DistanceMeasurement extends Component {
             onMouseOver,
             onMouseLeave,
             onMouseWheel,
+            onMouseDown,
+            onMouseUp,
+            onMouseMove,
             onContextMenu
         });
 
@@ -179,6 +220,9 @@ class DistanceMeasurement extends Component {
             onMouseOver,
             onMouseLeave,
             onMouseWheel,
+            onMouseDown,
+            onMouseUp,
+            onMouseMove,
             onContextMenu
         });
 

--- a/src/plugins/lib/html/Dot.js
+++ b/src/plugins/lib/html/Dot.js
@@ -56,9 +56,14 @@ class Dot {
         }
         parentElement.appendChild(dotClickable);
 
+        dotClickable.addEventListener('click', (event) => {
+            parentElement.dispatchEvent(new MouseEvent('mouseover', event));
+        });
+
         if (cfg.onMouseOver) {
             dotClickable.addEventListener('mouseover', (event) => {
                 cfg.onMouseOver(event, this);
+                parentElement.dispatchEvent(new MouseEvent('mouseover', event));
             });
         }
 
@@ -71,6 +76,24 @@ class Dot {
         if (cfg.onMouseWheel) {
             dotClickable.addEventListener('wheel', (event) => {
                 cfg.onMouseWheel(event, this);
+            });
+        }
+
+        if (cfg.onMouseDown) {
+            dotClickable.addEventListener('mousedown', (event) => {
+                cfg.onMouseDown(event, this);
+            });
+        }
+
+        if (cfg.onMouseUp) {
+            dotClickable.addEventListener('mouseup', (event) => {
+                cfg.onMouseUp(event, this);
+            });
+        }
+
+        if (cfg.onMouseMove) {
+            dotClickable.addEventListener('mousemove', (event) => {
+                cfg.onMouseMove(event, this);
             });
         }
 

--- a/src/plugins/lib/html/Label.js
+++ b/src/plugins/lib/html/Label.js
@@ -63,6 +63,24 @@ class Label {
             });
         }
 
+        if (cfg.onMouseDown) {
+            label.addEventListener('mousedown', (event) => {
+                cfg.onMouseDown(event, this);
+            });
+        }
+
+        if (cfg.onMouseUp) {
+            label.addEventListener('mouseup', (event) => {
+                cfg.onMouseUp(event, this);
+            });
+        }
+
+        if (cfg.onMouseMove) {
+            label.addEventListener('mousemove', (event) => {
+                cfg.onMouseMove(event, this);
+            });
+        }
+
         if (cfg.onContextMenu) {
             label.addEventListener('contextmenu', (event) => {
                 cfg.onContextMenu(event, this);

--- a/src/plugins/lib/html/Wire.js
+++ b/src/plugins/lib/html/Wire.js
@@ -95,6 +95,24 @@ class Wire {
             });
         }
 
+        if (cfg.onMouseDown) {
+            wireClickable.addEventListener('mousedown', (event) => {
+                cfg.onMouseDown(event, this);
+            });
+        }
+
+        if (cfg.onMouseUp) {
+            wireClickable.addEventListener('mouseup', (event) => {
+                cfg.onMouseUp(event, this);
+            });
+        }
+
+        if (cfg.onMouseMove) {
+            wireClickable.addEventListener('mousemove', (event) => {
+                cfg.onMouseMove(event, this);
+            });
+        }
+
         if (cfg.onContextMenu) {
             wireClickable.addEventListener('contextmenu', (event) => {
                 cfg.onContextMenu(event, this);


### PR DESCRIPTION
## Issue

Measurements don't allow mouse events to pass through them to the underlying canvas. Therefore, it's not possible to make a measurement on a location that is underneath an existing measurement. This also means that we can't snap to a vertex or edge that is obscured by a measurement.

[Screencast from 14.12.2023 10:04:06.webm](https://github.com/xeokit/xeokit-sdk/assets/83100/2d33d892-b216-4d65-a1a7-79479fda18d1)

## Fix

This PR modifies the input handlers for measurements so that the necessary input events can pass through the measurements. As a result, we can now "chain" measurements together, where we can, for example, snap to a vertex that a measurement is already attached to.

 
[Screencast from 14.12.2023 10:05:02.webm](https://github.com/xeokit/xeokit-sdk/assets/83100/e2284423-81e0-4004-9e46-590007363159)

