### PR TITLE
FIX: BitMap auto-scaling

### DIFF
--- a/src/viewer/scene/Bitmap/Bitmap.js
+++ b/src/viewer/scene/Bitmap/Bitmap.js
@@ -466,7 +466,7 @@ class Bitmap extends Component {
 
     _updateBitmapMeshScale() {
         const aspect = this._imageSize[1] / this._imageSize[0];
-        this._bitmapMesh.scale = [this._height * aspect, 1.0, this._height];
+        this._bitmapMesh.scale = [this._height / aspect, 1.0, this._height];
     }
 }
 


### PR DESCRIPTION
When loading BCFViewpoints containing bitmaps, the bitmaps are sized wrongly.

The reason is that xeokit is applying the aspect ratio wrongly when auto-scaling them. Fix by *dividing* height by the aspect ratio, instead of multiplying.

## Before

````javascript
_updateBitmapMeshScale() {
    const aspect = this._imageSize[1] / this._imageSize[0];
    this._bitmapMesh.scale = [this._height * aspect, 1.0, this._height];
}
````

![Screenshot from 2023-12-19 13-21-03](https://github.com/xeokit/xeokit-sdk/assets/83100/f962bf3d-2d5f-489d-a8c7-2f696a06ed8f)

## After

````javascript
_updateBitmapMeshScale() {
    const aspect = this._imageSize[1] / this._imageSize[0];
    this._bitmapMesh.scale = [this._height / aspect, 1.0, this._height];
}
````

![Screenshot from 2023-12-19 13-20-29](https://github.com/xeokit/xeokit-sdk/assets/83100/caee3471-0d94-412e-a49d-6810606a4a74)
