### PR TITLE
[FIX] SceneModelTransform: parentTransformId parameter doesn't work

### DIFF
--- a/src/viewer/scene/model/SceneModel.js
+++ b/src/viewer/scene/model/SceneModel.js
@@ -2679,7 +2679,7 @@ export class SceneModel extends Component {
         const transform = new SceneModelTransform({
             id: cfg.id,
             model: this,
-            parentTransform,
+            parent: parentTransform,
             matrix: cfg.matrix,
             position: cfg.position,
             scale: cfg.scale,


### PR DESCRIPTION
Follow-up fix for #1441