### PR TITLE
Add missing .js endings for import

### DIFF
--- a/src/plugins/GLTFLoaderPlugin/GLTFDefaultDataSource.js
+++ b/src/plugins/GLTFLoaderPlugin/GLTFDefaultDataSource.js
@@ -1,5 +1,5 @@
 import {utils} from "../../viewer/scene/utils.js";
-import {core} from "../../viewer/scene/core";
+import {core} from "../../viewer/scene/core.js";
 
 /**
  * Default data access strategy for {@link GLTFLoaderPlugin}.

--- a/src/viewer/Plugin.js
+++ b/src/viewer/Plugin.js
@@ -1,5 +1,5 @@
 import {Map} from "./scene/utils/Map.js";
-import {core} from "./scene/core";
+import {core} from "./scene/core.js";
 
 /**
  @desc Base class for {@link Viewer} plugin classes.

--- a/src/viewer/Viewer.js
+++ b/src/viewer/Viewer.js
@@ -3,7 +3,7 @@ import {CameraFlightAnimation} from "./scene/camera/CameraFlightAnimation.js";
 import {CameraControl} from "./scene/CameraControl/CameraControl.js";
 import {MetaScene} from "./metadata/MetaScene.js";
 import {LocaleService} from "./localization/LocaleService.js";
-import html2canvas from 'html2canvas/dist/html2canvas.esm.js';
+import html2canvas from '../../node_modules/html2canvas/dist/html2canvas.esm.js';
 
 /**
  * The 3D Viewer at the heart of the xeokit SDK.

--- a/src/viewer/scene/model/vbo/batching/triangles/renderers/EdgesEmphasisRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/renderers/EdgesEmphasisRenderer.js
@@ -1,5 +1,5 @@
 import {TrianglesBatchingRenderer} from "./TrianglesBatchingRenderer.js";
-import {EdgesRenderer} from "./EdgesRenderer";
+import {EdgesRenderer} from "./EdgesRenderer.js";
 
 
 /**

--- a/src/viewer/scene/utils.js
+++ b/src/viewer/scene/utils.js
@@ -1,7 +1,7 @@
 /**
  * @private
  */
-import {core} from "./core";
+import {core} from "./core.js";
 
 function xmlToJson(node, attributeRenamer) {
     if (node.nodeType === node.TEXT_NODE) {

--- a/src/viewer/scene/utils/FileLoader.js
+++ b/src/viewer/scene/utils/FileLoader.js
@@ -1,6 +1,6 @@
 import {Cache} from './Cache.js';
 import {Loader} from './Loader.js';
-import {core} from "../core";
+import {core} from "../core.js";
 
 const loading = {};
 


### PR DESCRIPTION
Changes:

- Adding missing ".js" extensions
- Changing html2canvas import to get it from node_modules <- I have to change this one as well everytime, if it should be the way it is, then please leave it as it is