### PR TITLE
[FEATURE] Adding ability to show labels one below the other for measurement plugin

### DIFF
--- a/examples/measurement/distance_createWithMouse_labelsNotOnWires.html
+++ b/examples/measurement/distance_createWithMouse_labelsNotOnWires.html
@@ -85,10 +85,10 @@
 <canvas id="myCanvas"></canvas>
 <div class="slideout-sidebar">
     <img class="info-icon" src="../../assets/images/measure_distance_icon.png"/>
-    <h1>DistanceMeasurementPlugin with DistanceMeasurementsMouseControl and PointerLens with Labels one under the other</h1>
+    <h1>DistanceMeasurementPlugin with DistanceMeasurementsMouseControl and PointerLens with Labels one below the other</h1>
     <h2>Click on the model to create distance measurements, with no vertex and edge snapping</h2>
     <p>In this example, we're loading a BIM model from the file system, then creating distance measurements wherever the
-        user clicks on the model with the mouse. However, in this example we can see the X, Y, Z values one under the other.</p>
+        user clicks on the model with the mouse. However, in this example we can see the X, Y, Z values one below the other.</p>
     <h3>Components Used</h3>
     <ul>
         <li>
@@ -171,7 +171,7 @@
 
     const distanceMeasurementsPlugin = new DistanceMeasurementsPlugin(viewer);
 
