### PR TITLE
[Fix] Fixed links to assets, removed link to roboto condensed

### DIFF
--- a/examples/annotations/index.html
+++ b/examples/annotations/index.html
@@ -8,7 +8,7 @@
     <link href='https://fonts.googleapis.com/css?family=Exo+2:400,800,900,700,600,500|Roboto:100,300,400,500,700,900'
           rel='stylesheet' type='text/css'>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
-    <link href='http://fonts.googleapis.com/css?family=Roboto+Condensed' rel='stylesheet' type='text/css'>
+    
 
     <style>
 

--- a/examples/bookmarking/index.html
+++ b/examples/bookmarking/index.html
@@ -8,7 +8,7 @@
     <link href='https://fonts.googleapis.com/css?family=Exo+2:400,800,900,700,600,500|Roboto:100,300,400,500,700,900'
           rel='stylesheet' type='text/css'>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
-    <link href='http://fonts.googleapis.com/css?family=Roboto+Condensed' rel='stylesheet' type='text/css'>
+    
 
     <style>
 

--- a/examples/buildings/index.html
+++ b/examples/buildings/index.html
@@ -7,7 +7,7 @@
     <title>xeokit Examples</title>
     <link href='https://fonts.googleapis.com/css?family=Exo+2:400,800,900,700,600,500|Roboto:100,300,400,500,700,900' rel='stylesheet' type='text/css'>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
-    <link href='http://fonts.googleapis.com/css?family=Roboto+Condensed' rel='stylesheet' type='text/css'>
+    
 
     <style>
 

--- a/examples/cad/index.html
+++ b/examples/cad/index.html
@@ -8,7 +8,7 @@
     <link href='https://fonts.googleapis.com/css?family=Exo+2:400,800,900,700,600,500|Roboto:100,300,400,500,700,900'
           rel='stylesheet' type='text/css'>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
-    <link href='http://fonts.googleapis.com/css?family=Roboto+Condensed' rel='stylesheet' type='text/css'>
+    
 
     <style>
 

--- a/examples/cities/index.html
+++ b/examples/cities/index.html
@@ -8,7 +8,7 @@
     <link href='https://fonts.googleapis.com/css?family=Exo+2:400,800,900,700,600,500|Roboto:100,300,400,500,700,900'
           rel='stylesheet' type='text/css'>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
-    <link href='http://fonts.googleapis.com/css?family=Roboto+Condensed' rel='stylesheet' type='text/css'>
+    
 
     <style>
 

--- a/examples/emphasising/index.html
+++ b/examples/emphasising/index.html
@@ -8,7 +8,7 @@
     <link href='https://fonts.googleapis.com/css?family=Exo+2:400,800,900,700,600,500|Roboto:100,300,400,500,700,900'
           rel='stylesheet' type='text/css'>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
-    <link href='http://fonts.googleapis.com/css?family=Roboto+Condensed' rel='stylesheet' type='text/css'>
+    
 
     <style>
 

--- a/examples/geometry/index.html
+++ b/examples/geometry/index.html
@@ -8,7 +8,7 @@
     <link href='https://fonts.googleapis.com/css?family=Exo+2:400,800,900,700,600,500|Roboto:100,300,400,500,700,900'
           rel='stylesheet' type='text/css'>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
-    <link href='http://fonts.googleapis.com/css?family=Roboto+Condensed' rel='stylesheet' type='text/css'>
+    
 
     <style>
 

--- a/examples/indexOld.html
+++ b/examples/indexOld.html
@@ -8,7 +8,7 @@
     <link href='https://fonts.googleapis.com/css?family=Exo+2:400,800,900,700,600,500|Roboto:100,300,400,500,700,900'
           rel='stylesheet' type='text/css'>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
-    <link href='http://fonts.googleapis.com/css?family=Roboto+Condensed' rel='stylesheet' type='text/css'>
+    
 
     <style>
 

--- a/examples/lidar/index.html
+++ b/examples/lidar/index.html
@@ -8,7 +8,7 @@
     <link href='https://fonts.googleapis.com/css?family=Exo+2:400,800,900,700,600,500|Roboto:100,300,400,500,700,900'
           rel='stylesheet' type='text/css'>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
-    <link href='http://fonts.googleapis.com/css?family=Roboto+Condensed' rel='stylesheet' type='text/css'>
+    
 
     <style>
 

--- a/examples/measurement/index.html
+++ b/examples/measurement/index.html
@@ -8,7 +8,7 @@
     <link href='https://fonts.googleapis.com/css?family=Exo+2:400,800,900,700,600,500|Roboto:100,300,400,500,700,900'
           rel='stylesheet' type='text/css'>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
