### PR TITLE
Add FastNavPlugin.defaultScaleCanvasResolutionFactor

### DIFF
--- a/examples/emphasising/select_glowThroughFalse_dtx.html
+++ b/examples/emphasising/select_glowThroughFalse_dtx.html
@@ -58,6 +58,7 @@
 
     viewer.scene.selectedMaterial.glowThrough = false;
     viewer.scene.selectedMaterial.fillAlpha = 1.0;
+    viewer.scene.selectedMaterial.edgeColor = [0,0,0];
     viewer.scene.selectedMaterial.edgeAlpha = 1.0;
 
     //------------------------------------------------------------------------------------------------------------------

--- a/examples/performance/FastNavPlugin_defaultScaleCanvasResolutionFactor.html
+++ b/examples/performance/FastNavPlugin_defaultScaleCanvasResolutionFactor.html
@@ -16,12 +16,14 @@
 <canvas id="myCanvas"></canvas>
 <div class="slideout-sidebar">
     <img class="info-icon" src="../../assets/images/performance_icon.png"/>
-    <h1>FastNavPlugin</h1>
+    <h1>FastNavPlugin with defaultScaleCanvasResolutionFactor</h1>
     <h2>Makes interaction smoother</h2>
     <p>Whenever the camera moves, <a href="../../docs/class/src/plugins/FastNavPlugin/FastNavPlugin.js~FastNavPlugin.html"
                                      target="_other">FastNavPlugin</a> temporarily reduces the canvas resolution and
         disables certain rendering
         effects, to make interaction smoother.</p>
+    <p>In this example, we configure FastNavPlugin with a value for defaultScaleCanvasResolutionFactor, which sets a
+    canvas scaling factor to revert to when we stop interacting.</p>
     <h3>Stats</h3>
     <ul>
         <li>
@@ -95,8 +97,8 @@
         hidePBR: true,
         hideTransparentObjects: false,
         scaleCanvasResolution: true,
-        defaultScaleCanvasResolutionFactor: 1.0,
-        scaleCanvasResolutionFactor: 0.5,
+        defaultScaleCanvasResolutionFactor: 0.5,
+        scaleCanvasResolutionFactor: 0.25,
         delayBeforeRestore: true,
         delayBeforeRestoreSeconds: 0.4
     });

--- a/examples/performance/index.html
+++ b/examples/performance/index.html
@@ -260,6 +260,7 @@
 
             "#FastNavPlugin",
             ["FastNavPlugin_HolterTower", "FastNavPlugin - Fast lower-quality rendering while user interacts"],
