### PR TITLE
Use GetNameFromTypeCode from web-ifc

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@loaders.gl/gltf": "^3.2.6",
     "@loaders.gl/las": "^3.2.6",
     "html2canvas": "^1.4.1",
-    "web-ifc": "^0.0.41"
+    "web-ifc": "^0.0.51"
   },
   "devDependencies": {
     "@babel/core": "^7.18.6",

--- a/src/plugins/WebIFCLoaderPlugin/WebIFCLoaderPlugin.js
+++ b/src/plugins/WebIFCLoaderPlugin/WebIFCLoaderPlugin.js
@@ -750,7 +750,7 @@ class WebIFCLoaderPlugin extends Plugin {
     }
 
     _parseSpatialChildren(ctx, ifcElement, parentMetaObjectId) {
-        const metaObjectType = ifcElement.__proto__.constructor.name;
+        const metaObjectType = this._ifcAPI.GetNameFromTypeCode(ifcElement.type);
         if (ctx.includeTypes && (!ctx.includeTypes[metaObjectType])) {
             return;
         }
@@ -765,7 +765,7 @@ class WebIFCLoaderPlugin extends Plugin {
 
     _createMetaObject(ctx, ifcElement, parentMetaObjectId) {
         const id = ifcElement.GlobalId.value;
-        const metaObjectType = ifcElement.__proto__.constructor.name;
+        const metaObjectType = this._ifcAPI.GetNameFromTypeCode(ifcElement.type);
         const metaObjectName = (ifcElement.Name && ifcElement.Name.value !== "") ? ifcElement.Name.value : metaObjectType;
         const metaObject = {
             id: id,


### PR DESCRIPTION
This little PR updates IFC Loader to correctly retrieve IFC classes (follow up to https://github.com/xeokit/xeokit-sdk/issues/1185).

It uses web-ifc's updated *GetNameFromTypeCode*, thanks to @beachtom [recent fix](https://github.com/IFCjs/web-ifc/issues/547).

DO NOT MERGE YET: web-ifc 0.0.51 is not released yet