### PR TITLE
Custom label color for NavCube

### DIFF
--- a/examples/navigation/NavCubePlugin_customColors.html
+++ b/examples/navigation/NavCubePlugin_customColors.html
@@ -90,10 +90,14 @@
         topColor: "#5555FF",
         bottomColor: "#fff155",
 
-        // We can also supply a color to highlight NavCuve regions
+        // We can also supply a color to highlight NavCube regions
         // as we hover the pointer over them:
 
-        hoverColor: "rgba(0,0.5,0,0.4)" // Default value
+        hoverColor: "rgba(0,0.5,0,0.4)", // Default value
+
+        // We can also optionally supply a color of a NavCube labels:
+
+        textColor: "black" // Default value
     });
 
     const sceneModel = xktLoader.load({

--- a/src/plugins/NavCubePlugin/CubeTextureCanvas.js
+++ b/src/plugins/NavCubePlugin/CubeTextureCanvas.js
@@ -7,6 +7,7 @@ function CubeTextureCanvas(viewer, navCubeScene, cfg = {}) {
 
     const cubeColor = "lightgrey";
     const cubeHighlightColor = cfg.hoverColor || "rgba(0,0,0,0.4)";
+    const textColor = cfg.textColor || "black";
 
     const height = 500;
     const width = height + (height / 3);
@@ -158,7 +159,7 @@ function CubeTextureCanvas(viewer, navCubeScene, cfg = {}) {
                 }
             }
             if (area.label) {
-                context.fillStyle = "black";
+                context.fillStyle = textColor;
                 context.font = '60px sans-serif';
                 context.textAlign = "center";
                 var xcenter = xmin + (width * 0.5);

--- a/src/plugins/NavCubePlugin/NavCubePlugin.js
+++ b/src/plugins/NavCubePlugin/NavCubePlugin.js
@@ -88,7 +88,7 @@ class NavCubePlugin extends Plugin {
      * @param {String} [cfg.cameraFly=true] Whether the {@link Camera} flies or jumps to each selected axis or diagonal.
      * @param {String} [cfg.cameraFitFOV=45] How much of the field-of-view, in degrees, that the 3D scene should fill the {@link Canvas} when the {@link Camera} moves to an axis or diagonal.
      * @param {String} [cfg.cameraFlyDuration=0.5] When flying the {@link Camera} to each new axis or diagonal, how long, in seconds, that the Camera takes to get there.
-     * @param {String} [cfg.color="lightgrey] Custom uniform color for the faces of the NavCube.
+     * @param {String} [cfg.color="lightgrey"] Custom uniform color for the faces of the NavCube.
      * @param {String} [cfg.frontColor="#55FF55"] Custom color for the front face of the NavCube. Overrides ````color````.
      * @param {String} [cfg.backColor="#55FF55"] Custom color for the back face of the NavCube. Overrides ````color````.
      * @param {String} [cfg.leftColor="#FF5555"] Custom color for the left face of the NavCube. Overrides ````color````.
@@ -96,6 +96,7 @@ class NavCubePlugin extends Plugin {
      * @param {String} [cfg.topColor="#5555FF"] Custom color for the top face of the NavCube. Overrides ````color````.
      * @param {String} [cfg.bottomColor="#5555FF"] Custom color for the bottom face of the NavCube. Overrides ````color````.
      * @param {String} [cfg.hoverColor="rgba(0,0,0,0.4)"] Custom color for highlighting regions on the NavCube as we hover the pointer over them.
+     * @param {String} [cfg.textColor="black"] Custom text color for labels of the NavCube.
      * @param {Boolean} [cfg.fitVisible=false] Sets whether the axis, corner and edge-aligned views will fit the
      * view to the entire {@link Scene} or just to visible object-{@link Entity}s. Entitys are visible objects when {@link Entity#isObject} and {@link Entity#visible} are both ````true````.
      * @param {Boolean} [cfg.synchProjection=false] Sets whether the NavCube switches between perspective and orthographic projections in synchrony with the {@link Camera}. When ````false````, the NavCube will always be rendered with perspective projection.

--- a/types/plugins/NavCubePlugin/NavCubePlugin.d.ts
+++ b/types/plugins/NavCubePlugin/NavCubePlugin.d.ts
@@ -34,6 +34,8 @@ export declare type NavCubePluginConfiguration = {
   bottomColor?: string;
   /** Custom color for highlighting regions on the NavCube as we hover the pointer over them. */
   hoverColor?: string;
+  /** Custom text color for labels of the NavCube. */
+  textColor?: string;
   /** Sets whether the axis, corner and edge-aligned views will fit the view to the entire {@link Scene} or just to visible object-{@link Entity}s. Entitys are visible objects when {@link Entity.isObject} and {@link Entity.visible} are both ````true````. */
   fitVisible?: boolean;
   /** Sets whether the NavCube switches between perspective and orthographic projections in synchrony with the {@link Camera}. When ````false````, the NavCube will always be rendered with perspective projection. */


### PR DESCRIPTION
- Adding ability to set a label color as described here: https://github.com/xeokit/xeokit-sdk/issues/1211
- Tiny fix of formatting in param for cfg.color (missing quotation mark)

Question if example file (https://github.com/xeokit/xeokit-sdk/blob/master/examples/navigation/NavCubePlugin.html) should be updated to show this feature.

Default color is set as black to don't change existing behaviour.