+            ["FastNavPlugin_defaultScaleCanvasResolutionFactor", "FastNavPlugin - Fast lower-quality rendering while user interacts, using defaultScaleCanvasResolutionFactor"]
         ],
 
         "Experiments": [

--- a/src/plugins/FastNavPlugin/FastNavPlugin.js
+++ b/src/plugins/FastNavPlugin/FastNavPlugin.js
@@ -71,6 +71,7 @@ import {Plugin} from "../../viewer/Plugin.js";
  *      hidePBR: true,                  // No physically-based rendering while we interact (default is true)
  *      hideTransparentObjects: true,   // Hide transparent objects while we interact (default is false)
  *      scaleCanvasResolution: true,    // Scale canvas resolution while we interact (default is false)
+ *      defaultScaleCanvasResolutionFactor: 1.0, // Factor by which we scale canvas resolution when we stop interacting (default is 1.0)
  *      scaleCanvasResolutionFactor: 0.5,  // Factor by which we scale canvas resolution when we interact (default is 0.6)
  *      delayBeforeRestore: true,       // When we stop interacting, delay before restoring normal render (default is true)
  *      delayBeforeRestoreSeconds: 0.5  // The delay duration, in seconds (default is 0.5)
@@ -103,6 +104,7 @@ class FastNavPlugin extends Plugin {
      * @param {Boolean} [cfg.hideEdges=true] Whether to temporarily hide edges whenever we interact with the Viewer.
      * @param {Boolean} [cfg.hideTransparentObjects=false] Whether to temporarily hide transparent objects whenever we interact with the Viewer.
      * @param {Number} [cfg.scaleCanvasResolution=false] Whether to temporarily down-scale the canvas resolution whenever we interact with the Viewer.
+     * @param {Number} [cfg.defaultScaleCanvasResolutionFactor=0.6] The factor by which we downscale the canvas resolution whenever we stop interacting with the Viewer.
      * @param {Number} [cfg.scaleCanvasResolutionFactor=0.6] The factor by which we downscale the canvas resolution whenever we interact with the Viewer.
      * @param {Boolean} [cfg.delayBeforeRestore=true] Whether to temporarily have a delay before restoring normal rendering after we stop interacting with the Viewer.
      * @param {Number} [cfg.delayBeforeRestoreSeconds=0.5] Delay in seconds before restoring normal rendering after we stop interacting with the Viewer.
@@ -117,6 +119,7 @@ class FastNavPlugin extends Plugin {
         this._hideEdges = cfg.hideEdges !== false;
         this._hideTransparentObjects = !!cfg.hideTransparentObjects;
         this._scaleCanvasResolution = !!cfg.scaleCanvasResolution;
+        this._defaultScaleCanvasResolutionFactor = cfg.defaultScaleCanvasResolutionFactor || 1.0;
         this._scaleCanvasResolutionFactor = cfg.scaleCanvasResolutionFactor || 0.6;
         this._delayBeforeRestore = (cfg.delayBeforeRestore !== false);
         this._delayBeforeRestoreSeconds = cfg.delayBeforeRestoreSeconds || 0.5;
@@ -135,14 +138,14 @@ class FastNavPlugin extends Plugin {
                 if (this._scaleCanvasResolution) {
                     viewer.scene.canvas.resolutionScale = this._scaleCanvasResolutionFactor;
                 } else {
-                    viewer.scene.canvas.resolutionScale = 1;
+                    viewer.scene.canvas.resolutionScale = this._defaultScaleCanvasResolutionFactor;
                 }
                 fastMode = true;
             }
         };
 
         const switchToHighQuality = () => {
-            viewer.scene.canvas.resolutionScale = 1;
+            viewer.scene.canvas.resolutionScale = this._defaultScaleCanvasResolutionFactor;
             viewer.scene._renderer.setEdgesEnabled(true);
             viewer.scene._renderer.setColorTextureEnabled(true);
             viewer.scene._renderer.setPBREnabled(true);
@@ -310,7 +313,7 @@ class FastNavPlugin extends Plugin {
     }
 
     /**
-     * Sets whether to temporarily scale the canvas resolution whenever we interact with the Viewer.
+     * Sets the factor to which we restore the canvas resolution scale when we stop interacting with the viewer.
      *
      * Default is ````false````.
      *
@@ -320,6 +323,34 @@ class FastNavPlugin extends Plugin {
      */
     set scaleCanvasResolution(scaleCanvasResolution) {
         this._scaleCanvasResolution = scaleCanvasResolution;
+    }
+
+    /**
+     * Gets the factor to which we restore the canvas resolution scale when we stop interacting with the viewer.
+     *
+     * Default is ````1.0````.
+     *
+     * Enable canvas resolution scaling by setting {@link FastNavPlugin#scaleCanvasResolution} ````true````.
+     *
+     * @return {Number} Factor by scale canvas resolution when we stop interacting with the viewer.
+     */
+    get defaultScaleCanvasResolutionFactor() {
+        return this._defaultScaleCanvasResolutionFactor;
+    }
+
+    /**
+     * Sets the factor to which we restore the canvas resolution scale when we stop interacting with the viewer.
+     *
+     * Accepted range is ````[0.0 .. 1.0]````.
+     *
+     * Default is ````1.0````.
+     *
+     * Enable canvas resolution scaling by setting {@link FastNavPlugin#scaleCanvasResolution} ````true````.
+     *
+     * @param {Number} defaultScaleCanvasResolutionFactor Factor by scale canvas resolution when we stop interacting with the viewer.
+     */
+    set defaultScaleCanvasResolutionFactor(defaultScaleCanvasResolutionFactor) {
+        this._defaultScaleCanvasResolutionFactor = defaultScaleCanvasResolutionFactor || 1.0;
     }
 
     /**


### PR DESCRIPTION
This PR extends `FastNavPlugin` with a new option, `defaultScaleCanvasResolutionFactor`, which sets the factor to which we restore the canvas resolution scale when we stop interacting with the viewer.

This allows us to use canvas resolution scaling for anti aliasing when we're not in fast navigation mode. 

## Usage

````javascript
    const fastNavPlugin = new FastNavPlugin(viewer, {
        hideEdges: true,
        hideSAO: true,
        hideColorTexture: true,
        hidePBR: true,
        hideTransparentObjects: false,
        scaleCanvasResolution: true,
        defaultScaleCanvasResolutionFactor: 0.5,
        scaleCanvasResolutionFactor: 0.25,
        delayBeforeRestore: true,
        delayBeforeRestoreSeconds: 0.4
    });
````