### PR TITLE
fix code comment typo in XKTLoaderPlugin.js

### DIFF
--- a/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
+++ b/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
@@ -354,9 +354,9 @@ parsers[ParserV10.version] = ParserV10;
  *      }
  *
  *      // Gets the contents of the given .XKT file in an arraybuffer
- *      getXKT(src, ok, error) {
+ *      getXKT(xKTSrc, ok, error) {
  *          console.log("MyDataSource#getXKT(" + xKTSrc + ", ... )");
- *          utils.loadArraybuffer(src,
+ *          utils.loadArraybuffer(xKTSrc,
  *              (arraybuffer) => {
  *                  ok(arraybuffer);
  *              },


### PR DESCRIPTION
I found typo when I tried custom data source.
https://github.com/xeokit/xeokit-sdk/blob/7c8853a3f883a5b6393490935dd262ca08433f44/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js#L328

I modified code comment to the similar getMetaModel one.
https://github.com/xeokit/xeokit-sdk/blob/7c8853a3f883a5b6393490935dd262ca08433f44/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js#L345-L355