### PR TITLE
[FIX] Distance measurement tool not working when model has a slice on specific axis #1428

### DIFF
--- a/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
+++ b/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
@@ -353,7 +353,7 @@ class DistanceMeasurement extends Component {
 
         if (this._sectionPlanesDirty) {
 
-            if (this._isSliced(this._wp)) {
+            if (this._isSliced(this._originWorld) || this._isSliced(this._targetWorld)) {
                 this._xAxisLabel.setCulled(true);
                 this._yAxisLabel.setCulled(true);
                 this._zAxisLabel.setCulled(true);


### PR DESCRIPTION
Fixes SectionPlanes clipping distance measurements too coarsely. 

A DistanceMeasurement is designed to become entirely invisible whenever either of its end points are clipped by a SectionPlane.

When clipping a SectionPlane, we are clipping the end points, but are also incorrectly clipping the intermediate points that are used when showing the X,Y,Z axis.

For some cases, this has the undesirable effect of causing DistanceMeasurements to be clipped when a SectionPlane is actually far away from the end points.

[Screencast from 01.04.2024 18:08:42.webm](https://github.com/xeokit/xeokit-sdk/assets/83100/6cf70f43-57fa-494d-9a00-c25b8e1d0930)
