### PR TITLE
Add canvasToPagePos callback for measurement controls

### DIFF
--- a/examples/measurement/angle_createWithMouse_snapping_canvasToPagePos.html
+++ b/examples/measurement/angle_createWithMouse_snapping_canvasToPagePos.html
@@ -1,0 +1,732 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>xeokit Example</title>
+    <link href="../css/pageStyle.css" rel="stylesheet"/>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
+
+    <style>
+
+        .viewer-ruler-wire-highlighted {
+            border: 2px solid white !important;
+        }
+
+        .viewer-ruler-label-highlighted {
+            border: 2px solid white !important;
+        }
+
+        .viewer-ruler-dot-highlighted {
+            border: 2px solid white !important;
+        }
+
+        .xeokit-context-menu {
+            font-family: 'Roboto', sans-serif;
+            font-size: 15px;
+            display: none;
+            z-index: 300000;
+            background: rgba(255, 255, 255, 0.46);
+            border: 1px solid black;
+            border-radius: 6px;
+            padding: 0;
+            width: 200px;
+        }
+
+        .xeokit-context-menu ul {
+            list-style: none;
+            margin-left: 0;
+            padding: 0;
+        }
+
+        .xeokit-context-menu ul li {
+            list-style-type: none;
+            padding-left: 10px;
+            padding-right: 20px;
+            padding-top: 4px;
+            padding-bottom: 4px;
+            color: black;
+            border-bottom: 1px solid gray;
+            background: rgba(255, 255, 255, 0.46);
+            cursor: pointer;
+            width: calc(100% - 30px);
+        }
+
+        .xeokit-context-menu ul li:hover {
+            background: black;
+            color: white;
+            font-weight: normal;
+        }
+
+        .xeokit-context-menu ul li span {
+            display: inline-block;
+        }
+
+        .xeokit-context-menu .disabled {
+            display: inline-block;
+            color: gray;
+            cursor: default;
+            font-weight: normal;
+        }
+
+        .xeokit-context-menu .disabled:hover {
+            color: gray;
+            cursor: default;
+            background: #eeeeee;
+            font-weight: normal;
+        }
+
+    </style>
+</head>
+<body>
+<input type="checkbox" id="info-button"/>
+<label for="info-button" class="info-button"><i class="far fa-3x fa-question-circle"></i></label>
+<canvas id="myCanvas"></canvas>
+<div class="slideout-sidebar">
+    <img class="info-icon" src="../../assets/images/measure_angle_icon.png"/>
+    <h1>AngleMeasurementPlugin with AngleMeasurementsMouseControl and PointerLens</h1>
+    <h2>Click on the model to create angle measurements, with vertex and snapping</h2>
+    <p>In this example, we're loading a BIM model from the file system, then creating angle measurements wherever the
+        user clicks on the model with the mouse.</p>
+    <h3>Components Used</h3>
+    <ul>
+        <li>
+            <a href="../../docs/class/src/viewer/Viewer.js~Viewer.html"
+               target="_other">Viewer</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/AngleMeasurementsPlugin/AngleMeasurementsPlugin.js~AngleMeasurementsPlugin.html"
+               target="_other">AngleMeasurementsPlugin</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/AngleMeasurementsPlugin/AngleMeasurementsMouseControl.js~AngleMeasurementsMouseControl.html"
+               target="_other">AngleMeasurementsMouseControl</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/extras/PointerLens/PointerLens.js~PointerLens.html"
+               target="_other">PointerLens</a>
+        </li>
+    </ul>
+
+    <h3>Assets</h3>
+    <ul>
+        <li>
+            <a href="http://openifcmodel.cs.auckland.ac.nz/Model/Details/274"
+               target="_other">Model source</a>
+        </li>
+    </ul>
+</div>
+</body>
+<script type="module">
+
+    import {Viewer, XKTLoaderPlugin, AngleMeasurementsPlugin, ContextMenu, AngleMeasurementsMouseControl, PointerLens} from "../../dist/xeokit-sdk.es.js";
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas",
+        dtxEnabled: true
+    });
+
+    viewer.camera.eye = [-3.93, 2.85, 27.01];
+    viewer.camera.look = [4.40, 3.72, 8.89];
+    viewer.camera.up = [-0.01, 0.99, 0.039];
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Load a model
+    //------------------------------------------------------------------------------------------------------------------
+
+    const xktLoader = new XKTLoaderPlugin(viewer);
+
+    const sceneModel = xktLoader.load({
+        id: "myModel",
+        src: "../../assets/models/xkt/v10/glTF-Embedded/Duplex_A_20110505.glTFEmbedded.xkt",
+        edges: true
+    });
+
+    sceneModel.on("loaded", ()=>{
+        viewer.cameraFlight.jumpTo(sceneModel);
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a context menu to delete and configure measurements
+    //------------------------------------------------------------------------------------------------------------------
+
+    const angleMeasurementsContextMenu = new ContextMenu({
+        items: [
+
+            [
+                {
+                    getTitle: (context) => {
+                        return context.measurement.labelsVisible ? "Hide Labels" : "Show Labels";
+                    },
+                    doAction: function (context) {
+                        context.measurement.labelsVisible = !context.measurement.labelsVisible;
+                    }
+                }
+            ], [
+                {
+                    title: "Delete Measurement",
+                    doAction: function (context) {
+                        context.measurement.destroy();
+                    }
+                }
+            ]
+
+        ]
+    });
+
+    angleMeasurementsContextMenu.on("hidden", () => {
+        if (angleMeasurementsContextMenu.context.measurement) {
+            angleMeasurementsContextMenu.context.measurement.setHighlighted(false);
+        }
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a AngleMeasurementsPlugin, with which we'll create AngleMeasurements
+    //------------------------------------------------------------------------------------------------------------------
+
+    const angleMeasurementsPlugin = new AngleMeasurementsPlugin(viewer, {
+        zIndex: 100000 // If set, the wires, dots and labels will have this zIndex (+1 for dots and +2 for labels).
+    });
+
+    const angleMeasurementsMouseControl  = new AngleMeasurementsMouseControl(angleMeasurementsPlugin, {
+        pointerLens : new PointerLens(viewer),
+
+        canvasToPagePos: (canvas, canvasPos, pagePos) => {
+            const getTop = el => el.offsetTop + (el.offsetParent && getTop(el.offsetParent));
+            const getLeft = el => el.offsetLeft + (el.offsetParent && getLeft(el.offsetParent));
+            pagePos[0] = getLeft(canvas) + canvasPos[0];
+            pagePos[1] = getTop(canvas) + canvasPos[1];
+        }
+    })
+
+    angleMeasurementsMouseControl.snapping = true;
+
+    angleMeasurementsMouseControl.activate();
+
+    angleMeasurementsPlugin.on("mouseOver", (e) => {
+        e.measurement.setHighlighted(true);
+    });
+
+    angleMeasurementsPlugin.on("mouseLeave", (e) => {
+        if (angleMeasurementsContextMenu.shown && angleMeasurementsContextMenu.context.measurement.id === e.measurement.id) {
+            return;
+        }
+        e.measurement.setHighlighted(false);
+    });
+
+    angleMeasurementsPlugin.on("contextMenu", (e) => {
+        angleMeasurementsContextMenu.context = { // Must set context before showing menu
+            viewer: viewer,
+            angleMeasurementsPlugin: angleMeasurementsPlugin,
+            measurement: e.measurement
+        };
+        angleMeasurementsContextMenu.show(e.event.clientX, e.event.clientY);
+        e.event.preventDefault();
+    });
+
+    const objectContextMenu = new ContextMenu({
+        items: [
+            [
+                {
+                    getTitle: function (context) {
+                        return (!context.entity.xrayed) ? "X-Ray" : "Undo X-Ray";
+                    },
+                    doAction: function (context) {
+                        context.entity.xrayed = !context.entity.xrayed;
+                    }
+                },
+                {
+                    title: "X-Ray Others",
+                    doAction: function (context) {
+                        const viewer = context.viewer;
+                        const scene = viewer.scene;
+                        const entity = context.entity;
+                        const metaObject = viewer.metaScene.metaObjects[entity.id];
+                        if (!metaObject) {
+                            return;
+                        }
+                        scene.setObjectsVisible(scene.objectIds, true);
+                        scene.setObjectsXRayed(scene.objectIds, true);
+                        scene.setObjectsSelected(scene.selectedObjectIds, false);
+                        scene.setObjectsHighlighted(scene.highlightedObjectIds, false);
+                        metaObject.withMetaObjectsInSubtree((metaObject) => {
+                            const entity = scene.objects[metaObject.id];
+                            if (entity) {
+                                entity.xrayed = false;
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "X-Ray All",
+                    getEnabled: function (context) {
+                        const scene = context.viewer.scene;
+                        return (scene.numXRayedObjects < scene.numObjects);
+                    },
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        scene.setObjectsXRayed(scene.objectIds, true);
+                    }
+                },
+                {
+                    title: "X-Ray None",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.numXRayedObjects > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsXRayed(context.viewer.scene.xrayedObjectIds, false);
+                    }
+                }
+            ],
+            [
+                {
+                    title: "Hide",
+                    getEnabled: function (context) {
+                        return context.entity.visible;
+                    },
+                    doAction: function (context) {
+                        context.entity.visible = false;
+                    }
+                },
+                {
+                    title: "Hide Others",
+                    doAction: function (context) {
+                        const viewer = context.viewer;
+                        const scene = viewer.scene;
+                        const entity = context.entity;
+                        const metaObject = viewer.metaScene.metaObjects[entity.id];
+                        if (!metaObject) {
+                            return;
+                        }
+                        scene.setObjectsVisible(scene.visibleObjectIds, false);
+                        scene.setObjectsXRayed(scene.xrayedObjectIds, false);
+                        scene.setObjectsSelected(scene.selectedObjectIds, false);
+                        scene.setObjectsHighlighted(scene.highlightedObjectIds, false);
+                        metaObject.withMetaObjectsInSubtree((metaObject) => {
+                            const entity = scene.objects[metaObject.id];
+                            if (entity) {
+                                entity.visible = true;
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "Hide All",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.numVisibleObjects > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsVisible(context.viewer.scene.visibleObjectIds, false);
+                    }
+                },
+                {
+                    title: "Show All",
+                    getEnabled: function (context) {
+                        const scene = context.viewer.scene;
+                        return (scene.numVisibleObjects < scene.numObjects);
+                    },
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        scene.setObjectsVisible(scene.objectIds, true);
+                    }
+                }
+            ],
+            [
+                {
+                    getTitle: function (context) {
+                        return (!context.entity.selected) ? "Select" : "Undo Select";
+                    },
+                    doAction: function (context) {
+                        context.entity.selected = !context.entity.selected;
+                    }
+                },
+                {
+                    title: "Select All",
+                    getEnabled: function (context) {
+                        const scene = context.viewer.scene;
+                        return (scene.numSelectedObjects < scene.numObjects);
+                    },
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        scene.setObjectsSelected(scene.objectIds, true);
+                    }
+                },
+                {
+                    title: "Select None",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.numSelectedObjects > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsSelected(context.viewer.scene.selectedObjectIds, false);
+                    }
+                }
+            ],
+
+            [
+                {
+                    title: "Camera..",
+                    items: [
+                        [
+                            {
+                                title: "View Fit",
+                                doAction: function (context) {
+                                    const viewer = context.viewer;
+                                    const scene = viewer.scene;
+                                    const entity = context.entity;
+                                    viewer.cameraFlight.flyTo({
+                                        aabb: entity.aabb,
+                                        duration: 0.5
+                                    }, () => {
+                                        setTimeout(function () {
+                                            scene.setObjectsHighlighted(scene.highlightedObjectIds, false);
+                                        }, 500);
+                                    });
+                                }
+                            },
+                            {
+                                title: "View Fit All",
+                                doAction: function (context) {
+                                    const scene = context.viewer.scene;
+                                    context.viewer.cameraFlight.flyTo({
+                                        projection: "perspective",
+                                        aabb: scene.getAABB(),
+                                        duration: 0.5
+                                    });
+                                }
+                            }
+                        ],
+                        [
+                            {
+                                title: "Perspective",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.camera.projection !== "perspective");
+                                },
+                                doAction: function (context) {
+                                    context.viewer.cameraFlight.flyTo({
+                                        projection: "perspective"
+                                    });
+                                }
+                            },
+                            {
+                                title: "Orthographic",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.camera.projection !== "ortho");
+                                },
+                                doAction: function (context) {
+                                    context.viewer.cameraFlight.flyTo({
+                                        projection: "ortho"
+                                    });
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ],
+
+            [
+                {
+                    title: "Effects..",
+                    items: [
+                        [
+                            {
+                                getTitle: (context) => {
+                                    return context.viewer.scene.edgeMaterial.edges ? "Disable Edges" : "Enable Edges";
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.edgeMaterial.edges = !context.viewer.scene.edgeMaterial.edges;
+                                }
+                            },
+                            {
+                                getTitle: (context) => {
+                                    return context.viewer.scene.sao.enabled ? "Disable SAO" : "Enable SAO";
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.sao.enabled = !context.viewer.scene.sao.enabled;
+                                }
+                            },
+                            {
+                                getTitle: (context) => {
+                                    return context.viewer.scene.pbrEnabled ? "Disable PBR" : "Enable PBR";
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.pbrEnabled = !context.viewer.scene.pbrEnabled;
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ],
+
+            [
+                {
+                    title: "Measurements..",
+                    getEnabled: function (context) {
+                        return (Object.keys(angleMeasurementsPlugin.measurements).length > 0);
+                    },
+                    items: [
+                        [
+                            {
+                                getTitle: function (context) {
+                                    return (Object.keys(angleMeasurementsPlugin.measurements).length > 0) ? "Show All Labels" : "Hide All Labels";
+                                },
+                                getEnabled: function (context) {
+                                    return (Object.keys(angleMeasurementsPlugin.measurements).length > 0);
+                                },
+                                doAction: function (context) {
+                                    //angleMeasurementsPlugin.clear();
+                                }
+                            },
+                            {
+                                getTitle: function (context) {
+                                    return (Object.keys(angleMeasurementsPlugin.measurements).length > 0) ? "Show All Axis" : "Hide All Axis";
+                                },
+                                getEnabled: function (context) {
+                                    return (Object.keys(angleMeasurementsPlugin.measurements).length > 0);
+                                },
+                                doAction: function (context) {
+                                    //angleMeasurementsPlugin.clear();
+                                }
+                            },
+                            {
+                                title: "Delete All",
+                                getEnabled: function (context) {
+                                    return (Object.keys(angleMeasurementsPlugin.measurements).length > 0);
+                                },
+                                doAction: function (context) {
+                                    angleMeasurementsPlugin.clear();
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ]
+        ],
+        enabled: true
+    });
+
+    const canvasContextMenu = new ContextMenu({
+        enabled: true,
+        context: {
+            viewer: viewer
+        },
+        items: [
+            [
+                {
+                    title: "Objects..",
+                    items: [
+                        [
+                            {
+                                title: "X-Ray All",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.numXRayedObjects < scene.numObjects);
+                                },
+                                doAction: function (context) {
+                                    const scene = context.viewer.scene;
+                                    scene.setObjectsXRayed(scene.objectIds, true);
+                                }
+                            },
+                            {
+                                title: "X-Ray None",
+                                getEnabled: function (context) {
+                                    return (context.viewer.scene.numXRayedObjects > 0);
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.setObjectsXRayed(context.viewer.scene.xrayedObjectIds, false);
+                                }
+                            }
+                        ],
+                        [
+                            {
+                                title: "Hide All",
+                                getEnabled: function (context) {
+                                    return (context.viewer.scene.numVisibleObjects > 0);
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.setObjectsVisible(context.viewer.scene.visibleObjectIds, false);
+                                }
+                            },
+                            {
+                                title: "Show All",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.numVisibleObjects < scene.numObjects);
+                                },
+                                doAction: function (context) {
+                                    const scene = context.viewer.scene;
+                                    scene.setObjectsVisible(scene.objectIds, true);
+                                    scene.setObjectsXRayed(scene.xrayedObjectIds, false);
+                                    scene.setObjectsSelected(scene.selectedObjectIds, false);
+                                }
+                            }
+                        ],
+
+                        [
+                            {
+                                title: "Select All",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.numSelectedObjects < scene.numObjects);
+                                },
+                                doAction: function (context) {
+                                    const scene = context.viewer.scene;
+                                    scene.setObjectsSelected(scene.objectIds, true);
+                                }
+                            },
+                            {
+                                title: "Select None",
+                                getEnabled: function (context) {
+                                    return (context.viewer.scene.numSelectedObjects > 0);
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.setObjectsSelected(context.viewer.scene.selectedObjectIds, false);
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ],
+            [
+                {
+                    title: "Camera..",
+                    items: [
+                        [
+                            {
+                                title: "View Fit All",
+                                doAction: function (context) {
+                                    context.viewer.cameraFlight.flyTo({
+                                        aabb: context.viewer.scene.getAABB()
+                                    });
+                                }
+                            }
+                        ],
+                        [
+                            {
+                                title: "Perspective",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.camera.projection !== "perspective");
+                                },
+                                doAction: function (context) {
+                                    context.viewer.cameraFlight.flyTo({
+                                        projection: "perspective"
+                                    });
+                                }
+                            },
+                            {
+                                title: "Orthographic",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.camera.projection !== "ortho");
+                                },
+                                doAction: function (context) {
+                                    context.viewer.cameraFlight.flyTo({
+                                        projection: "ortho"
+                                    });
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ],
+
+            [
+                {
+                    title: "Effects..",
+                    items: [
+                        [
+                            {
+                                getTitle: (context) => {
+                                    return context.viewer.scene.edgeMaterial.edges ? "Disable Edges" : "Enable Edges";
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.edgeMaterial.edges = !context.viewer.scene.edgeMaterial.edges;
+                                }
+                            },
+                            {
+                                getTitle: (context) => {
+                                    return context.viewer.scene.sao.enabled ? "Disable SAO" : "Enable SAO";
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.sao.enabled = !context.viewer.scene.sao.enabled;
+                                }
+                            },
+                            {
+                                getTitle: (context) => {
+                                    return context.viewer.scene.pbrEnabled ? "Disable PBR" : "Enable PBR";
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.pbrEnabled = !context.viewer.scene.pbrEnabled;
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ],
+            [
+                {
+                    title: "Measurements..",
+                    getEnabled: function (context) {
+                        return (Object.keys(angleMeasurementsPlugin.measurements).length > 0);
+                    },
+                    items: [
+                        [
+                            {
+                                getTitle: function (context) {
+                                    return (Object.keys(angleMeasurementsPlugin.measurements).length > 0) ? "Show All Labels" : "Hide All Labels";
+                                },
+                                getEnabled: function (context) {
+                                    return (Object.keys(angleMeasurementsPlugin.measurements).length > 0);
+                                },
+                                doAction: function (context) {
+                                    //angleMeasurementsPlugin.clear();
+                                }
+                            },
+                            {
+                                title: "Delete All",
+                                getEnabled: function (context) {
+                                    return (Object.keys(angleMeasurementsPlugin.measurements).length > 0);
+                                },
+                                doAction: function (context) {
+                                    angleMeasurementsPlugin.clear();
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ]
+        ]
+    });
+
+    viewer.cameraControl.on("rightClick", (e) => {
+
+        const hit = viewer.scene.pick({
+            canvasPos: e.canvasPos
+        });
+
+        if (hit && hit.entity.isObject) {
+
+            objectContextMenu.context = { // Must set context before showing menu
+                viewer: viewer,
+                entity: hit.entity
+            };
+
+            objectContextMenu.show(e.pagePos[0], e.pagePos[1]);
+        } else {
+
+            canvasContextMenu.context = { // Must set context before showing menu
+                viewer: viewer
+            };
+
+            canvasContextMenu.show(e.pagePos[0], e.pagePos[1]);
+        }
+
+        e.event.preventDefault();
+    });
+
+
+</script>
+</html>

--- a/examples/measurement/distance_createWithMouse_snapping_canvasToPagePos.html
+++ b/examples/measurement/distance_createWithMouse_snapping_canvasToPagePos.html
@@ -1,0 +1,314 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>xeokit Example</title>
+    <link href="../css/pageStyle.css" rel="stylesheet"/>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
+
+    <style>
+
+        .viewer-ruler-wire-highlighted {
+            border: 2px solid white !important;
+        }
+
+        .viewer-ruler-label-highlighted {
+            border: 2px solid white !important;
+        }
+
+        .viewer-ruler-dot-highlighted {
+            border: 2px solid white !important;
+        }
+
+        .xeokit-context-menu {
+            font-family: 'Roboto', sans-serif;
+            font-size: 15px;
+            display: none;
+            z-index: 300000;
+            background: rgba(255, 255, 255, 0.46);
+            border: 1px solid black;
+            border-radius: 6px;
+            padding: 0;
+            width: 200px;
+        }
+
+        .xeokit-context-menu ul {
+            list-style: none;
+            margin-left: 0;
+            padding: 0;
+        }
+
+        .xeokit-context-menu ul li {
+            list-style-type: none;
+            padding-left: 10px;
+            padding-right: 20px;
+            padding-top: 4px;
+            padding-bottom: 4px;
+            color: black;
+            border-bottom: 1px solid gray;
+            background: rgba(255, 255, 255, 0.46);
+            cursor: pointer;
+            width: calc(100% - 30px);
+        }
+
+        .xeokit-context-menu ul li:hover {
+            background: black;
+            color: white;
+            font-weight: normal;
+        }
+
+        .xeokit-context-menu ul li span {
+            display: inline-block;
+        }
+
+        .xeokit-context-menu .disabled {
+            display: inline-block;
+            color: gray;
+            cursor: default;
+            font-weight: normal;
+        }
+
+        .xeokit-context-menu .disabled:hover {
+            color: gray;
+            cursor: default;
+            background: #eeeeee;
+            font-weight: normal;
+        }
+
+    </style>
+</head>
+<body>
+<input type="checkbox" id="info-button"/>
+<label for="info-button" class="info-button"><i class="far fa-3x fa-question-circle"></i></label>
+<canvas id="myCanvas"></canvas>
+<div class="slideout-sidebar">
+    <img class="info-icon" src="../../assets/images/measure_distance_icon.png"/>
+    <h1>DistanceMeasurementPlugin with DistanceMeasurementsMouseControl and PointerLens</h1>
+    <h2>Click on the model to create distance measurements, with no vertex and edge snapping</h2>
+    <p>In this example, we're loading a BIM model from the file system, then creating distance measurements wherever the
+        user clicks on the model with the mouse.</p>
+    <h3>Components Used</h3>
+    <ul>
+        <li>
+            <a href="../../docs/class/src/viewer/Viewer.js~Viewer.html"
+               target="_other">Viewer</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsPlugin.js~DistanceMeasurementsPlugin.html"
+               target="_other">DistanceMeasurementsPlugin</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsMouseControl.js~DistanceMeasurementsMouseControl.html"
+               target="_other">DistanceMeasurementsMouseControl</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/extras/PointerLens/PointerLens.js~PointerLens.html"
+               target="_other">PointerLens</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js~XKTLoaderPlugin.html"
+               target="_other">XKTLoaderPlugin</a>
+        </li>
+    </ul>
+    <h3>Tutorials</h3>
+    <ul>
+        <li>
+            <a href="https://www.notion.so/xeokit/Accurate-Measurements-with-Snapping-5e6606afef20428f9b319ea0e82270f9"
+               target="_other">Accurate Measurements with Snapping</a>
+        </li>
+    </ul>
+    <h3>Assets</h3>
+    <ul>
+        <li>
+            <a href="http://openifcmodel.cs.auckland.ac.nz/Model/Details/274"
+               target="_other">Model source</a>
+        </li>
+    </ul>
+</div>
+</body>
+<script type="module">
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Import the modules we need for this example
+    //------------------------------------------------------------------------------------------------------------------
+
+    import {
+        Viewer,
+        XKTLoaderPlugin,
+        ContextMenu,
+        DistanceMeasurementsPlugin,
+        DistanceMeasurementsMouseControl,
+        PointerLens
+    } from "../../dist/xeokit-sdk.es.js";
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a Viewer and arrange the camera
+    //------------------------------------------------------------------------------------------------------------------
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas",
+        dtxEnabled: true
+    });
+
+    viewer.camera.eye = [-3.93, 2.85, 27.01];
+    viewer.camera.look = [4.40, 3.72, 8.89];
+    viewer.camera.up = [-0.01, 0.99, 0.039];
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Load a model
+    //------------------------------------------------------------------------------------------------------------------
+
+    const xktLoader = new XKTLoaderPlugin(viewer);
+
+    const sceneModel = xktLoader.load({
+        id: "myModel",
+        src: "../../assets/models/xkt/v10/glTF-Embedded/Duplex_A_20110505.glTFEmbedded.xkt",
+        edges: true
+    });
+
+    sceneModel.on("loaded", () => {
+        viewer.cameraFlight.jumpTo(sceneModel);
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // DistanceMeasurementsPlugin, DistanceMeasurementsMouseControl and PointerLens
+    //------------------------------------------------------------------------------------------------------------------
+
+    const distanceMeasurementsPlugin = new DistanceMeasurementsPlugin(viewer);
+
+    distanceMeasurementsPlugin.on("mouseOver", (e) => {
+        e.measurement.setHighlighted(true);
+    });
+
+    distanceMeasurementsPlugin.on("mouseLeave", (e) => {
+        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.measurement.id === e.measurement.id) {
+            return;
+        }
+        e.measurement.setHighlighted(false);
+    });
+
+    const distanceMeasurementsMouseControl = new DistanceMeasurementsMouseControl(distanceMeasurementsPlugin, {
+        pointerLens: new PointerLens(viewer),
+
+        canvasToPagePos: (canvas, canvasPos, pagePos) => {
+            const getTop = el => el.offsetTop + (el.offsetParent && getTop(el.offsetParent));
+            const getLeft = el => el.offsetLeft + (el.offsetParent && getLeft(el.offsetParent));
+            pagePos[0] = getLeft(canvas) + canvasPos[0];
+            pagePos[1] = getTop(canvas) + canvasPos[1];
+        }
+    })
+
+    distanceMeasurementsMouseControl.snapping = true;
+
+    distanceMeasurementsMouseControl.activate();
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a context menu to delete and configure measurements
+    //------------------------------------------------------------------------------------------------------------------
+
+    const distanceMeasurementsContextMenu = new ContextMenu({
+        items: [
+            [
+                {
+                    title: "Clear",
+                    doAction: function (context) {
+                        context.distanceMeasurement.destroy();
+                    }
+                },
+                {
+                    getTitle: (context) => {
+                        return context.distanceMeasurement.axisVisible ? "Hide Axis" : "Show Axis";
+                    },
+                    doAction: function (context) {
+                        context.distanceMeasurement.axisVisible = !context.distanceMeasurement.axisVisible;
+                    }
+                },
+                {
+                    getTitle: (context) => {
+                        return context.distanceMeasurement.labelsVisible ? "Hide Labels" : "Show Labels";
+                    },
+                    doAction: function (context) {
+                        context.distanceMeasurement.labelsVisible = !context.distanceMeasurement.labelsVisible;
+                    }
+                }
+            ], [
+                {
+                    title: "Clear All",
+                    getEnabled: function (context) {
+                        return (Object.keys(context.distanceMeasurementsPlugin.measurements).length > 0);
+                    },
+                    doAction: function (context) {
+                        context.distanceMeasurementsPlugin.clear();
+                    }
+                }
+            ]
+        ]
+    });
+
+    distanceMeasurementsContextMenu.on("hidden", () => {
+        if (distanceMeasurementsContextMenu.context.distanceMeasurement) {
+            distanceMeasurementsContextMenu.context.distanceMeasurement.setHighlighted(false);
+        }
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a context menu to activate and deactivate the control
+    //------------------------------------------------------------------------------------------------------------------
+
+    const canvasContextMenu = new ContextMenu({
+        enabled: true,
+        context: {
+            viewer: viewer
+        },
+        items: [
+            [
+                {
+                    getTitle: (context) => {
+                        return distanceMeasurementsPlugin.control.active ? "Deactivate Control" : "Activate Control";
+                    },
+                    doAction: function (context) {
+                        distanceMeasurementsPlugin.control.active
+                            ? distanceMeasurementsPlugin.control.deactivate()
+                            : distanceMeasurementsPlugin.control.activate();
+                    }
+                }
+            ]
+        ]
+    });
+
+    // viewer.cameraControl.on("rightClick", function (e) {
+    //     canvasContextMenu.show(e.pagePos[0], e.pagePos[1]);
+    //     e.event.preventDefault();
+    // });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create an DistanceMeasurementsPlugin, activate its DistanceMeasuremntsControl
+    //------------------------------------------------------------------------------------------------------------------
+
+    distanceMeasurementsPlugin.on("mouseOver", (e) => {
+        e.distanceMeasurement.setHighlighted(true);
+    });
+
+    distanceMeasurementsPlugin.on("mouseLeave", (e) => {
+        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.distanceMeasurement.id === e.distanceMeasurement.id) {
+            return;
+        }
+        e.distanceMeasurement.setHighlighted(false);
+    });
+
+    distanceMeasurementsPlugin.on("contextMenu", (e) => {
+        distanceMeasurementsContextMenu.context = { // Must set context before showing menu
+            viewer: viewer,
+            distanceMeasurementsPlugin: distanceMeasurementsPlugin,
+            distanceMeasurement: e.distanceMeasurement
+        };
+        distanceMeasurementsContextMenu.show(e.event.clientX, e.event.clientY);
+        e.event.preventDefault();
+    });
+
+    window.viewer = viewer;
+
+</script>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,18 @@
 {
   "name": "@xeokit/xeokit-sdk",
-  "version": "2.5.2-beta-30",
+  "version": "2.6.0-beta-10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xeokit/xeokit-sdk",
-      "version": "2.5.2-beta-30",
+      "version": "2.6.0-beta-10",
       "license": "See LICENSE.txt",
       "dependencies": {
         "@loaders.gl/core": "^3.2.6",
         "@loaders.gl/gltf": "^3.2.6",
         "@loaders.gl/las": "^3.2.6",
-        "html2canvas": "^1.4.1",
-        "web-ifc": "^0.0.51"
+        "html2canvas": "^1.4.1"
       },
       "devDependencies": {
         "@babel/core": "^7.18.6",
@@ -5903,11 +5902,6 @@
       "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
       "dev": true
     },
-    "node_modules/web-ifc": {
-      "version": "0.0.51",
-      "resolved": "https://registry.npmjs.org/web-ifc/-/web-ifc-0.0.51.tgz",
-      "integrity": "sha512-eh1+4viQz+ICHsp7Ukq8ru71O9FWO+ejiU9r5lhxKGVIDdDtt7YegdR4RHAhxpZhHCXo6tDNvqgxyWUeCcwZ2Q=="
-    },
     "node_modules/webidl-conversions": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-2.0.1.tgz",
@@ -10539,11 +10533,6 @@
       "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
       "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
       "dev": true
-    },
-    "web-ifc": {
-      "version": "0.0.51",
-      "resolved": "https://registry.npmjs.org/web-ifc/-/web-ifc-0.0.51.tgz",
-      "integrity": "sha512-eh1+4viQz+ICHsp7Ukq8ru71O9FWO+ejiU9r5lhxKGVIDdDtt7YegdR4RHAhxpZhHCXo6tDNvqgxyWUeCcwZ2Q=="
     },
     "webidl-conversions": {
       "version": "2.0.1",

--- a/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsMouseControl.js
+++ b/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsMouseControl.js
@@ -47,12 +47,15 @@ export class DistanceMeasurementsMouseControl extends DistanceMeasurementsContro
      *
      * @param {DistanceMeasurementsPlugin} distanceMeasurementsPlugin The AngleMeasurementsPlugin to control.
      * @param [cfg] Configuration
+     * @param {function} [cfg.canvasToPagePos] Optional function to map canvas-space coordinates to page coordinates.
      * @param {PointerLens} [cfg.pointerLens] A PointerLens to use to provide a magnified view of the cursor when snapping is enabled.
      * @param {boolean} [cfg.snapping=true] Whether to initially enable snap-to-vertex and snap-to-edge for this DistanceMeasurementsMouseControl.
      */
     constructor(distanceMeasurementsPlugin, cfg = {}) {
 
         super(distanceMeasurementsPlugin.viewer.scene);
+
+        this._canvasToPagePos = cfg.canvasToPagePos;
 
         this.pointerLens = cfg.pointerLens;
 
@@ -200,6 +203,8 @@ export class DistanceMeasurementsMouseControl extends DistanceMeasurementsContro
         const getTop = el => el.offsetTop + (el.offsetParent && getTop(el.offsetParent));
         const getLeft = el => el.offsetLeft + (el.offsetParent && getLeft(el.offsetParent));
 
+        const pagePos = math.vec2();
+
         this._onCameraControlHoverSnapOrSurface = cameraControl.on(
             this._snapping
                 ? "hoverSnapOrSurface"
@@ -210,8 +215,14 @@ export class DistanceMeasurementsMouseControl extends DistanceMeasurementsContro
                 pointerCanvasPos.set(event.canvasPos);
                 if (this._mouseState === MOUSE_FIRST_CLICK_EXPECTED) {
 
-                    this._markerDiv.style.left = `${getLeft(canvas) + canvasPos[0] - 5}px`;
-                    this._markerDiv.style.top = `${getTop(canvas) + canvasPos[1] - 5}px`;
+                    if (this._canvasToPagePos) {
+                        this._canvasToPagePos(canvas, canvasPos, pagePos);
+                        this._markerDiv.style.left = `${pagePos[0] - 5}px`;
+                        this._markerDiv.style.top = `${pagePos[1] - 5}px`;
+                    } else {
+                        this._markerDiv.style.left = `${getLeft(canvas) + canvasPos[0] - 5}px`;
+                        this._markerDiv.style.top = `${getTop(canvas) + canvasPos[1] - 5}px`;
+                    }
 
                     this._markerDiv.style.background = "pink";
                     if (event.snappedToVertex || event.snappedToEdge) {


### PR DESCRIPTION
Within measurements controllers, we're having difficulties robustly mapping canvas-space coordinates to page coordinates for some HTML layouts.

Until we work out a robust mapping internally, we'll support a user-configured mapping function for `DistanceMeasurementsMouseControl` and `AngleMeasurementsMouseControl`. 

Usage shown below.

## Distance measurements

````javascript
 const distanceMeasurementsPlugin = new DistanceMeasurementsPlugin(viewer);

const distanceMeasurementsMouseControl = new DistanceMeasurementsMouseControl(distanceMeasurementsPlugin, {

     canvasToPagePos: (canvas, canvasPos, pagePos) => {
         const getTop = el => el.offsetTop + (el.offsetParent && getTop(el.offsetParent));
         const getLeft = el => el.offsetLeft + (el.offsetParent && getLeft(el.offsetParent));
         pagePos[0] = getLeft(canvas) + canvasPos[0];
         pagePos[1] = getTop(canvas) + canvasPos[1];
     }
})

````

## Angle measurements

````javascript
    const angleMeasurementsPlugin = new AngleMeasurementsPlugin(viewer);

    const angleMeasurementsMouseControl  = new AngleMeasurementsMouseControl(angleMeasurementsPlugin, {
       
        canvasToPagePos: (canvas, canvasPos, pagePos) => {
            const getTop = el => el.offsetTop + (el.offsetParent && getTop(el.offsetParent));
            const getLeft = el => el.offsetLeft + (el.offsetParent && getLeft(el.offsetParent));
            pagePos[0] = getLeft(canvas) + canvasPos[0];
            pagePos[1] = getTop(canvas) + canvasPos[1];
        }
    })
````