-    distanceMeasurementsPlugin.labelsOnWires = false; // Changes the labels visibility mode, so one can be under the other.
+    distanceMeasurementsPlugin.defaultLabelsOnWires = false; // Changes the labels visibility mode, so one can be under the other.
 
     distanceMeasurementsPlugin.on("mouseOver", (e) => {
         e.measurement.setHighlighted(true);

--- a/examples/measurement/distance_createWithMouse_labelsNotOnWires.html
+++ b/examples/measurement/distance_createWithMouse_labelsNotOnWires.html
@@ -1,0 +1,302 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>xeokit Example</title>
+    <link href="../css/pageStyle.css" rel="stylesheet"/>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
+
+    <style>
+
+        .viewer-ruler-wire-highlighted {
+            border: 2px solid white !important;
+        }
+
+        .viewer-ruler-label-highlighted {
+            border: 2px solid white !important;
+        }
+
+        .viewer-ruler-dot-highlighted {
+            border: 2px solid white !important;
+        }
+
+        .xeokit-context-menu {
+            font-family: 'Roboto', sans-serif;
+            font-size: 15px;
+            display: none;
+            z-index: 300000;
+            background: rgba(255, 255, 255, 0.46);
+            border: 1px solid black;
+            border-radius: 6px;
+            padding: 0;
+            width: 200px;
+        }
+
+        .xeokit-context-menu ul {
+            list-style: none;
+            margin-left: 0;
+            padding: 0;
+        }
+
+        .xeokit-context-menu ul li {
+            list-style-type: none;
+            padding-left: 10px;
+            padding-right: 20px;
+            padding-top: 4px;
+            padding-bottom: 4px;
+            color: black;
+            border-bottom: 1px solid gray;
+            background: rgba(255, 255, 255, 0.46);
+            cursor: pointer;
+            width: calc(100% - 30px);
+        }
+
+        .xeokit-context-menu ul li:hover {
+            background: black;
+            color: white;
+            font-weight: normal;
+        }
+
+        .xeokit-context-menu ul li span {
+            display: inline-block;
+        }
+
+        .xeokit-context-menu .disabled {
+            display: inline-block;
+            color: gray;
+            cursor: default;
+            font-weight: normal;
+        }
+
+        .xeokit-context-menu .disabled:hover {
+            color: gray;
+            cursor: default;
+            background: #eeeeee;
+            font-weight: normal;
+        }
+
+    </style>
+</head>
+<body>
+<input type="checkbox" id="info-button"/>
+<label for="info-button" class="info-button"><i class="far fa-3x fa-question-circle"></i></label>
+<canvas id="myCanvas"></canvas>
+<div class="slideout-sidebar">
+    <img class="info-icon" src="../../assets/images/measure_distance_icon.png"/>
+    <h1>DistanceMeasurementPlugin with DistanceMeasurementsMouseControl and PointerLens with Labels one under the other</h1>
+    <h2>Click on the model to create distance measurements, with no vertex and edge snapping</h2>
+    <p>In this example, we're loading a BIM model from the file system, then creating distance measurements wherever the
+        user clicks on the model with the mouse. However, in this example we can see the X, Y, Z values one under the other.</p>
+    <h3>Components Used</h3>
+    <ul>
+        <li>
+            <a href="../../docs/class/src/viewer/Viewer.js~Viewer.html"
+               target="_other">Viewer</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsPlugin.js~DistanceMeasurementsPlugin.html"
+               target="_other">DistanceMeasurementsPlugin</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsMouseControl.js~DistanceMeasurementsMouseControl.html"
+               target="_other">DistanceMeasurementsMouseControl</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/extras/PointerLens/PointerLens.js~PointerLens.html"
+               target="_other">PointerLens</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js~XKTLoaderPlugin.html"
+               target="_other">XKTLoaderPlugin</a>
+        </li>
+    </ul>
+    <h3>Tutorials</h3>
+    <ul>
+        <li>
+            <a href="https://www.notion.so/xeokit/Accurate-Measurements-with-Snapping-5e6606afef20428f9b319ea0e82270f9"
+               target="_other">Accurate Measurements with Snapping</a>
+        </li>
+    </ul>
+    <h3>Assets</h3>
+    <ul>
+        <li>
+            <a href="http://openifcmodel.cs.auckland.ac.nz/Model/Details/274"
+               target="_other">Model source</a>
+        </li>
+    </ul>
+</div>
+</body>
+<script type="module">
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Import the modules we need for this example
+    //------------------------------------------------------------------------------------------------------------------
+
+    import {Viewer, XKTLoaderPlugin, ContextMenu, DistanceMeasurementsPlugin, DistanceMeasurementsMouseControl, PointerLens} from "../../dist/xeokit-sdk.es.js";
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a Viewer and arrange the camera
+    //------------------------------------------------------------------------------------------------------------------
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas",
+        dtxEnabled: true
+    });
+
+    viewer.camera.eye = [-3.93, 2.85, 27.01];
+    viewer.camera.look = [4.40, 3.72, 8.89];
+    viewer.camera.up = [-0.01, 0.99, 0.039];
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Load a model
+    //------------------------------------------------------------------------------------------------------------------
+
+    const xktLoader = new XKTLoaderPlugin(viewer);
+
+    const sceneModel = xktLoader.load({
+        id: "myModel",
+        src: "../../assets/models/xkt/v10/glTF-Embedded/Duplex_A_20110505.glTFEmbedded.xkt",
+        edges: true
+    });
+
+    sceneModel.on("loaded", ()=>{
+        viewer.cameraFlight.jumpTo(sceneModel);
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // DistanceMeasurementsPlugin, DistanceMeasurementsMouseControl and PointerLens
+    //------------------------------------------------------------------------------------------------------------------
+
+    const distanceMeasurementsPlugin = new DistanceMeasurementsPlugin(viewer);
+
+    distanceMeasurementsPlugin.labelsOnWires = false; // Changes the labels visibility mode, so one can be under the other.
+
+    distanceMeasurementsPlugin.on("mouseOver", (e) => {
+        e.measurement.setHighlighted(true);
+    });
+
+    distanceMeasurementsPlugin.on("mouseLeave", (e) => {
+        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.measurement.id === e.measurement.id) {
+            return;
+        }
+        e.measurement.setHighlighted(false);
+    });
+
+    const distanceMeasurementsMouseControl  = new DistanceMeasurementsMouseControl(distanceMeasurementsPlugin, {
+        pointerLens : new PointerLens(viewer)
+    })
+
+    distanceMeasurementsMouseControl.snapping = true;
+
+    distanceMeasurementsMouseControl.activate();
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a context menu to delete and configure measurements
+    //------------------------------------------------------------------------------------------------------------------
+
+    const distanceMeasurementsContextMenu = new ContextMenu({
+        items: [
+            [
+                {
+                    title: "Clear",
+                    doAction: function (context) {
+                        context.distanceMeasurement.destroy();
+                    }
+                },
+                {
+                    getTitle: (context) => {
+                        return context.distanceMeasurement.axisVisible ? "Hide Axis" : "Show Axis";
+                    },
+                    doAction: function (context) {
+                        context.distanceMeasurement.axisVisible = !context.distanceMeasurement.axisVisible;
+                    }
+                },
+                {
+                    getTitle: (context) => {
+                        return context.distanceMeasurement.labelsVisible ? "Hide Labels" : "Show Labels";
+                    },
+                    doAction: function (context) {
+                        context.distanceMeasurement.labelsVisible = !context.distanceMeasurement.labelsVisible;
+                    }
+                }
+            ], [
+                {
+                    title: "Clear All",
+                    getEnabled: function (context) {
+                        return (Object.keys(context.distanceMeasurementsPlugin.measurements).length > 0);
+                    },
+                    doAction: function (context) {
+                        context.distanceMeasurementsPlugin.clear();
+                    }
+                }
+            ]
+        ]
+    });
+
+    distanceMeasurementsContextMenu.on("hidden", () => {
+        if (distanceMeasurementsContextMenu.context.distanceMeasurement) {
+            distanceMeasurementsContextMenu.context.distanceMeasurement.setHighlighted(false);
+        }
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a context menu to activate and deactivate the control
+    //------------------------------------------------------------------------------------------------------------------
+
+    const canvasContextMenu = new ContextMenu({
+        enabled: true,
+        context: {
+            viewer: viewer
+        },
+        items: [
+            [
+                {
+                    getTitle: (context) => {
+                        return distanceMeasurementsPlugin.control.active ? "Deactivate Control" : "Activate Control";
+                    },
+                    doAction: function (context) {
+                        distanceMeasurementsPlugin.control.active
+                            ? distanceMeasurementsPlugin.control.deactivate()
+                            : distanceMeasurementsPlugin.control.activate();
+                    }
+                }
+            ]
+        ]
+    });
+
+    // viewer.cameraControl.on("rightClick", function (e) {
+    //     canvasContextMenu.show(e.pagePos[0], e.pagePos[1]);
+    //     e.event.preventDefault();
+    // });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create an DistanceMeasurementsPlugin, activate its DistanceMeasuremntsControl
+    //------------------------------------------------------------------------------------------------------------------
+
+    distanceMeasurementsPlugin.on("mouseOver", (e) => {
+        e.distanceMeasurement.setHighlighted(true);
+    });
+
+    distanceMeasurementsPlugin.on("mouseLeave", (e) => {
+        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.distanceMeasurement.id === e.distanceMeasurement.id) {
+            return;
+        }
+        e.distanceMeasurement.setHighlighted(false);
+    });
+
+    distanceMeasurementsPlugin.on("contextMenu", (e) => {
+        distanceMeasurementsContextMenu.context = { // Must set context before showing menu
+            viewer: viewer,
+            distanceMeasurementsPlugin: distanceMeasurementsPlugin,
+            distanceMeasurement: e.distanceMeasurement
+        };
+        distanceMeasurementsContextMenu.show(e.event.clientX, e.event.clientY);
+        e.event.preventDefault();
+    });
+
+    window.viewer = viewer;
+
+</script>
+</html>

--- a/examples/measurement/distance_modelWithMeasurements.html
+++ b/examples/measurement/distance_modelWithMeasurements.html
@@ -275,7 +275,8 @@
                 worldPos: [5.2587011937829935, 0.07359975878555769, 17.844586643910404]
             },
             visible: true,
-            wireVisible: true
+            wireVisible: true,
+            labelsOnWires: false,
         });
     });
 

