### PR TITLE
[FIX] Tolerate metamodel PropertySets with missing properties

### DIFF
--- a/src/viewer/metadata/MetaModel.js
+++ b/src/viewer/metadata/MetaModel.js
@@ -178,6 +178,9 @@ class MetaModel {
         if (metaModelData.propertySets) {
             for (let i = 0, len = metaModelData.propertySets.length; i < len; i++) {
                 const propertySetData = metaModelData.propertySets[i];
+                if (!propertySetData.properties) { // HACK: https://github.com/Creoox/creoox-ifc2gltfcxconverter/issues/8
+                    propertySetData.properties = [];
+                }
                 let propertySet = metaScene.propertySets[propertySetData.id];
                 if (!propertySet) {
                     if (propertyLookup) {


### PR DESCRIPTION
`ifc2gltfcxconverter` `3_0_19_beta` on Linux creates in the metamodel JSON some PropertySets that do not have `properties` attributes.

 This creates an exception in xeokit-sdk when loading the metamodels, which assumes that the `properties` array exists on each PropertySet, (see screenshot below).

This PR makes xeokit-sdk robust for `PropertySets` without `properties` attributes.
 
![Screenshot from 2024-03-13 15-46-00](https://github.com/Creoox/creoox-ifc2gltfcxconverter/assets/83100/8d23e048-e925-47bd-865b-b8f7be60156a)

