### PR TITLE
Fixed BCFViewpointsPlugin setViewpoint setting IfcSpaces visible when spaces_visible is false

### DIFF
--- a/src/plugins/BCFViewpointsPlugin/BCFViewpointsPlugin.js
+++ b/src/plugins/BCFViewpointsPlugin/BCFViewpointsPlugin.js
@@ -757,7 +757,7 @@ class BCFViewpointsPlugin extends Plugin {
                 const view_setup_hints = bcfViewpoint.components.visibility.view_setup_hints;
                 if (view_setup_hints) {
                     if (view_setup_hints.spaces_visible === false) {
-                        scene.setObjectsVisible(viewer.metaScene.getObjectIDsByType("IfcSpace"), true);
+                        scene.setObjectsVisible(viewer.metaScene.getObjectIDsByType("IfcSpace"), false);
                     }
                     if (view_setup_hints.spaces_translucent !== undefined) {
                         scene.setObjectsXRayed(viewer.metaScene.getObjectIDsByType("IfcSpace"), true);


### PR DESCRIPTION
Fixed an issue where spaces are set visible when the view_setup_hints.spaces_visible is false. 
Looking at earlier versions of the file it seems that the spaces were supposed to be set invisible when the value is false, so I have reverted back to that here. 

The previous change to this line: https://github.com/xeokit/xeokit-sdk/commit/121d69278cf472396e113f2a2956fd30d4421e96#diff-75b53714641211fbda32412d7bd9dd7c4523fcb1e6f88389a4cb972d9803b23eR760