--- a/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
+++ b/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
@@ -241,7 +241,7 @@ class DistanceMeasurement extends Component {
         this._zAxisVisible = false;
         this._axisEnabled = true;
         this._labelsVisible = false;
-        this._labelsOnWires = true;
+        this._labelsOnWires = false;
         this._clickable = false;
 
         this._originMarker.on("worldPos", (value) => {
@@ -893,6 +893,7 @@ class DistanceMeasurement extends Component {
      * @type {Boolean}
      */
     set labelsOnWires(value) {
+        value = value !== undefined ? Boolean(value) : this.plugin.defaultLabelsOnWires;
         this._labelsOnWires = value;
     }
 

--- a/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
+++ b/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
@@ -241,6 +241,7 @@ class DistanceMeasurement extends Component {
         this._zAxisVisible = false;
         this._axisEnabled = true;
         this._labelsVisible = false;
+        this._labelsOnWires = true;
         this._clickable = false;
 
         this._originMarker.on("worldPos", (value) => {
@@ -300,6 +301,7 @@ class DistanceMeasurement extends Component {
         this.yAxisVisible = cfg.yAxisVisible;
         this.zAxisVisible = cfg.zAxisVisible;
         this.labelsVisible = cfg.labelsVisible;
+        this.labelsOnWires = cfg.labelsOnWires;
     }
 
     _update() {
@@ -451,9 +453,19 @@ class DistanceMeasurement extends Component {
 
                 this._lengthLabel.setPosOnWire(cp[0], cp[1], cp[6], cp[7]);
 
-                this._xAxisLabel.setPosOnWire(cp[0], cp[1], cp[2], cp[3]);
-                this._yAxisLabel.setPosOnWire(cp[2], cp[3], cp[4], cp[5]);
-                this._zAxisLabel.setPosOnWire(cp[4], cp[5], cp[6], cp[7]);
+                if (this.labelsOnWires) {
+                    this._xAxisLabel.setPosOnWire(cp[0], cp[1], cp[2], cp[3]);
+                    this._yAxisLabel.setPosOnWire(cp[2], cp[3], cp[4], cp[5]);
+                    this._zAxisLabel.setPosOnWire(cp[4], cp[5], cp[6], cp[7]);
+                } else {
+                    const labelOffset = 35;
+                    let currentLabelOffset = labelOffset;
+                    this._xAxisLabel.setPosOnWire(cp[0], cp[1] + currentLabelOffset, cp[6], cp[7] + currentLabelOffset);
+                    currentLabelOffset += labelOffset;
+                    this._yAxisLabel.setPosOnWire(cp[0], cp[1] + currentLabelOffset, cp[6], cp[7] + currentLabelOffset);
+                    currentLabelOffset += labelOffset;
+                    this._zAxisLabel.setPosOnWire(cp[0], cp[1] + currentLabelOffset, cp[6], cp[7] + currentLabelOffset);
+                }
 
                 const tilde = this._approximate ? " ~ " : " = ";
 
@@ -466,9 +478,15 @@ class DistanceMeasurement extends Component {
 
                 const labelMinAxisLength = this.plugin.labelMinAxisLength;
 
-                this._xAxisLabelCulled = (xAxisCanvasLength < labelMinAxisLength);
-                this._yAxisLabelCulled = (yAxisCanvasLength < labelMinAxisLength);
-                this._zAxisLabelCulled = (zAxisCanvasLength < labelMinAxisLength);
+                if (this.labelsOnWires){
+                    this._xAxisLabelCulled = (xAxisCanvasLength < labelMinAxisLength);
+                    this._yAxisLabelCulled = (yAxisCanvasLength < labelMinAxisLength);
+                    this._zAxisLabelCulled = (zAxisCanvasLength < labelMinAxisLength);
+                } else {
+                    this._xAxisLabelCulled = false;
+                    this._yAxisLabelCulled = false;
+                    this._zAxisLabelCulled = false;
+                }
 
                 if (!this._xAxisLabelCulled) {
                     this._xAxisLabel.setText(tilde + Math.abs((this._targetWorld[0] - this._originWorld[0]) * scale).toFixed(2) + unitAbbrev);
@@ -867,6 +885,24 @@ class DistanceMeasurement extends Component {
      */
     get labelsVisible() {
         return this._labelsVisible;
+    }
+
+    /**
+     * Sets if labels should be positioned on the wires.
+     *
+     * @type {Boolean}
+     */
+    set labelsOnWires(value) {
+        this._labelsOnWires = value;
+    }
+
+    /**
+     * Gets if labels should be positioned on the wires.
+     *
+     * @type {Boolean}
+     */
+    get labelsOnWires() {
+        return this._labelsOnWires;
     }
 
     /**

--- a/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsPlugin.js
+++ b/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsPlugin.js
@@ -242,6 +242,7 @@ class DistanceMeasurementsPlugin extends Plugin {
      * @param {boolean} [cfg.defaultZAxisVisible=true] The default value of the DistanceMeasurements `zAxisVisible` property.
      * @param {string} [cfg.defaultColor=#00BBFF] The default color of the length dots, wire and label.
      * @param {number} [cfg.zIndex] If set, the wires, dots and labels will have this zIndex (+1 for dots and +2 for labels).
+     * @param {boolean} [cfg.labelsOnWires=true] If true = labels will be set on wires, false = labels will be set one above the other.
      * @param {PointerCircle} [cfg.pointerLens] A PointerLens to help the user position the pointer. This can be shared with other plugins.
      */
     constructor(viewer, cfg = {}) {
@@ -269,6 +270,7 @@ class DistanceMeasurementsPlugin extends Plugin {
         this.defaultZAxisVisible = cfg.defaultZAxisVisible !== false;
         this.defaultColor = cfg.defaultColor !== undefined ? cfg.defaultColor : "#00BBFF";
         this.zIndex = cfg.zIndex || 10000;
+        this.labelsOnWires = cfg.labelsOnWires || true;
 
         this._onMouseOver = (event, measurement) => {
             this.fire("mouseOver", {

--- a/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsPlugin.js
+++ b/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsPlugin.js
@@ -242,7 +242,7 @@ class DistanceMeasurementsPlugin extends Plugin {
      * @param {boolean} [cfg.defaultZAxisVisible=true] The default value of the DistanceMeasurements `zAxisVisible` property.
      * @param {string} [cfg.defaultColor=#00BBFF] The default color of the length dots, wire and label.
      * @param {number} [cfg.zIndex] If set, the wires, dots and labels will have this zIndex (+1 for dots and +2 for labels).
-     * @param {boolean} [cfg.labelsOnWires=true] If true = labels will be set on wires, false = labels will be set one above the other.
+     * @param {boolean} [cfg.defaultLabelsOnWires=true] The default value of the DistanceMeasurements `labelsOnWires` property.
      * @param {PointerCircle} [cfg.pointerLens] A PointerLens to help the user position the pointer. This can be shared with other plugins.
      */
     constructor(viewer, cfg = {}) {
@@ -270,7 +270,7 @@ class DistanceMeasurementsPlugin extends Plugin {
         this.defaultZAxisVisible = cfg.defaultZAxisVisible !== false;
         this.defaultColor = cfg.defaultColor !== undefined ? cfg.defaultColor : "#00BBFF";
         this.zIndex = cfg.zIndex || 10000;
-        this.labelsOnWires = cfg.labelsOnWires || true;
+        this.defaultLabelsOnWires = cfg.defaultLabelsOnWires !== false;
 
         this._onMouseOver = (event, measurement) => {
             this.fire("mouseOver", {
@@ -393,6 +393,7 @@ class DistanceMeasurementsPlugin extends Plugin {
      * @param {Boolean} [params.zAxisVisible=true] Whether to initially show the Z-axis-aligned wires between {@link DistanceMeasurement#origin} and {@link DistanceMeasurement#target}.
      * @param {Boolean} [params.labelsVisible=true] Whether to initially show the labels.
      * @param {string} [params.color] The color of the length dot, wire and label.
+     * @param {Boolean} [params.labelsOnWires=true] Determines if labels will be set on wires or one below the other.
      * @returns {DistanceMeasurement} The new {@link DistanceMeasurement}.
      */
     createMeasurement(params = {}) {
@@ -424,6 +425,7 @@ class DistanceMeasurementsPlugin extends Plugin {
             originVisible: params.originVisible,
             targetVisible: params.targetVisible,
             color: params.color,
+            labelsOnWires: params.labelsOnWires !== false && this.defaultLabelsOnWires !== false,
             onMouseOver: this._onMouseOver,
             onMouseLeave: this._onMouseLeave,
             onContextMenu: this._onContextMenu


### PR DESCRIPTION
Related to: https://github.com/xeokit/xeokit-sdk/issues/1065

![2024-02-10_13h37_22](https://github.com/xeokit/xeokit-sdk/assets/47977819/2be9272b-1bb1-4496-b5f4-6eec667b9317)

![2024-02-10_17h48_33](https://github.com/xeokit/xeokit-sdk/assets/47977819/94c67150-a41b-4651-a40b-203595023637)

Few notes:
- update was made in a way to not break existing behaviour. User needs to set labelsOnWires to false to display it in a new way.
- it was made on purpose to display all the time X, Y, Z once we choose to show one label below another one. The other option would be to try to hide the ones that are zero's (same as it is with labelsOnWires), but after experimenting a while with it I choose to stick to showing X, Y, Z no matter of the value. It was a subjective decision, so it can be questionable.
- there are 2 examples updated: 1 new (copy of existing one, but with changed value) and 1 updated (updated one had 2 existing measurements, so I set 1 with new settings).
- d.ts files will be updated once this part will be accepted