### PR TITLE
[FEATURE] Cross section highlight

### DIFF
--- a/examples/slicing/SectionPlanesPlugin_Duplex_SectionPath_CrossSections.html
+++ b/examples/slicing/SectionPlanesPlugin_Duplex_SectionPath_CrossSections.html
@@ -191,7 +191,7 @@
     //------------------------------------------------------------------------------------------------------------------
 
     viewer.scene.crossSections.sliceThickness = 0.05;
-    viewer.scene.crossSections.sliceColor = [1.0, 0.0, 0.0, 1.0];
+    viewer.scene.crossSections.sliceColor = [51/255.0, 51/255.0, 51/255.0, 1.0];
   });
 
 

--- a/examples/slicing/SectionPlanesPlugin_Duplex_SectionPath_CrossSections.html
+++ b/examples/slicing/SectionPlanesPlugin_Duplex_SectionPath_CrossSections.html
@@ -191,7 +191,7 @@
     //------------------------------------------------------------------------------------------------------------------
 
     viewer.scene.crossSections.sliceThickness = 0.05;
-    viewer.scene.crossSections.sliceColor = [51/255.0, 51/255.0, 51/255.0, 1.0];
+    viewer.scene.crossSections.sliceColor = [0.0, 0.0, 0.0, 1.0];
   });
 
 

