### PR TITLE
Fixed duplicate loading of .obj model causing material ID errors

### DIFF
--- a/src/plugins/OBJLoaderPlugin/OBJSceneGraphLoader.js
+++ b/src/plugins/OBJLoaderPlugin/OBJSceneGraphLoader.js
@@ -650,7 +650,14 @@ var parseMTL = (function () {
     }
 
     function createMaterial(modelNode, materialCfg) {
-        new PhongMaterial(modelNode, materialCfg);
+        var material = modelNode.scene.components[materialCfg.id];
+        if(material){
+            console.warn("Material already loaded");
+            if(!modelNode._ownedComponents)  modelNode._ownedComponents = {};
+            modelNode._ownedComponents[materialCfg.id] = material;
+        }else{
+            new PhongMaterial(modelNode, materialCfg);
+        }
     }
 
     function parseRGB(value) {

--- a/src/plugins/OBJLoaderPlugin/OBJSceneGraphLoader.js
+++ b/src/plugins/OBJLoaderPlugin/OBJSceneGraphLoader.js
@@ -560,7 +560,7 @@ var parseMTL = (function () {
 
                 case "newmtl": // New material
                     materialCfg = {
-                        id: value
+                        id: value ? `${modelNode.id}_${value}` : ""
                     };
                     createMaterial(modelNode, materialCfg);
                     break;

--- a/src/plugins/OBJLoaderPlugin/OBJSceneGraphLoader.js
+++ b/src/plugins/OBJLoaderPlugin/OBJSceneGraphLoader.js
@@ -532,7 +532,6 @@ var parseMTL = (function () {
         var materialCfg = {
             id: "Default"
         };
-        var needCreate = false;
         var line;
         var pos;
         var key;
@@ -560,13 +559,10 @@ var parseMTL = (function () {
             switch (key.toLowerCase()) {
 
                 case "newmtl": // New material
-                    //if (needCreate) {
-                    createMaterial(modelNode, materialCfg);
-                    //}
                     materialCfg = {
                         id: value
                     };
-                    needCreate = true;
+                    createMaterial(modelNode, materialCfg);
                     break;
 
                 case 'ka':
@@ -623,10 +619,6 @@ var parseMTL = (function () {
                 default:
                 // modelNode.error("Unrecognized token: " + key);
             }
-        }
-
-        if (needCreate) {
-            createMaterial(modelNode, materialCfg);
         }
     };
 


### PR DESCRIPTION
I'm excited to make my first contribution to the project!

This pull request addresses the issue described in the closed issue: https://github.com/xeokit/xeokit-sdk/issues/1403, where loading an .obj model could result in the creation of unnecessary "Default" materials or duplicate materials.

I've implemented a solution based on approaches used in my previous projects, which effectively prevents these issues.

### Key changes:
- Don't create a Default material everytime that parse a MTL file
- The Material id is generated using the node id + "_" + material.id
- If the material of the same type of node try to be created again, just link the instance to the new component setted in _ownedComponents attributes


### Testing:

I've thoroughly tested this solution in my local environment to ensure it resolves the issue without introducing any regressions.
I welcome any feedback or suggestions you may have.

Thank you for your time!