### PR TITLE
Throws when one try to create a scene with an unused mesh during finalize.

### DIFF
--- a/src/viewer/scene/model/SceneModel.js
+++ b/src/viewer/scene/model/SceneModel.js
@@ -3472,6 +3472,9 @@ export class SceneModel extends Component {
         if (this.destroyed) {
             return;
         }
+        if (!this._areAllMeshesUsedByEntities()){
+            throw "All meshes should be used by entities to finalize SceneModel"
+        }
         for (let i = 0, len = this.layerList.length; i < len; i++) {
             const layer = this.layerList[i];
             layer.finalize();
@@ -3546,6 +3549,31 @@ export class SceneModel extends Component {
                 renderFlags.visibleLayers[renderFlags.numVisibleLayers++] = layerIndex;
             }
         }
+    }
+
+    /** @private */
+    _areAllMeshesUsedByEntities(){
+        let isMeshUsedDictionary = []
+        for (let i = 0; i < this._meshList.length; i++){
+            let currentMeshId = this._meshList[i].id;
+            isMeshUsedDictionary[currentMeshId] = false;
+        }
+        for (let i = 0; i < this._entityList.length; i++) {
+            let currentEntity = this._entityList[i];
+            let currentMeshes = currentEntity.meshes;
+            for (let j = 0; j < currentMeshes.length; j++){
+                let currentMeshId = currentMeshes[j].id;
+                isMeshUsedDictionary[currentMeshId] = true;
+            }
+        }
+        for (let key in isMeshUsedDictionary){
+            let currentMeshResult = isMeshUsedDictionary[key];
+            if (!currentMeshResult){
+                return false;
+            }
+        }
+
+        return true;
     }
 
     _getActiveSectionPlanesForLayer(layer) {


### PR DESCRIPTION
I tried to implement easiest fix of this issue: https://github.com/xeokit/xeokit-sdk/issues/1336

Please have a look at that proposal and give me hints if I got something wrong.
When someone tries to create a mesh that is later not used -> error should be thrown during finalize.
It's a quite big change of existing behaviour.