### PR TITLE
[FIX] Reset cameraControl default values when followPointer config is dynamically changed

### DIFF
--- a/src/viewer/scene/CameraControl/lib/CameraUpdater.js
+++ b/src/viewer/scene/CameraControl/lib/CameraUpdater.js
@@ -103,6 +103,9 @@ class CameraUpdater {
                         }
                     }
                 }
+            } else {
+              dollyDistFactor = 1;
+              followPointerWorldPos = null;
             }
 
             const dollyDeltaForDist = (updates.dollyDelta * dollyDistFactor);


### PR DESCRIPTION
Use case:
- I added a UI button to switch `cameraControl.followPointer` on and off (`true`/ `false`).
=> The dolly rate when `followPointer` is `false` is not consistent.

Steps to reproduce the issue:
- dolly using the mouse wheel on an object when `cameraControl.followPointer` is `true`. (it sets the `dollyDistFactor` to a computed value)
- change the `cameraControl.followPointer` to `false`.
=> the distance from the previous object influences the dolly rate because `dollyDistFactor` is not reset to `1`.