### PR TITLE
FIX Viewer.js breaking import

### DIFF
--- a/src/viewer/Viewer.js
+++ b/src/viewer/Viewer.js
@@ -3,7 +3,7 @@ import {CameraFlightAnimation} from "./scene/camera/CameraFlightAnimation.js";
 import {CameraControl} from "./scene/CameraControl/CameraControl.js";
 import {MetaScene} from "./metadata/MetaScene.js";
 import {LocaleService} from "./localization/LocaleService.js";
-import html2canvas from '../../node_modules/html2canvas/dist/html2canvas.esm.js';
+import html2canvas from 'html2canvas/dist/html2canvas.esm.js';
 
 /**
  * The 3D Viewer at the heart of the xeokit SDK.


### PR DESCRIPTION
This PR reverts this import to its previous value. The current import is breaking xeokit if used as an npm dependency.