-    <link href='http://fonts.googleapis.com/css?family=Roboto+Condensed' rel='stylesheet' type='text/css'>
+    
 
     <style>
 

--- a/examples/navigation/TreeViewPlugin_Containment.html
+++ b/examples/navigation/TreeViewPlugin_Containment.html
@@ -233,7 +233,7 @@
 
     const sceneModel = xktLoader.load({
         id: "Widget",
-        src: "../../../assets/models/xkt/v8/ifc/Schependomlaan.ifc.xkt",
+        src: "../../assets/models/xkt/v8/ifc/Schependomlaan.ifc.xkt",
         edges: true,
         excludeUnclassifiedObjects: false
     });

--- a/examples/navigation/TreeViewPlugin_Containment_3DXML.html
+++ b/examples/navigation/TreeViewPlugin_Containment_3DXML.html
@@ -325,7 +325,7 @@
 
     const sceneModel = xml3dLoader.load({
         id: "myModel",
-        src: "../../../assets/models/xml3d/3dpreview.3dxml",
+        src: "../../assets/models/xml3d/3dpreview.3dxml",
         materialType: "SpecularMaterial", // <<----------- Create physically-based SpecularMaterials
         edges: true,
         createMetaModel: true

--- a/examples/navigation/TreeViewPlugin_Containment_Federated.html
+++ b/examples/navigation/TreeViewPlugin_Containment_Federated.html
@@ -278,25 +278,25 @@
 
     xktLoader.load({
         id: "model0",
-        src: "../../../assets/models/xkt/v10/federated/Clinic/model.glb.xkt",
+        src: "../../assets/models/xkt/v10/federated/Clinic/model.glb.xkt",
         edges: true
     }).on("loaded", () => {
 
         xktLoader.load({
             id: "model1",
-            src: "../../../assets/models/xkt/v10/federated/Clinic/model_1.glb.xkt",
+            src: "../../assets/models/xkt/v10/federated/Clinic/model_1.glb.xkt",
             edges: true
         }).on("loaded", () => {
 
             xktLoader.load({
                 id: "model2",
-                src: "../../../assets/models/xkt/v10/federated/Clinic/model_2.glb.xkt",
+                src: "../../assets/models/xkt/v10/federated/Clinic/model_2.glb.xkt",
                 edges: true
             }).on("loaded", () => {
 
                 xktLoader.load({
                     id: "model3",
-                    src: "../../../assets/models/xkt/v10/federated/Clinic/model_3.glb.xkt",
+                    src: "../../assets/models/xkt/v10/federated/Clinic/model_3.glb.xkt",
                     edges: true
                 }).on("loaded", () => {
 

--- a/examples/navigation/TreeViewPlugin_options_renderService.html
+++ b/examples/navigation/TreeViewPlugin_options_renderService.html
@@ -403,7 +403,7 @@
 
     const sceneModel = xktLoader.load({
         id: "Widget",
-        src: "../../../assets/models/xkt/v8/ifc/Schependomlaan.ifc.xkt",
+        src: "../../assets/models/xkt/v8/ifc/Schependomlaan.ifc.xkt",
         edges: true,
         excludeUnclassifiedObjects: false
     });

--- a/examples/navigation/index.html
+++ b/examples/navigation/index.html
@@ -8,7 +8,7 @@
     <link href='https://fonts.googleapis.com/css?family=Exo+2:400,800,900,700,600,500|Roboto:100,300,400,500,700,900'
           rel='stylesheet' type='text/css'>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
-    <link href='http://fonts.googleapis.com/css?family=Roboto+Condensed' rel='stylesheet' type='text/css'>
+    
 
     <style>
 

--- a/examples/performance/index.html
+++ b/examples/performance/index.html
@@ -8,7 +8,7 @@
     <link href='https://fonts.googleapis.com/css?family=Exo+2:400,800,900,700,600,500|Roboto:100,300,400,500,700,900'
           rel='stylesheet' type='text/css'>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
-    <link href='http://fonts.googleapis.com/css?family=Roboto+Condensed' rel='stylesheet' type='text/css'>
+    
 
     <style>
 

--- a/examples/picking/index.html
+++ b/examples/picking/index.html
@@ -8,7 +8,7 @@
     <link href='https://fonts.googleapis.com/css?family=Exo+2:400,800,900,700,600,500|Roboto:100,300,400,500,700,900'
           rel='stylesheet' type='text/css'>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
-    <link href='http://fonts.googleapis.com/css?family=Roboto+Condensed' rel='stylesheet' type='text/css'>
+    
 
     <style>
 

--- a/examples/scenegraph/index.html
+++ b/examples/scenegraph/index.html
@@ -8,7 +8,7 @@
     <link href='https://fonts.googleapis.com/css?family=Exo+2:400,800,900,700,600,500|Roboto:100,300,400,500,700,900'
           rel='stylesheet' type='text/css'>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
-    <link href='http://fonts.googleapis.com/css?family=Roboto+Condensed' rel='stylesheet' type='text/css'>
+    
 
     <style>
 

--- a/examples/scenemodel/index.html
+++ b/examples/scenemodel/index.html
@@ -8,7 +8,7 @@
     <link href='https://fonts.googleapis.com/css?family=Exo+2:400,800,900,700,600,500|Roboto:100,300,400,500,700,900'
           rel='stylesheet' type='text/css'>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
-    <link href='http://fonts.googleapis.com/css?family=Roboto+Condensed' rel='stylesheet' type='text/css'>
+    
 
     <style>
 

--- a/examples/slicing/index.html
+++ b/examples/slicing/index.html
@@ -8,7 +8,7 @@
     <link href='https://fonts.googleapis.com/css?family=Exo+2:400,800,900,700,600,500|Roboto:100,300,400,500,700,900'
           rel='stylesheet' type='text/css'>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
-    <link href='http://fonts.googleapis.com/css?family=Roboto+Condensed' rel='stylesheet' type='text/css'>
+    
 
     <style>
 

--- a/examples/snapshots/getSnapshot_excludeSectionPlaneControl.html
+++ b/examples/snapshots/getSnapshot_excludeSectionPlaneControl.html
@@ -114,7 +114,7 @@
 
     const sceneModel = xktLoader.load({
         id: "myModel",
-        src: "../../../assets/models/xkt/v10/glTF-Embedded/Duplex_A_20110505.glTFEmbedded.xkt", // Creates a MetaObject instances in scene.metaScene.metaObjects
+        src: "../../assets/models/xkt/v10/glTF-Embedded/Duplex_A_20110505.glTFEmbedded.xkt", // Creates a MetaObject instances in scene.metaScene.metaObjects
         edges: true,
         backfaces: true // Sometimes it's best to show backfaces, so that sliced objects look less odd
     });

--- a/examples/snapshots/getSnapshot_includeSectionPlaneControl.html
+++ b/examples/snapshots/getSnapshot_includeSectionPlaneControl.html
@@ -113,7 +113,7 @@
 
     const sceneModel = xktLoader.load({
         id: "myModel",
-        src: "../../../assets/models/xkt/v10/glTF-Embedded/Duplex_A_20110505.glTFEmbedded.xkt", // Creates a MetaObject instances in scene.metaScene.metaObjects
+        src: "../../assets/models/xkt/v10/glTF-Embedded/Duplex_A_20110505.glTFEmbedded.xkt", // Creates a MetaObject instances in scene.metaScene.metaObjects
         edges: true,
         backfaces: true // Sometimes it's best to show backfaces, so that sliced objects look less odd
     });

--- a/examples/snapshots/index.html
+++ b/examples/snapshots/index.html
@@ -8,7 +8,7 @@
     <link href='https://fonts.googleapis.com/css?family=Exo+2:400,800,900,700,600,500|Roboto:100,300,400,500,700,900'
           rel='stylesheet' type='text/css'>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
-    <link href='http://fonts.googleapis.com/css?family=Roboto+Condensed' rel='stylesheet' type='text/css'>
+    
 
     <style>
 

--- a/examples/viewer/index.html
+++ b/examples/viewer/index.html
@@ -8,7 +8,7 @@
     <link href='https://fonts.googleapis.com/css?family=Exo+2:400,800,900,700,600,500|Roboto:100,300,400,500,700,900'
           rel='stylesheet' type='text/css'>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
-    <link href='http://fonts.googleapis.com/css?family=Roboto+Condensed' rel='stylesheet' type='text/css'>
+    
 
     <style>
 

--- a/examples/viewer/logDepthBuf_perspective.html
+++ b/examples/viewer/logDepthBuf_perspective.html
@@ -159,7 +159,7 @@
 
     const sceneModel = xktLoader.load({
         id: "myModel",
-        src: "../../../assets/models/xkt/v7/MAP/MAP.xkt",
+        src: "../../assets/models/xkt/v7/MAP/MAP.xkt",
         edges: true
     });
 


### PR DESCRIPTION
Some example files had wrong links to assets, for example: https://xeokit.github.io/xeokit-sdk/examples/navigation/#TreeViewPlugin_Containment

All the index.html files had a stylesheet link to http://fonts.googleapis.com, since the example site is loaded over https the file was not loaded (and not needed). So removed from all files