--- a/examples/slicing/SectionPlanesPlugin_Duplex_SectionPath_CrossSections.html
+++ b/examples/slicing/SectionPlanesPlugin_Duplex_SectionPath_CrossSections.html
@@ -1,0 +1,199 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>xeokit Example</title>
+  <link href="../css/pageStyle.css" rel="stylesheet"/>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
+  <style>
+    #sliderContainer {
+      pointer-events: all;
+      height: 100px;
+      /*overflow-y: scroll;*/
+      overflow-x: hidden;
+      position: absolute;
+      bottom: 0;
+      color: black;
+      z-index: 200000;
+      float: left;
+      left: 0;
+      padding-left: 10px;
+      padding-right: 10px;
+      font-family: 'Roboto', sans-serif;
+      font-size: 15px;
+      user-select: none;
+      -ms-user-select: none;
+      -moz-user-select: none;
+      -webkit-user-select: none;
+      width: 95%;
+    }
+    input {
+      vertical-align: middle;
+    }
+    .slider {
+      width: 100%;
+    }
+    #info-button:checked ~ #sliderContainer {
+      width: calc(95% - 400px);
+    }
+  </style>
+</head>
+<body>
+<input type="checkbox" id="info-button"/>
+<label for="info-button" class="info-button"><i class="far fa-3x fa-question-circle"></i></label>
+<canvas id="myCanvas"></canvas>
+<div id="sliderContainer">
+  <label>
+    <input id="section_path" type="range" min="0" max="1" value="0" step="0.0001" class="slider">
+  </label>
+</div>
+<div class="slideout-sidebar">
+  <img class="info-icon" src="../../assets/images/section_plane_icon.png"/>
+  <h1>SectionPlanesPlugin_Duplex_SectionPath_CrossSections</h1>
+  <h2>Slices models open to reveal internal structures along the path</h2>
+  <p>In this example, we're loading an IFC2x3 BIM model from the file system, then slicing it with a section
+    plane and controlling it via slider along the section path.</p>
+  <h3>Stats</h3>
+  <ul>
+    <li>
+      <div id="time">Loading JavaScript modules...</div>
+    </li>
+  </ul>
+  <h3>Components used</h3>
+  <ul>
+    <li>
+      <a href="../../docs/class/src/viewer/Viewer.js~Viewer.html"
+         target="_other">Viewer</a>
+    </li>
+    <li>
+      <a href="../../docs/class/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js~XKTLoaderPlugin.html"
+         target="_other">XKTLoaderPlugin</a>
+    </li>
+    <li>
+      <a href="../../docs/class/src/plugins/SectionPlanesPlugin/SectionPlanesPlugin.js~SectionPlanesPlugin.html"
+         target="_other">SectionPlanesPlugin</a>
+    </li>
+  </ul>
+  <h3>Resources</h3>
+  <ul>
+    <li>
+      <a href="http://openifcmodel.cs.auckland.ac.nz/Model/Details/274"
+         target="_other">Model source</a>
+    </li>
+  </ul>
+</div>
+</body>
+
+<script type="module">
+
+  //------------------------------------------------------------------------------------------------------------------
+  // Import the modules we need for this example
+  //------------------------------------------------------------------------------------------------------------------
+
+  import {PhongMaterial, Viewer, math, SectionPlanesPlugin, XKTLoaderPlugin, Mesh, ReadableGeometry, buildPolylineGeometryFromCurve, SplineCurve} from "../../dist/xeokit-sdk.es.js";
+
+  //------------------------------------------------------------------------------------------------------------------
+  // Create a Viewer and arrange the camera
+  //------------------------------------------------------------------------------------------------------------------
+
+  const viewer = new Viewer({
+    canvasId: "myCanvas",
+    transparent: true
+  });
+
+  viewer.camera.eye = [-2.341298674548419, 22.43987089731119, 7.236688436028655];
+  viewer.camera.look = [4.399999999999963, 3.7240000000000606, 8.899000000000006];
+  viewer.camera.up = [0.9102954845584759, 0.34781746407929504, 0.22446635042673466];
+
+  const cameraControl = viewer.cameraControl;
+  cameraControl.navMode = "orbit";
+  cameraControl.followPointer = true;
+
+  //----------------------------------------------------------------------------------------------------------------------
+  // Create a xeokit loader plugin, load a model, fit to view
+  //----------------------------------------------------------------------------------------------------------------------
+
+  const xktLoader = new XKTLoaderPlugin(viewer);
+
+  var t0 = performance.now();
+
+  document.getElementById("time").innerHTML = "Loading model...";
+
+  const sceneModel = xktLoader.load({
+    id: "myModel",
+    src: "../../assets/models/xkt/v10/glTF-Embedded/Duplex_A_20110505.glTFEmbedded.xkt",
+    edges: true
+  });
+
+  sceneModel.on("loaded", () => {
+    var t1 = performance.now();
+    document.getElementById("time").innerHTML = "Model loaded in " + Math.floor(t1 - t0) / 1000.0 + " seconds<br>Objects: " + sceneModel.numEntities;
+
+    let path = new SplineCurve(viewer.scene, {
+      points: [
+        [0, 0, -10],
+        [0, 0, -3],
+        [10, 0, 10],
+        [10, 0, 30],
+      ],
+    });
+
+    new Mesh(viewer.scene, {
+      geometry: new ReadableGeometry(viewer.scene, buildPolylineGeometryFromCurve({
+        id: "SplineCurve",
+        curve: path,
+        divisions: 50,
+      })),
+      material: new PhongMaterial(viewer.scene, {
+        emissive: [1, 0, 0]
+      })
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a moving SectionPlane, that moves through the table models
+    //------------------------------------------------------------------------------------------------------------------
+
+    const sectionPlanes = new SectionPlanesPlugin(viewer, {
+      overviewCanvasId: "mySectionPlanesOverviewCanvas",
+      overviewVisible: true
+    });
+
+    let currentPoint = path.getPoint(0);
+    let currentDirection = path.getTangent(0);
+
+    const sectionPlane = sectionPlanes.createSectionPlane({
+      id: "mySectionPlane",
+      pos: currentPoint,
+      dir: currentDirection
+    });
+
+    sectionPlanes.showControl(sectionPlane.id);
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Controlling SectionPlane position and direction
+    //------------------------------------------------------------------------------------------------------------------
+
+    let currentT = 0.0;
+    document.getElementById("section_path").oninput = function() {
+      currentT = Number(document.getElementById("section_path").value);
+      currentPoint = path.getPoint(currentT);
+      currentDirection = path.getTangent(currentT);
+      sectionPlane.pos = currentPoint;
+      sectionPlane.dir = currentDirection;
+    };
+
+    window.viewer = viewer;
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Controlling CrossSections settings
+    //------------------------------------------------------------------------------------------------------------------
+
+    viewer.scene.crossSections.sliceThickness = 0.05;
+    viewer.scene.crossSections.sliceColor = [1.0, 0.0, 0.0, 1.0];
+  });
+
+
+</script>
+</html>

--- a/src/viewer/scene/model/vbo/VBORenderer.js
+++ b/src/viewer/scene/model/vbo/VBORenderer.js
@@ -117,6 +117,10 @@ export class VBORenderer {
             const sectionPlanes = scene._sectionPlanesState.sectionPlanes;
             const baseIndex = layerIndex * numSectionPlanes;
             const renderFlags = model.renderFlags;
+            if (scene.crossSections) {
+                gl.uniform4fv(this._uSliceColor, scene.crossSections.sliceColor);
+                gl.uniform1f(this._uSliceThickness, scene.crossSections.sliceThickness);
+            }
             for (let sectionPlaneIndex = 0; sectionPlaneIndex < numAllocatedSectionPlanes; sectionPlaneIndex++) {
                 const sectionPlaneUniforms = this._uSectionPlanes[sectionPlaneIndex];
                 if (sectionPlaneUniforms) {
@@ -278,6 +282,11 @@ export class VBORenderer {
 
         this._uPointSize = program.getLocation("pointSize");
         this._uNearPlaneHeight = program.getLocation("nearPlaneHeight");
+
+        if (scene.crossSections) {
+            this._uSliceColor = program.getLocation("sliceColor");
+            this._uSliceThickness = program.getLocation("sliceThickness");
+        }
     }
 
     _bindProgram(frameCtx) {

--- a/src/viewer/scene/model/vbo/batching/triangles/renderers/EdgesColorRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/renderers/EdgesColorRenderer.js
@@ -105,15 +105,11 @@ export class EdgesColorRenderer extends EdgesRenderer {
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
                 src.push("uniform vec3 sectionPlaneDir" + i + ";");
             }
-            src.push("uniform float sliceThickness;");
-            src.push("uniform vec4 sliceColor;");
         }
         src.push("in vec4 vColor;");
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
-            src.push("  vec4 newColor;");
-            src.push("  newColor = vColor;");
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
@@ -122,12 +118,7 @@ export class EdgesColorRenderer extends EdgesRenderer {
                 src.push("   dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
                 src.push("}");
             }
-            src.push("  if (dist > sliceThickness) { ");
-            src.push("      discard;")
-            src.push("  }");
-            src.push("  if (dist > 0.0) { ");
-            src.push("      newColor = sliceColor;");
-            src.push("  }");
+            src.push("  if (dist > 0.0) { discard; }");
             src.push("}");
         }
         if (scene.logarithmicDepthBufferEnabled) {

--- a/src/viewer/scene/model/vbo/batching/triangles/renderers/EdgesColorRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/renderers/EdgesColorRenderer.js
@@ -67,7 +67,7 @@ export class EdgesColorRenderer extends EdgesRenderer {
 
         src.push("vec4 clipPos = projMatrix * viewPosition;");
         if (scene.logarithmicDepthBufferEnabled) {
-           src.push("vFragDepth = 1.0 + clipPos.w;");
+            src.push("vFragDepth = 1.0 + clipPos.w;");
             src.push("isPerspective = float (isPerspectiveMatrix(projMatrix));");
         }
         src.push("gl_Position = clipPos;");
@@ -105,11 +105,15 @@ export class EdgesColorRenderer extends EdgesRenderer {
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
                 src.push("uniform vec3 sectionPlaneDir" + i + ";");
             }
+            src.push("uniform float sliceThickness;");
+            src.push("uniform vec4 sliceColor;");
         }
         src.push("in vec4 vColor;");
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
+            src.push("  vec4 newColor;");
+            src.push("  newColor = vColor;");
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
@@ -118,7 +122,12 @@ export class EdgesColorRenderer extends EdgesRenderer {
                 src.push("   dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
                 src.push("}");
             }
-            src.push("  if (dist > 0.0) { discard; }");
+            src.push("  if (dist > sliceThickness) { ");
+            src.push("      discard;")
+            src.push("  }");
+            src.push("  if (dist > 0.0) { ");
+            src.push("      newColor = sliceColor;");
+            src.push("  }");
             src.push("}");
         }
         if (scene.logarithmicDepthBufferEnabled) {

--- a/src/viewer/scene/model/vbo/batching/triangles/renderers/EdgesEmphasisRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/renderers/EdgesEmphasisRenderer.js
@@ -1,5 +1,5 @@
 import {TrianglesBatchingRenderer} from "./TrianglesBatchingRenderer.js";
-import {EdgesRenderer} from "./EdgesRenderer";
+import {EdgesRenderer} from "./EdgesRenderer.js";
 
 
 /**
@@ -71,7 +71,7 @@ export class EdgesEmphasisRenderer extends EdgesRenderer {
 
         src.push("vec4 clipPos = projMatrix * viewPosition;");
         if (scene.logarithmicDepthBufferEnabled) {
-           src.push("vFragDepth = 1.0 + clipPos.w;");
+            src.push("vFragDepth = 1.0 + clipPos.w;");
             src.push("isPerspective = float (isPerspectiveMatrix(projMatrix));");
         }
         src.push("gl_Position = clipPos;");
@@ -88,7 +88,7 @@ export class EdgesEmphasisRenderer extends EdgesRenderer {
         const src = [];
         src.push("#version 300 es");
         src.push("// EdgesEmphasisRenderer fragment shader");
-        
+
         src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
         src.push("precision highp float;");
         src.push("precision highp int;");
@@ -109,11 +109,16 @@ export class EdgesEmphasisRenderer extends EdgesRenderer {
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
                 src.push("uniform vec3 sectionPlaneDir" + i + ";");
             }
+            src.push("uniform float sliceThickness;");
+            src.push("uniform vec4 sliceColor;");
         }
         src.push("in vec4 vColor;");
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
+            console.log("Edges renderer with clipping");
+            src.push("  vec4 newColor;");
+            src.push("  newColor = vColor;");
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
@@ -122,7 +127,12 @@ export class EdgesEmphasisRenderer extends EdgesRenderer {
                 src.push("   dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
                 src.push("}");
             }
-            src.push("  if (dist > 0.0) { discard; }");
+            src.push("  if (dist > sliceThickness) { ");
+            src.push("      discard;")
+            src.push("  }");
+            src.push("  if (dist > 0.0) { ");
+            src.push("      newColor = sliceColor;");
+            src.push("  }");
             src.push("}");
         }
         if (scene.logarithmicDepthBufferEnabled) {

--- a/src/viewer/scene/model/vbo/batching/triangles/renderers/EdgesEmphasisRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/renderers/EdgesEmphasisRenderer.js
@@ -116,7 +116,6 @@ export class EdgesEmphasisRenderer extends EdgesRenderer {
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
-            console.log("Edges renderer with clipping");
             src.push("  vec4 newColor;");
             src.push("  newColor = vColor;");
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");

--- a/src/viewer/scene/model/vbo/batching/triangles/renderers/EdgesEmphasisRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/renderers/EdgesEmphasisRenderer.js
@@ -109,15 +109,11 @@ export class EdgesEmphasisRenderer extends EdgesRenderer {
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
                 src.push("uniform vec3 sectionPlaneDir" + i + ";");
             }
-            src.push("uniform float sliceThickness;");
-            src.push("uniform vec4 sliceColor;");
         }
         src.push("in vec4 vColor;");
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
-            src.push("  vec4 newColor;");
-            src.push("  newColor = vColor;");
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
@@ -126,12 +122,7 @@ export class EdgesEmphasisRenderer extends EdgesRenderer {
                 src.push("   dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
                 src.push("}");
             }
-            src.push("  if (dist > sliceThickness) { ");
-            src.push("      discard;")
-            src.push("  }");
-            src.push("  if (dist > 0.0) { ");
-            src.push("      newColor = sliceColor;");
-            src.push("  }");
+            src.push("  if (dist > 0.0) { discard; }");
             src.push("}");
         }
         if (scene.logarithmicDepthBufferEnabled) {

--- a/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesColorRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesColorRenderer.js
@@ -194,6 +194,8 @@ export class TrianglesColorRenderer extends TrianglesBatchingRenderer {
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
                 src.push("uniform vec3 sectionPlaneDir" + i + ";");
             }
+            src.push("uniform float sliceThickness;");
+            src.push("uniform vec4 sliceColor;");
         }
         src.push("in vec4 vColor;");
         src.push("out vec4 outColor;");
@@ -210,14 +212,11 @@ export class TrianglesColorRenderer extends TrianglesBatchingRenderer {
                 src.push("   dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
                 src.push("}");
             }
-            src.push("  if (dist > " + scene.crossSections.sliceThickness.toPrecision(6) + ") { ");
+            src.push("  if (dist > sliceThickness) { ");
             src.push("      discard;")
             src.push("  }");
             src.push("  if (dist > 0.0) { ");
-            src.push("      newColor = vec4(" + scene.crossSections.sliceColor[0].toPrecision(6) + ", "
-                + scene.crossSections.sliceColor[1].toPrecision(6) + ", "
-                + scene.crossSections.sliceColor[2].toPrecision(6) + ", "
-                + scene.crossSections.sliceColor[3].toPrecision(6) + ");");
+            src.push("      newColor = sliceColor;");
             src.push("  }");
             src.push("}");
         }

--- a/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesColorRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesColorRenderer.js
@@ -200,10 +200,9 @@ export class TrianglesColorRenderer extends TrianglesBatchingRenderer {
         src.push("in vec4 vColor;");
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
-
+        src.push("  vec4 newColor;");
+        src.push("  newColor = vColor;");
         if (clipping) {
-            src.push("  vec4 newColor;");
-            src.push("  newColor = vColor;");
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");

--- a/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesColorRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesColorRenderer.js
@@ -200,7 +200,6 @@ export class TrianglesColorRenderer extends TrianglesBatchingRenderer {
         src.push("void main(void) {");
 
         if (clipping) {
-            console.log("Triangles renderer with clipping");
             src.push("  vec4 newColor;");
             src.push("  newColor = vColor;");
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
@@ -211,11 +210,14 @@ export class TrianglesColorRenderer extends TrianglesBatchingRenderer {
                 src.push("   dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
                 src.push("}");
             }
-            src.push("  if (dist > 0.1) { ");
+            src.push("  if (dist > " + scene.crossSections.sliceThickness.toPrecision(6) + ") { ");
             src.push("      discard;")
             src.push("  }");
             src.push("  if (dist > 0.0) { ");
-            src.push("      newColor = vec4(0.0, 0.0, 0.0, 1.0);");
+            src.push("      newColor = vec4(" + scene.crossSections.sliceColor[0].toPrecision(6) + ", "
+                + scene.crossSections.sliceColor[1].toPrecision(6) + ", "
+                + scene.crossSections.sliceColor[2].toPrecision(6) + ", "
+                + scene.crossSections.sliceColor[3].toPrecision(6) + ");");
             src.push("  }");
             src.push("}");
         }

--- a/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesColorRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesColorRenderer.js
@@ -139,7 +139,7 @@ export class TrianglesColorRenderer extends TrianglesBatchingRenderer {
 
         src.push("vec4 clipPos = projMatrix * viewPosition;");
         if (scene.logarithmicDepthBufferEnabled) {
-           src.push("vFragDepth = 1.0 + clipPos.w;");
+            src.push("vFragDepth = 1.0 + clipPos.w;");
             src.push("isPerspective = float (isPerspectiveMatrix(projMatrix));");
         }
         if (clipping) {
@@ -200,6 +200,9 @@ export class TrianglesColorRenderer extends TrianglesBatchingRenderer {
         src.push("void main(void) {");
 
         if (clipping) {
+            console.log("Triangles renderer with clipping");
+            src.push("  vec4 newColor;");
+            src.push("  newColor = vColor;");
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
@@ -208,9 +211,12 @@ export class TrianglesColorRenderer extends TrianglesBatchingRenderer {
                 src.push("   dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
                 src.push("}");
             }
-                src.push("  if (dist > 0.0) { ");
-                src.push("      discard;")
-                src.push("  }");
+            src.push("  if (dist > 0.1) { ");
+            src.push("      discard;")
+            src.push("  }");
+            src.push("  if (dist > 0.0) { ");
+            src.push("      newColor = vec4(0.0, 0.0, 0.0, 1.0);");
+            src.push("  }");
             src.push("}");
         }
 
@@ -227,9 +233,9 @@ export class TrianglesColorRenderer extends TrianglesBatchingRenderer {
             src.push("   float blendFactor       = uSAOParams[3];");
             src.push("   vec2 uv                 = vec2(gl_FragCoord.x / viewportWidth, gl_FragCoord.y / viewportHeight);");
             src.push("   float ambient           = smoothstep(blendCutoff, 1.0, unpackRGBToFloat(texture(uOcclusionTexture, uv))) * blendFactor;");
-            src.push("   outColor            = vec4(vColor.rgb * ambient, 1.0);");
+            src.push("   outColor            = vec4(newColor.rgb * ambient, 1.0);");
         } else {
-            src.push("   outColor            = vColor;");
+            src.push("   outColor            = newColor;");
         }
 
         src.push("}");

--- a/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesColorTextureRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesColorTextureRenderer.js
@@ -150,6 +150,8 @@ export class TrianglesColorTextureRenderer extends TrianglesBatchingRenderer {
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
                 src.push("uniform vec3 sectionPlaneDir" + i + ";");
             }
+            src.push("uniform float sliceThickness;");
+            src.push("uniform vec4 sliceColor;");
         }
         this._addMatricesUniformBlockLines(src);
         src.push("uniform vec4 lightAmbient;");
@@ -179,6 +181,8 @@ export class TrianglesColorTextureRenderer extends TrianglesBatchingRenderer {
         src.push("void main(void) {");
 
         if (clipping) {
+            src.push("  vec4 newColor;");
+            src.push("  newColor = vColor;");
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
@@ -187,8 +191,11 @@ export class TrianglesColorTextureRenderer extends TrianglesBatchingRenderer {
                 src.push("   dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
                 src.push("}");
             }
-            src.push("  if (dist > 0.0) { ");
+            src.push("  if (dist > sliceThickness) { ");
             src.push("      discard;")
+            src.push("  }");
+            src.push("  if (dist > 0.0) { ");
+            src.push("      newColor = sliceColor;");
             src.push("  }");
             src.push("}");
         }

--- a/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesColorTextureRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesColorTextureRenderer.js
@@ -240,7 +240,7 @@ export class TrianglesColorTextureRenderer extends TrianglesBatchingRenderer {
             src.push("reflectedColor += lambertian * (lightColor" + i + ".rgb * lightColor" + i + ".a);");
         }
 
-        src.push("vec4 color =  vec4((lightAmbient.rgb * lightAmbient.a * vColor.rgb) + (reflectedColor * vColor.rgb), vColor.a);");
+        src.push("vec4 color =  vec4((lightAmbient.rgb * lightAmbient.a * newColor.rgb) + (reflectedColor * newColor.rgb), newColor.a);");
         if (gammaOutput) {
             src.push("vec4 colorTexel = color * sRGBToLinear(texture(uColorMap, vUV));");
         } else {

--- a/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesColorTextureRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesColorTextureRenderer.js
@@ -179,10 +179,9 @@ export class TrianglesColorTextureRenderer extends TrianglesBatchingRenderer {
         src.push("out vec4 outColor;");
 
         src.push("void main(void) {");
-
+        src.push("  vec4 newColor;");
+        src.push("  newColor = vColor;");
         if (clipping) {
-            src.push("  vec4 newColor;");
-            src.push("  newColor = vColor;");
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");

--- a/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesFlatColorRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesFlatColorRenderer.js
@@ -125,6 +125,8 @@ export class TrianglesFlatColorRenderer extends TrianglesBatchingRenderer {
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
                 src.push("uniform vec3 sectionPlaneDir" + i + ";");
             }
+            src.push("uniform float sliceThickness;");
+            src.push("uniform vec4 sliceColor;");
         }
 
         this._addMatricesUniformBlockLines(src);
@@ -155,6 +157,8 @@ export class TrianglesFlatColorRenderer extends TrianglesBatchingRenderer {
         src.push("void main(void) {");
 
         if (clipping) {
+            src.push("  vec4 newColor;");
+            src.push("  newColor = vColor;");
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
@@ -163,8 +167,11 @@ export class TrianglesFlatColorRenderer extends TrianglesBatchingRenderer {
                 src.push("   dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
                 src.push("}");
             }
-            src.push("  if (dist > 0.0) { ");
+            src.push("  if (dist > sliceThickness) { ");
             src.push("      discard;")
+            src.push("  }");
+            src.push("  if (dist > 0.0) { ");
+            src.push("      newColor = sliceColor;");
             src.push("  }");
             src.push("}");
         }

--- a/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesFlatColorRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesFlatColorRenderer.js
@@ -155,10 +155,9 @@ export class TrianglesFlatColorRenderer extends TrianglesBatchingRenderer {
         src.push("out vec4 outColor;");
 
         src.push("void main(void) {");
-
+        src.push("  vec4 newColor;");
+        src.push("  newColor = vColor;");
         if (clipping) {
-            src.push("  vec4 newColor;");
-            src.push("  newColor = vColor;");
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");

--- a/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesFlatColorRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesFlatColorRenderer.js
@@ -216,7 +216,7 @@ export class TrianglesFlatColorRenderer extends TrianglesBatchingRenderer {
             src.push("reflectedColor += lambertian * (lightColor" + i + ".rgb * lightColor" + i + ".a);");
         }
 
-        src.push("vec4 fragColor =  vec4((lightAmbient.rgb * lightAmbient.a * vColor.rgb) + (reflectedColor * vColor.rgb), vColor.a);");
+        src.push("vec4 fragColor =  vec4((lightAmbient.rgb * lightAmbient.a * newColor.rgb) + (reflectedColor * newColor.rgb), newColor.a);");
 
         if (this._withSAO) {
             // Doing SAO blend in the main solid fill draw shader just so that edge lines can be drawn over the top

--- a/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesSilhouetteRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesSilhouetteRenderer.js
@@ -137,7 +137,7 @@ export class TrianglesSilhouetteRenderer extends TrianglesBatchingRenderer {
         if (scene.logarithmicDepthBufferEnabled) {
             src.push("    gl_FragDepth = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;");
         }
-        src.push("outColor = vColor;");
+        src.push("outColor = newColor;");
         src.push("}");
         return src;
     }

--- a/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesSilhouetteRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesSilhouetteRenderer.js
@@ -115,9 +115,9 @@ export class TrianglesSilhouetteRenderer extends TrianglesBatchingRenderer {
         src.push("in vec4 vColor;");
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
+        src.push("  vec4 newColor;");
+        src.push("  newColor = vColor;");
         if (clipping) {
-            src.push("  vec4 newColor;");
-            src.push("  newColor = vColor;");
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");

--- a/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesSilhouetteRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesSilhouetteRenderer.js
@@ -18,7 +18,7 @@ export class TrianglesSilhouetteRenderer extends TrianglesBatchingRenderer {
         const src = [];
         src.push("#version 300 es");
         src.push("// Triangles batching silhouette vertex shader");
-        
+
         src.push("uniform int renderPass;");
 
         src.push("in vec3 position;");
@@ -70,7 +70,7 @@ export class TrianglesSilhouetteRenderer extends TrianglesBatchingRenderer {
         src.push("vColor = vec4(silhouetteColor.r, silhouetteColor.g, silhouetteColor.b, min(silhouetteColor.a, color.a ));");
         src.push("vec4 clipPos = projMatrix * viewPosition;");
         if (scene.logarithmicDepthBufferEnabled) {
-           src.push("vFragDepth = 1.0 + clipPos.w;");
+            src.push("vFragDepth = 1.0 + clipPos.w;");
             src.push("isPerspective = float (isPerspectiveMatrix(projMatrix));");
         }
         src.push("gl_Position = clipPos;");
@@ -88,7 +88,7 @@ export class TrianglesSilhouetteRenderer extends TrianglesBatchingRenderer {
         const src = [];
         src.push("#version 300 es");
         src.push("// Triangles batching silhouette fragment shader");
-        
+
         src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
         src.push("precision highp float;");
         src.push("precision highp int;");
@@ -109,20 +109,29 @@ export class TrianglesSilhouetteRenderer extends TrianglesBatchingRenderer {
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
                 src.push("uniform vec3 sectionPlaneDir" + i + ";");
             }
+            src.push("uniform float sliceThickness;");
+            src.push("uniform vec4 sliceColor;");
         }
         src.push("in vec4 vColor;");
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
+            src.push("  vec4 newColor;");
+            src.push("  newColor = vColor;");
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
-            for (i = 0, len = sectionPlanesState.getNumAllocatedSectionPlanes(); i < len; i++) {
+            for (let i = 0, len = sectionPlanesState.getNumAllocatedSectionPlanes(); i < len; i++) {
                 src.push("if (sectionPlaneActive" + i + ") {");
                 src.push("   dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
                 src.push("}");
             }
-            src.push("  if (dist > 0.0) { discard; }");
+            src.push("  if (dist > sliceThickness) { ");
+            src.push("      discard;")
+            src.push("  }");
+            src.push("  if (dist > 0.0) { ");
+            src.push("      newColor = sliceColor;");
+            src.push("  }");
             src.push("}");
         }
         if (scene.logarithmicDepthBufferEnabled) {
@@ -133,4 +142,3 @@ export class TrianglesSilhouetteRenderer extends TrianglesBatchingRenderer {
         return src;
     }
 }
-

--- a/src/viewer/scene/model/vbo/instancing/triangles/renderers/EdgesColorRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/renderers/EdgesColorRenderer.js
@@ -109,15 +109,11 @@ export class EdgesColorRenderer extends EdgesRenderer {
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
                 src.push("uniform vec3 sectionPlaneDir" + i + ";");
             }
-            src.push("uniform float sliceThickness;");
-            src.push("uniform vec4 sliceColor;");
         }
         src.push("in vec4 vColor;");
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
-            src.push("  vec4 newColor;");
-            src.push("  newColor = vColor;");
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
@@ -126,12 +122,7 @@ export class EdgesColorRenderer extends EdgesRenderer {
                 src.push("   dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
                 src.push("}");
             }
-            src.push("  if (dist > sliceThickness) { ");
-            src.push("      discard;")
-            src.push("  }");
-            src.push("  if (dist > 0.0) { ");
-            src.push("      newColor = sliceColor;");
-            src.push("  }");
+            src.push("  if (dist > 0.0) { discard; }");
             src.push("}");
         }
         if (scene.logarithmicDepthBufferEnabled) {

--- a/src/viewer/scene/model/vbo/instancing/triangles/renderers/EdgesColorRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/renderers/EdgesColorRenderer.js
@@ -5,10 +5,10 @@ import {EdgesRenderer} from "./EdgesRenderer.js";
  */
 
 
-export class EdgesEmphasisRenderer extends EdgesRenderer {
+export class EdgesColorRenderer extends EdgesRenderer {
 
-    drawLayer(frameCtx, instancingLayer, renderPass) {
-        super.drawLayer(frameCtx, instancingLayer, renderPass, {colorUniform: true});
+    drawLayer(frameCtx, batchingLayer, renderPass) {
+        super.drawLayer(frameCtx, batchingLayer, renderPass, { colorUniform: false });
     }
 
     _buildVertexShader() {
@@ -17,12 +17,11 @@ export class EdgesEmphasisRenderer extends EdgesRenderer {
         const clipping = sectionPlanesState.getNumAllocatedSectionPlanes() > 0;
         const src = [];
         src.push("#version 300 es");
-        src.push("// EdgesEmphasisRenderer vertex shader");
+        src.push("// EdgesColorRenderer vertex shader");
 
         src.push("uniform int renderPass;");
-        src.push("uniform vec4 color;");
-
         src.push("in vec3 position;");
+        src.push("in vec4 color;");
         if (scene.entityOffsetsEnabled) {
             src.push("in vec3 offset;");
         }
@@ -59,9 +58,7 @@ export class EdgesEmphasisRenderer extends EdgesRenderer {
         src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
 
         src.push("} else {");
-
-        src.push("vec4 worldPosition = worldMatrix * positionsDecodeMatrix * vec4(position, 1.0); ");
-
+        src.push("vec4 worldPosition = positionsDecodeMatrix * vec4(position, 1.0); ");
         src.push("worldPosition = worldMatrix * vec4(dot(worldPosition, modelMatrixCol0), dot(worldPosition, modelMatrixCol1), dot(worldPosition, modelMatrixCol2), 1.0);");
         if (scene.entityOffsetsEnabled) {
             src.push("      worldPosition.xyz = worldPosition.xyz + offset;");
@@ -77,7 +74,8 @@ export class EdgesEmphasisRenderer extends EdgesRenderer {
             src.push("isPerspective = float (isPerspectiveMatrix(projMatrix));");
         }
         src.push("gl_Position = clipPos;");
-        src.push("vColor = vec4(color.r, color.g, color.b, color.a);");
+        //   src.push("vColor = vec4(float(color.r-100.0) / 255.0, float(color.g-100.0) / 255.0, float(color.b-100.0) / 255.0, float(color.a) / 255.0);");
+        src.push("vColor = vec4(float(color.r*0.5) / 255.0, float(color.g*0.5) / 255.0, float(color.b*0.5) / 255.0, float(color.a) / 255.0);");
         src.push("}");
         src.push("}");
         return src;
@@ -89,7 +87,7 @@ export class EdgesEmphasisRenderer extends EdgesRenderer {
         const clipping = sectionPlanesState.getNumAllocatedSectionPlanes() > 0;
         const src = [];
         src.push("#version 300 es");
-        src.push("// EdgesEmphasisRenderer fragment shader");
+        src.push("// EdgesColorRenderer fragment shader");
 
         src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
         src.push("precision highp float;");

--- a/src/viewer/scene/model/vbo/instancing/triangles/renderers/EdgesEmphasisRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/renderers/EdgesEmphasisRenderer.js
@@ -111,11 +111,15 @@ export class EdgesEmphasisRenderer extends EdgesRenderer {
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
                 src.push("uniform vec3 sectionPlaneDir" + i + ";");
             }
+            src.push("uniform float sliceThickness;");
+            src.push("uniform vec4 sliceColor;");
         }
         src.push("in vec4 vColor;");
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
+            src.push("  vec4 newColor;");
+            src.push("  newColor = vColor;");
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
@@ -124,7 +128,12 @@ export class EdgesEmphasisRenderer extends EdgesRenderer {
                 src.push("   dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
                 src.push("}");
             }
-            src.push("  if (dist > 0.0) { discard; }");
+            src.push("  if (dist > sliceThickness) { ");
+            src.push("      discard;")
+            src.push("  }");
+            src.push("  if (dist > 0.0) { ");
+            src.push("      newColor = sliceColor;");
+            src.push("  }");
             src.push("}");
         }
         if (scene.logarithmicDepthBufferEnabled) {

--- a/src/viewer/scene/model/vbo/instancing/triangles/renderers/EdgesEmphasisRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/renderers/EdgesEmphasisRenderer.js
@@ -111,15 +111,11 @@ export class EdgesEmphasisRenderer extends EdgesRenderer {
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
                 src.push("uniform vec3 sectionPlaneDir" + i + ";");
             }
-            src.push("uniform float sliceThickness;");
-            src.push("uniform vec4 sliceColor;");
         }
         src.push("in vec4 vColor;");
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
-            src.push("  vec4 newColor;");
-            src.push("  newColor = vColor;");
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
@@ -128,12 +124,7 @@ export class EdgesEmphasisRenderer extends EdgesRenderer {
                 src.push("   dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
                 src.push("}");
             }
-            src.push("  if (dist > sliceThickness) { ");
-            src.push("      discard;")
-            src.push("  }");
-            src.push("  if (dist > 0.0) { ");
-            src.push("      newColor = sliceColor;");
-            src.push("  }");
+            src.push("  if (dist > 0.0) { discard; }");
             src.push("}");
         }
         if (scene.logarithmicDepthBufferEnabled) {

--- a/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesColorRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesColorRenderer.js
@@ -207,12 +207,16 @@ class TrianglesColorRenderer extends TrianglesInstancingRenderer {
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
                 src.push("uniform vec3 sectionPlaneDir" + i + ";");
             }
+            src.push("uniform float sliceThickness;");
+            src.push("uniform vec4 sliceColor;");
         }
         src.push("in vec4 vColor;");
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
 
         if (clipping) {
+            src.push("  vec4 newColor;");
+            src.push("  newColor = vColor;");
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
@@ -221,8 +225,11 @@ class TrianglesColorRenderer extends TrianglesInstancingRenderer {
                 src.push("   dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
                 src.push("}");
             }
-            src.push("  if (dist > 0.0) { ");
+            src.push("  if (dist > sliceThickness) { ");
             src.push("      discard;")
+            src.push("  }");
+            src.push("  if (dist > 0.0) { ");
+            src.push("      newColor = sliceColor;");
             src.push("  }");
             src.push("}");
         }

--- a/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesColorRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesColorRenderer.js
@@ -248,9 +248,9 @@ class TrianglesColorRenderer extends TrianglesInstancingRenderer {
             src.push("   float blendFactor       = uSAOParams[3];");
             src.push("   vec2 uv                 = vec2(gl_FragCoord.x / viewportWidth, gl_FragCoord.y / viewportHeight);");
             src.push("   float ambient           = smoothstep(blendCutoff, 1.0, unpackRGBToFloat(texture(uOcclusionTexture, uv))) * blendFactor;");
-            src.push("   outColor                = vec4(vColor.rgb * ambient, 1.0);");
+            src.push("   outColor                = vec4(newColor.rgb * ambient, 1.0);");
         } else {
-            src.push("    outColor           = vColor;");
+            src.push("    outColor           = newColor;");
         }
         src.push("}");
         return src;

--- a/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesColorRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesColorRenderer.js
@@ -213,10 +213,9 @@ class TrianglesColorRenderer extends TrianglesInstancingRenderer {
         src.push("in vec4 vColor;");
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
-
+        src.push("  vec4 newColor;");
+        src.push("  newColor = vColor;");
         if (clipping) {
-            src.push("  vec4 newColor;");
-            src.push("  newColor = vColor;");
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");

--- a/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesColorTextureRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesColorTextureRenderer.js
@@ -159,6 +159,8 @@ export class TrianglesColorTextureRenderer extends TrianglesInstancingRenderer {
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
                 src.push("uniform vec3 sectionPlaneDir" + i + ";");
             }
+            src.push("uniform float sliceThickness;");
+            src.push("uniform vec4 sliceColor;");
         }
         this._addMatricesUniformBlockLines(src);
 
@@ -189,6 +191,8 @@ export class TrianglesColorTextureRenderer extends TrianglesInstancingRenderer {
         src.push("void main(void) {");
 
         if (clipping) {
+            src.push("  vec4 newColor;");
+            src.push("  newColor = vColor;");
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
@@ -197,8 +201,11 @@ export class TrianglesColorTextureRenderer extends TrianglesInstancingRenderer {
                 src.push("   dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
                 src.push("}");
             }
-            src.push("  if (dist > 0.0) { ");
+            src.push("  if (dist > sliceThickness) { ");
             src.push("      discard;")
+            src.push("  }");
+            src.push("  if (dist > 0.0) { ");
+            src.push("      newColor = sliceColor;");
             src.push("  }");
             src.push("}");
         }

--- a/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesColorTextureRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesColorTextureRenderer.js
@@ -249,7 +249,7 @@ export class TrianglesColorTextureRenderer extends TrianglesInstancingRenderer {
             src.push("reflectedColor += lambertian * (lightColor" + i + ".rgb * lightColor" + i + ".a);");
         }
 
-        src.push("vec4 color =  vec4((lightAmbient.rgb * lightAmbient.a * vColor.rgb) + (reflectedColor * vColor.rgb), vColor.a);");
+        src.push("vec4 color =  vec4((lightAmbient.rgb * lightAmbient.a * newColor.rgb) + (reflectedColor * newColor.rgb), newColor.a);");
         if (gammaOutput) {
             src.push("vec4 colorTexel = color * sRGBToLinear(texture(uColorMap, vUV));");
         } else {
@@ -266,9 +266,9 @@ export class TrianglesColorTextureRenderer extends TrianglesInstancingRenderer {
             src.push("   float blendFactor       = uSAOParams[3];");
             src.push("   vec2 uv                 = vec2(gl_FragCoord.x / viewportWidth, gl_FragCoord.y / viewportHeight);");
             src.push("   float ambient           = smoothstep(blendCutoff, 1.0, unpackRGBToFloat(texture(uOcclusionTexture, uv))) * blendFactor;");
-            src.push("   outColor                = vec4(vColor.rgb * colorTexel.rgb * ambient, opacity);");
+            src.push("   outColor                = vec4(newColor.rgb * colorTexel.rgb * ambient, opacity);");
         } else {
-            src.push("   outColor                = vec4(vColor.rgb * colorTexel.rgb, opacity);");
+            src.push("   outColor                = vec4(newColor.rgb * colorTexel.rgb, opacity);");
         }
 
         if (gammaOutput) {

--- a/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesColorTextureRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesColorTextureRenderer.js
@@ -189,10 +189,9 @@ export class TrianglesColorTextureRenderer extends TrianglesInstancingRenderer {
         src.push("out vec4 outColor;");
 
         src.push("void main(void) {");
-
+        src.push("  vec4 newColor;");
+        src.push("  newColor = vColor;");
         if (clipping) {
-            src.push("  vec4 newColor;");
-            src.push("  newColor = vColor;");
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");

--- a/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesFlatColorRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesFlatColorRenderer.js
@@ -165,10 +165,9 @@ export class TrianglesFlatColorRenderer extends TrianglesInstancingRenderer {
         src.push("out vec4 outColor;");
 
         src.push("void main(void) {");
-
+        src.push("  vec4 newColor;");
+        src.push("  newColor = vColor;");
         if (clipping) {
-            src.push("  vec4 newColor;");
-            src.push("  newColor = vColor;");
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");

--- a/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesFlatColorRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesFlatColorRenderer.js
@@ -18,7 +18,7 @@ export class TrianglesFlatColorRenderer extends TrianglesInstancingRenderer {
         const src = [];
         src.push("#version 300 es");
         src.push("// Instancing geometry flat-shading drawing vertex shader");
-        
+
         src.push("uniform int renderPass;");
 
         src.push("in vec3 position;");
@@ -43,7 +43,7 @@ export class TrianglesFlatColorRenderer extends TrianglesInstancingRenderer {
             src.push("}");
             src.push("out float isPerspective;");
         }
-        
+
         if (clipping) {
             src.push("out vec4 vWorldPosition;");
             src.push("out float vFlags;");
@@ -75,7 +75,7 @@ export class TrianglesFlatColorRenderer extends TrianglesInstancingRenderer {
 
         src.push("vec4 clipPos = projMatrix * viewPosition;");
         if (scene.logarithmicDepthBufferEnabled) {
-           src.push("vFragDepth = 1.0 + clipPos.w;");
+            src.push("vFragDepth = 1.0 + clipPos.w;");
             src.push("isPerspective = float (isPerspectiveMatrix(projMatrix));");
         }
 
@@ -100,7 +100,7 @@ export class TrianglesFlatColorRenderer extends TrianglesInstancingRenderer {
         const src = [];
         src.push("#version 300 es");
         src.push("// Instancing geometry flat-shading drawing fragment shader");
-        
+
         src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
         src.push("precision highp float;");
         src.push("precision highp int;");
@@ -109,9 +109,9 @@ export class TrianglesFlatColorRenderer extends TrianglesInstancingRenderer {
         src.push("precision mediump int;");
         src.push("#endif");
         if (scene.logarithmicDepthBufferEnabled) {
-                src.push("in float isPerspective;");
-                src.push("uniform float logDepthBufFC;");
-                src.push("in float vFragDepth;");
+            src.push("in float isPerspective;");
+            src.push("uniform float logDepthBufFC;");
+            src.push("in float vFragDepth;");
         }
         if (this._withSAO) {
             src.push("uniform sampler2D uOcclusionTexture;");
@@ -134,6 +134,8 @@ export class TrianglesFlatColorRenderer extends TrianglesInstancingRenderer {
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
                 src.push("uniform vec3 sectionPlaneDir" + i + ";");
             }
+            src.push("uniform float sliceThickness;");
+            src.push("uniform vec4 sliceColor;");
         }
 
         this._addMatricesUniformBlockLines(src);
@@ -165,6 +167,8 @@ export class TrianglesFlatColorRenderer extends TrianglesInstancingRenderer {
         src.push("void main(void) {");
 
         if (clipping) {
+            src.push("  vec4 newColor;");
+            src.push("  newColor = vColor;");
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
@@ -173,8 +177,11 @@ export class TrianglesFlatColorRenderer extends TrianglesInstancingRenderer {
                 src.push("   dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
                 src.push("}");
             }
-            src.push("  if (dist > 0.0) { ");
+            src.push("  if (dist > sliceThickness) { ");
             src.push("      discard;")
+            src.push("  }");
+            src.push("  if (dist > 0.0) { ");
+            src.push("      newColor = sliceColor;");
             src.push("  }");
             src.push("}");
         }

--- a/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesFlatColorRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesFlatColorRenderer.js
@@ -225,7 +225,7 @@ export class TrianglesFlatColorRenderer extends TrianglesInstancingRenderer {
             src.push("reflectedColor += lambertian * (lightColor" + i + ".rgb * lightColor" + i + ".a);");
         }
 
-        src.push("vec4 fragColor = vec4((lightAmbient.rgb * lightAmbient.a * vColor.rgb) + (reflectedColor * vColor.rgb), vColor.a);");
+        src.push("vec4 fragColor = vec4((lightAmbient.rgb * lightAmbient.a * newColor.rgb) + (reflectedColor * newColor.rgb), newColor.a);");
 
         if (this._withSAO) {
             // Doing SAO blend in the main solid fill draw shader just so that edge lines can be drawn over the top

--- a/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesSilhouetteRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesSilhouetteRenderer.js
@@ -141,7 +141,7 @@ export class TrianglesSilhouetteRenderer extends TrianglesInstancingRenderer {
         if (scene.logarithmicDepthBufferEnabled) {
             src.push("    gl_FragDepth = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;");
         }
-        src.push("outColor = vColor;");
+        src.push("outColor = newColor;");
         src.push("}");
         return src;
     }

--- a/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesSilhouetteRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesSilhouetteRenderer.js
@@ -17,7 +17,7 @@ export class TrianglesSilhouetteRenderer extends TrianglesInstancingRenderer {
         const src = [];
         src.push("#version 300 es");
         src.push("// Instancing silhouette vertex shader");
-        
+
         src.push("uniform int renderPass;");
 
         src.push("in vec3 position;");
@@ -76,7 +76,7 @@ export class TrianglesSilhouetteRenderer extends TrianglesInstancingRenderer {
         src.push("vColor = vec4(silhouetteColor.r, silhouetteColor.g, silhouetteColor.b, min(silhouetteColor.a, float(color.a) / 255.0));");
         src.push("vec4 clipPos = projMatrix * viewPosition;");
         if (scene.logarithmicDepthBufferEnabled) {
-           src.push("vFragDepth = 1.0 + clipPos.w;");
+            src.push("vFragDepth = 1.0 + clipPos.w;");
             src.push("isPerspective = float (isPerspectiveMatrix(projMatrix));");
         }
         src.push("gl_Position = clipPos;");
@@ -92,7 +92,7 @@ export class TrianglesSilhouetteRenderer extends TrianglesInstancingRenderer {
         const src = [];
         src.push("#version 300 es");
         src.push("// Instancing fill fragment shader");
-        
+
         src.push("#ifdef GL_FRAGMENT_PRECISION_HIGH");
         src.push("precision highp float;");
         src.push("precision highp int;");
@@ -113,11 +113,15 @@ export class TrianglesSilhouetteRenderer extends TrianglesInstancingRenderer {
                 src.push("uniform vec3 sectionPlanePos" + i + ";");
                 src.push("uniform vec3 sectionPlaneDir" + i + ";");
             }
+            src.push("uniform float sliceThickness;");
+            src.push("uniform vec4 sliceColor;");
         }
         src.push("in vec4 vColor;");
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
         if (clipping) {
+            src.push("  vec4 newColor;");
+            src.push("  newColor = vColor;");
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");
@@ -126,7 +130,12 @@ export class TrianglesSilhouetteRenderer extends TrianglesInstancingRenderer {
                 src.push("   dist += clamp(dot(-sectionPlaneDir" + i + ".xyz, vWorldPosition.xyz - sectionPlanePos" + i + ".xyz), 0.0, 1000.0);");
                 src.push("}");
             }
-            src.push("if (dist > 0.0) { discard; }");
+            src.push("  if (dist > sliceThickness) { ");
+            src.push("      discard;")
+            src.push("  }");
+            src.push("  if (dist > 0.0) { ");
+            src.push("      newColor = sliceColor;");
+            src.push("  }");
             src.push("}");
         }
         if (scene.logarithmicDepthBufferEnabled) {

--- a/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesSilhouetteRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesSilhouetteRenderer.js
@@ -119,9 +119,9 @@ export class TrianglesSilhouetteRenderer extends TrianglesInstancingRenderer {
         src.push("in vec4 vColor;");
         src.push("out vec4 outColor;");
         src.push("void main(void) {");
+        src.push("  vec4 newColor;");
+        src.push("  newColor = vColor;");
         if (clipping) {
-            src.push("  vec4 newColor;");
-            src.push("  newColor = vColor;");
             src.push("  bool clippable = (int(vFlags) >> 16 & 0xF) == 1;");
             src.push("  if (clippable) {");
             src.push("  float dist = 0.0;");

--- a/src/viewer/scene/postfx/CrossSections.js
+++ b/src/viewer/scene/postfx/CrossSections.js
@@ -1,0 +1,80 @@
+import {Component} from '../Component.js';
+
+class CrossSections extends Component {
+
+    /** @private */
+    constructor(owner, cfg = {}) {
+
+        super(owner, cfg);
+
+        this.sliceColor = cfg.sliceColor;
+        this.sliceThickness  = cfg.sliceThickness;
+    }
+
+    /**
+     * Sets the thickness of a slice created by a section.
+     *
+     * Default value is ````0.0````.
+     *
+     * @type {Number}
+     */
+    set sliceThickness(value) {
+        if (value === undefined || value === null) {
+            value = 0.0;
+        }
+        if (this._sliceThickness === value) {
+            return;
+        }
+        this._sliceThickness = value;
+        this.glRedraw();
+    }
+
+    /**
+     * Gets the thickness of a slice created by a section.
+     *
+     * Default value is ````0.0````.
+     *
+     * @type {Number}
+     */
+    get sliceThickness() {
+        return this._sliceThickness;
+    }
+
+    /**
+     * Sets the color of a slice created by a section.
+     *
+     * Default value is ````[1.0, 0.0, 0.0, 1.0]````.
+     *
+     * @type {Number}
+     */
+    set sliceColor(value) {
+        if (value === undefined || value === null) {
+            value = [1.0, 0.0, 0.0, 1.0];
+        }
+        if (this._sliceColor === value) {
+            return;
+        }
+        this._sliceColor = value;
+        this.glRedraw();
+    }
+
+    /**
+     * Gets the thickness of a slice created by a section.
+     *
+     * Default value is ````[1.0, 0.0, 0.0, 1.0]````.
+     *
+     * @type {Number}
+     */
+    get sliceColor() {
+        return this._sliceColor;
+    }
+
+    /**
+     * Destroys this component.
+     */
+    destroy() {
+        super.destroy();
+    }
+}
+
+export {CrossSections};

--- a/src/viewer/scene/postfx/CrossSections.js
+++ b/src/viewer/scene/postfx/CrossSections.js
@@ -43,13 +43,13 @@ class CrossSections extends Component {
     /**
      * Sets the color of a slice created by a section.
      *
-     * Default value is ````[1.0, 0.0, 0.0, 1.0]````.
+     * Default value is ````[0.0, 0.0, 0.0, 1.0]````.
      *
      * @type {Number}
      */
     set sliceColor(value) {
         if (value === undefined || value === null) {
-            value = [1.0, 0.0, 0.0, 1.0];
+            value = [0.0, 0.0, 0.0, 1.0];
         }
         if (this._sliceColor === value) {
             return;
@@ -61,7 +61,7 @@ class CrossSections extends Component {
     /**
      * Gets the thickness of a slice created by a section.
      *
-     * Default value is ````[1.0, 0.0, 0.0, 1.0]````.
+     * Default value is ````[0.0, 0.0, 0.0, 1.0]````.
      *
      * @type {Number}
      */

--- a/src/viewer/scene/scene/Scene.js
+++ b/src/viewer/scene/scene/Scene.js
@@ -16,6 +16,7 @@ import {EmphasisMaterial} from '../materials/EmphasisMaterial.js';
 import {EdgeMaterial} from '../materials/EdgeMaterial.js';
 import {Metrics} from "../metriqs/Metriqs.js";
 import {SAO} from "../postfx/SAO.js";
+import {CrossSections} from "../postfx/CrossSections.js";
 import {PointsMaterial} from "../materials/PointsMaterial.js";
 import {LinesMaterial} from "../materials/LinesMaterial.js";
 
@@ -838,6 +839,14 @@ class Scene extends Component {
          */
         this.sao = new SAO(this, {
             enabled: cfg.saoEnabled
+        });
+
+        /** Configures Cross Sections for this Scene.
+         * @type {CrossSections}
+         * @final
+         */
+        this.crossSections = new CrossSections(this, {
+
         });
 
         this.ticksPerRender = cfg.ticksPerRender;


### PR DESCRIPTION
Hey Lindsay,

it is WIP for you to try it out, not to merge yet. Generally it allows to color sections a little bit, by leaving a slice just a little bit and coloring this slice black.

https://github.com/xeokit/xeokit-sdk/assets/47977819/4689851c-5581-40d5-b356-93103f83b93f

As we can see in the picture: solution is not perfect, The distance is set to 0.1, can be smaller, but the smaller the number, the more difficult it is to spot these new "section lines".

It also changes slightly existing behaviour, cause rather than slicing at 0.0, I have to leave this tiny slice to color it.

Also it opens some other questions:
- should we ask if someone wants to color these lines? Or maybe we should ask for slice width? Then in the shader we'd have to get that info somehow.
- you can see some objects (such as some furniture in this example) not having same effect. I believe there are some other places I'd have to add such update, to some other shaders, right?

Looking forward to hearing from you.