### PR TITLE
ContextMenu enhancements and example improvements

### DIFF
--- a/examples/measurement/angle_createWithMouse_nosnapping.html
+++ b/examples/measurement/angle_createWithMouse_nosnapping.html
@@ -131,6 +131,8 @@
     viewer.camera.look = [4.40, 3.72, 8.89];
     viewer.camera.up = [-0.01, 0.99, 0.039];
 
+    viewer.cameraControl.panRightClick = false; // Prevents right-click-drag panning interfering with ContextMenus
+
     const xktLoader = new XKTLoaderPlugin(viewer);
 
     const sceneModel = xktLoader.load({
@@ -149,17 +151,17 @@
             [
                 {
                     getTitle: (context) => {
-                        return context.measurement.labelsVisible ? "Hide Labels" : "Show Labels";
+                        return context.angleMeasurement.labelsVisible ? "Hide Labels" : "Show Labels";
                     },
                     doAction: function (context) {
-                        context.measurement.labelsVisible = !context.measurement.labelsVisible;
+                        context.angleMeasurement.labelsVisible = !context.angleMeasurement.labelsVisible;
                     }
                 }
             ], [
                 {
                     title: "Delete Measurement",
                     doAction: function (context) {
-                        context.measurement.destroy();
+                        context.angleMeasurement.destroy();
                     }
                 }
             ]
@@ -168,8 +170,8 @@
     });
 
     angleMeasurementsContextMenu.on("hidden", () => {
-        if (angleMeasurementsContextMenu.context.measurement) {
-            angleMeasurementsContextMenu.context.measurement.setHighlighted(false);
+        if (angleMeasurementsContextMenu.context.angleMeasurement) {
+            angleMeasurementsContextMenu.context.angleMeasurement.setHighlighted(false);
         }
     });
 
@@ -190,21 +192,21 @@
     angleMeasurementsMouseControl.activate();
 
     angleMeasurementsPlugin.on("mouseOver", (e) => {
-        e.measurement.setHighlighted(true);
+        e.angleMeasurement.setHighlighted(true);
     });
 
     angleMeasurementsPlugin.on("mouseLeave", (e) => {
-        if (angleMeasurementsContextMenu.shown && angleMeasurementsContextMenu.context.measurement.id === e.measurement.id) {
+        if (angleMeasurementsContextMenu.shown && angleMeasurementsContextMenu.context.angleMeasurement.id === e.angleMeasurement.id) {
             return;
         }
-        e.measurement.setHighlighted(false);
+        e.angleMeasurement.setHighlighted(false);
     });
 
     angleMeasurementsPlugin.on("contextMenu", (e) => {
         angleMeasurementsContextMenu.context = { // Must set context before showing menu
             viewer: viewer,
             angleMeasurementsPlugin: angleMeasurementsPlugin,
-            measurement: e.measurement
+            angleMeasurement: e.angleMeasurement
         };
         angleMeasurementsContextMenu.show(e.event.clientX, e.event.clientY);
         e.event.preventDefault();
@@ -728,31 +730,50 @@
         ]
     });
 
-    viewer.cameraControl.on("rightClick", (e) => {
-
+    viewer.scene.canvas.canvas.addEventListener('contextmenu', (event) => {
+        const canvasPos = getCanvasPosFromEvent(event);
         const hit = viewer.scene.pick({
-            canvasPos: e.canvasPos
+            canvasPos
         });
-
         if (hit && hit.entity.isObject) {
-
             objectContextMenu.context = { // Must set context before showing menu
-                viewer: viewer,
+                viewer,
                 entity: hit.entity
             };
-
-            objectContextMenu.show(e.pagePos[0], e.pagePos[1]);
+            objectContextMenu.show(event.pageX, event.pageY);
         } else {
-
             canvasContextMenu.context = { // Must set context before showing menu
-                viewer: viewer
+                viewer
             };
-
-            canvasContextMenu.show(e.pagePos[0], e.pagePos[1]);
+            canvasContextMenu.show(event.pageX, event.pageY);
         }
-
-        e.event.preventDefault();
+        event.preventDefault();
     });
+
+    const getCanvasPosFromEvent = function (event) {
+        const canvasPos = [];
+        if (!event) {
+            event = window.event;
+            canvasPos[0] = event.x;
+            canvasPos[1] = event.y;
+        } else {
+            let element = event.target;
+            let totalOffsetLeft = 0;
+            let totalOffsetTop = 0;
+            let totalScrollX = 0;
+            let totalScrollY = 0;
+            while (element.offsetParent) {
+                totalOffsetLeft += element.offsetLeft;
+                totalOffsetTop += element.offsetTop;
+                totalScrollX += element.scrollLeft;
+                totalScrollY += element.scrollTop;
+                element = element.offsetParent;
+            }
+            canvasPos[0] = event.pageX + totalScrollX - totalOffsetLeft;
+            canvasPos[1] = event.pageY + totalScrollY - totalOffsetTop;
+        }
+        return canvasPos;
+    };
 
 
 </script>

--- a/examples/measurement/angle_createWithMouse_snapping.html
+++ b/examples/measurement/angle_createWithMouse_snapping.html
@@ -131,6 +131,8 @@
     viewer.camera.look = [4.40, 3.72, 8.89];
     viewer.camera.up = [-0.01, 0.99, 0.039];
 
+    viewer.cameraControl.panRightClick = false; // Prevents right-click-drag panning interfering with ContextMenus
+
     //------------------------------------------------------------------------------------------------------------------
     // Load a model
     //------------------------------------------------------------------------------------------------------------------
@@ -157,17 +159,17 @@
             [
                 {
                     getTitle: (context) => {
-                        return context.measurement.labelsVisible ? "Hide Labels" : "Show Labels";
+                        return context.angleMeasurement.labelsVisible ? "Hide Labels" : "Show Labels";
                     },
                     doAction: function (context) {
-                        context.measurement.labelsVisible = !context.measurement.labelsVisible;
+                        context.angleMeasurement.labelsVisible = !context.angleMeasurement.labelsVisible;
                     }
                 }
             ], [
                 {
                     title: "Delete Measurement",
                     doAction: function (context) {
-                        context.measurement.destroy();
+                        context.angleMeasurement.destroy();
                     }
                 }
             ]
@@ -176,8 +178,8 @@
     });
 
     angleMeasurementsContextMenu.on("hidden", () => {
-        if (angleMeasurementsContextMenu.context.measurement) {
-            angleMeasurementsContextMenu.context.measurement.setHighlighted(false);
+        if (angleMeasurementsContextMenu.context.angleMeasurement) {
+            angleMeasurementsContextMenu.context.angleMeasurement.setHighlighted(false);
         }
     });
 
@@ -189,25 +191,25 @@
         zIndex: 100000 // If set, the wires, dots and labels will have this zIndex (+1 for dots and +2 for labels).
     });
 
-    angleMeasurementsPlugin.on("measurementStart", (measurement) => {
+    angleMeasurementsPlugin.on("measurementStart", (angleMeasurement) => {
         console.log("measurementStart");
-        console.log("origin", measurement.origin.entity);
-        console.log("corner", measurement.corner.entity);
-        console.log("target", measurement.target.entity);
+        console.log("origin", angleMeasurement.origin.entity);
+        console.log("corner", angleMeasurement.corner.entity);
+        console.log("target", angleMeasurement.target.entity);
     });
 
-    angleMeasurementsPlugin.on("measurementEnd", (measurement) => {
+    angleMeasurementsPlugin.on("measurementEnd", (angleMeasurement) => {
         console.log("measurementEnd");
-        console.log("origin", measurement.origin.entity);
-        console.log("corner", measurement.corner.entity);
-        console.log("target", measurement.target.entity);
+        console.log("origin", angleMeasurement.origin.entity);
+        console.log("corner", angleMeasurement.corner.entity);
+        console.log("target", angleMeasurement.target.entity);
     });
 
-    angleMeasurementsPlugin.on("measurementCancel", (measurement) => {
+    angleMeasurementsPlugin.on("measurementCancel", (angleMeasurement) => {
         console.log("measurementCancel");
-        console.log("origin", measurement.origin.entity);
-        console.log("corner", measurement.corner.entity);
-        console.log("target", measurement.target.entity);
+        console.log("origin", angleMeasurement.origin.entity);
+        console.log("corner", angleMeasurement.corner.entity);
+        console.log("target", angleMeasurement.target.entity);
     });
 
     const angleMeasurementsMouseControl  = new AngleMeasurementsMouseControl(angleMeasurementsPlugin, {
@@ -219,21 +221,21 @@
     angleMeasurementsMouseControl.activate();
 
     angleMeasurementsPlugin.on("mouseOver", (e) => {
-        e.measurement.setHighlighted(true);
+        e.angleMeasurement.setHighlighted(true);
     });
 
     angleMeasurementsPlugin.on("mouseLeave", (e) => {
-        if (angleMeasurementsContextMenu.shown && angleMeasurementsContextMenu.context.measurement.id === e.measurement.id) {
+        if (angleMeasurementsContextMenu.shown && angleMeasurementsContextMenu.context.angleMeasurement.id === e.angleMeasurement.id) {
             return;
         }
-        e.measurement.setHighlighted(false);
+        e.angleMeasurement.setHighlighted(false);
     });
 
     angleMeasurementsPlugin.on("contextMenu", (e) => {
         angleMeasurementsContextMenu.context = { // Must set context before showing menu
             viewer: viewer,
             angleMeasurementsPlugin: angleMeasurementsPlugin,
-            measurement: e.measurement
+            angleMeasurement: e.angleMeasurement
         };
         angleMeasurementsContextMenu.show(e.event.clientX, e.event.clientY);
         e.event.preventDefault();
@@ -717,28 +719,21 @@
 
     viewer.scene.canvas.canvas.addEventListener('contextmenu', (event) => {
         const canvasPos = getCanvasPosFromEvent(event);
-
         const hit = viewer.scene.pick({
             canvasPos
         });
-
         if (hit && hit.entity.isObject) {
-
             objectContextMenu.context = { // Must set context before showing menu
-                viewer: viewer,
+                viewer,
                 entity: hit.entity
             };
-
-            objectContextMenu.show(canvasPos[0], canvasPos[1]);
+            objectContextMenu.show(event.pageX, event.pageY);
         } else {
-
             canvasContextMenu.context = { // Must set context before showing menu
-                viewer: viewer
+                viewer
             };
-
-            canvasContextMenu.show(canvasPos[0], canvasPos[1]);
+            canvasContextMenu.show(event.pageX, event.pageY);
         }
-
         event.preventDefault();
     });
 
@@ -766,6 +761,7 @@
         }
         return canvasPos;
     };
+
 
 </script>
 </html>

--- a/examples/measurement/angle_createWithMouse_snapping_canvasToPagePos.html
+++ b/examples/measurement/angle_createWithMouse_snapping_canvasToPagePos.html
@@ -131,6 +131,8 @@
     viewer.camera.look = [4.40, 3.72, 8.89];
     viewer.camera.up = [-0.01, 0.99, 0.039];
 
+    viewer.cameraControl.panRightClick = false; // Prevents right-click-drag panning interfering with ContextMenus
+
     //------------------------------------------------------------------------------------------------------------------
     // Load a model
     //------------------------------------------------------------------------------------------------------------------
@@ -157,17 +159,17 @@
             [
                 {
                     getTitle: (context) => {
-                        return context.measurement.labelsVisible ? "Hide Labels" : "Show Labels";
+                        return context.angleMeasurement.labelsVisible ? "Hide Labels" : "Show Labels";
                     },
                     doAction: function (context) {
-                        context.measurement.labelsVisible = !context.measurement.labelsVisible;
+                        context.angleMeasurement.labelsVisible = !context.angleMeasurement.labelsVisible;
                     }
                 }
             ], [
                 {
                     title: "Delete Measurement",
                     doAction: function (context) {
-                        context.measurement.destroy();
+                        context.angleMeasurement.destroy();
                     }
                 }
             ]
@@ -176,8 +178,8 @@
     });
 
     angleMeasurementsContextMenu.on("hidden", () => {
-        if (angleMeasurementsContextMenu.context.measurement) {
-            angleMeasurementsContextMenu.context.measurement.setHighlighted(false);
+        if (angleMeasurementsContextMenu.context.angleMeasurement) {
+            angleMeasurementsContextMenu.context.angleMeasurement.setHighlighted(false);
         }
     });
 
@@ -205,21 +207,21 @@
     angleMeasurementsMouseControl.activate();
 
     angleMeasurementsPlugin.on("mouseOver", (e) => {
-        e.measurement.setHighlighted(true);
+        e.angleMeasurement.setHighlighted(true);
     });
 
     angleMeasurementsPlugin.on("mouseLeave", (e) => {
-        if (angleMeasurementsContextMenu.shown && angleMeasurementsContextMenu.context.measurement.id === e.measurement.id) {
+        if (angleMeasurementsContextMenu.shown && angleMeasurementsContextMenu.context.angleMeasurement.id === e.angleMeasurement.id) {
             return;
         }
-        e.measurement.setHighlighted(false);
+        e.angleMeasurement.setHighlighted(false);
     });
 
     angleMeasurementsPlugin.on("contextMenu", (e) => {
         angleMeasurementsContextMenu.context = { // Must set context before showing menu
             viewer: viewer,
             angleMeasurementsPlugin: angleMeasurementsPlugin,
-            measurement: e.measurement
+            angleMeasurement: e.angleMeasurement
         };
         angleMeasurementsContextMenu.show(e.event.clientX, e.event.clientY);
         e.event.preventDefault();
@@ -701,31 +703,50 @@
         ]
     });
 
-    viewer.cameraControl.on("rightClick", (e) => {
-
+    viewer.scene.canvas.canvas.addEventListener('contextmenu', (event) => {
+        const canvasPos = getCanvasPosFromEvent(event);
         const hit = viewer.scene.pick({
-            canvasPos: e.canvasPos
+            canvasPos
         });
-
         if (hit && hit.entity.isObject) {
-
             objectContextMenu.context = { // Must set context before showing menu
-                viewer: viewer,
+                viewer,
                 entity: hit.entity
             };
-
-            objectContextMenu.show(e.pagePos[0], e.pagePos[1]);
+            objectContextMenu.show(event.pageX, event.pageY);
         } else {
-
             canvasContextMenu.context = { // Must set context before showing menu
-                viewer: viewer
+                viewer
             };
-
-            canvasContextMenu.show(e.pagePos[0], e.pagePos[1]);
+            canvasContextMenu.show(event.pageX, event.pageY);
         }
-
-        e.event.preventDefault();
+        event.preventDefault();
     });
+
+    const getCanvasPosFromEvent = function (event) {
+        const canvasPos = [];
+        if (!event) {
+            event = window.event;
+            canvasPos[0] = event.x;
+            canvasPos[1] = event.y;
+        } else {
+            let element = event.target;
+            let totalOffsetLeft = 0;
+            let totalOffsetTop = 0;
+            let totalScrollX = 0;
+            let totalScrollY = 0;
+            while (element.offsetParent) {
+                totalOffsetLeft += element.offsetLeft;
+                totalOffsetTop += element.offsetTop;
+                totalScrollX += element.scrollLeft;
+                totalScrollY += element.scrollTop;
+                element = element.offsetParent;
+            }
+            canvasPos[0] = event.pageX + totalScrollX - totalOffsetLeft;
+            canvasPos[1] = event.pageY + totalScrollY - totalOffsetTop;
+        }
+        return canvasPos;
+    };
 
 
 </script>

--- a/examples/measurement/angle_createWithMouse_snapping_offsetCanvas.html
+++ b/examples/measurement/angle_createWithMouse_snapping_offsetCanvas.html
@@ -131,6 +131,9 @@
     viewer.camera.look = [4.40, 3.72, 8.89];
     viewer.camera.up = [-0.01, 0.99, 0.039];
 
+    viewer.cameraControl.panRightClick = false; // Prevents right-click-drag panning interfering with ContextMenus
+
+
     //------------------------------------------------------------------------------------------------------------------
     // Load a model
     //------------------------------------------------------------------------------------------------------------------
@@ -157,17 +160,17 @@
             [
                 {
                     getTitle: (context) => {
-                        return context.measurement.labelsVisible ? "Hide Labels" : "Show Labels";
+                        return context.angleMeasurement.labelsVisible ? "Hide Labels" : "Show Labels";
                     },
                     doAction: function (context) {
-                        context.measurement.labelsVisible = !context.measurement.labelsVisible;
+                        context.angleMeasurement.labelsVisible = !context.angleMeasurement.labelsVisible;
                     }
                 }
             ], [
                 {
                     title: "Delete Measurement",
                     doAction: function (context) {
-                        context.measurement.destroy();
+                        context.angleMeasurement.destroy();
                     }
                 }
             ]
@@ -176,8 +179,8 @@
     });
 
     angleMeasurementsContextMenu.on("hidden", () => {
-        if (angleMeasurementsContextMenu.context.measurement) {
-            angleMeasurementsContextMenu.context.measurement.setHighlighted(false);
+        if (angleMeasurementsContextMenu.context.angleMeasurement) {
+            angleMeasurementsContextMenu.context.angleMeasurement.setHighlighted(false);
         }
     });
 
@@ -198,21 +201,21 @@
     angleMeasurementsMouseControl.activate();
 
     angleMeasurementsPlugin.on("mouseOver", (e) => {
-        e.measurement.setHighlighted(true);
+        e.angleMeasurement.setHighlighted(true);
     });
 
     angleMeasurementsPlugin.on("mouseLeave", (e) => {
-        if (angleMeasurementsContextMenu.shown && angleMeasurementsContextMenu.context.measurement.id === e.measurement.id) {
+        if (angleMeasurementsContextMenu.shown && angleMeasurementsContextMenu.context.angleMeasurement.id === e.angleMeasurement.id) {
             return;
         }
-        e.measurement.setHighlighted(false);
+        e.angleMeasurement.setHighlighted(false);
     });
 
     angleMeasurementsPlugin.on("contextMenu", (e) => {
         angleMeasurementsContextMenu.context = { // Must set context before showing menu
             viewer: viewer,
             angleMeasurementsPlugin: angleMeasurementsPlugin,
-            measurement: e.measurement
+            angleMeasurement: e.angleMeasurement
         };
         angleMeasurementsContextMenu.show(e.event.clientX, e.event.clientY);
         e.event.preventDefault();
@@ -694,31 +697,51 @@
         ]
     });
 
-    viewer.cameraControl.on("rightClick", (e) => {
-
+    viewer.scene.canvas.canvas.addEventListener('contextmenu', (event) => {
+        const canvasPos = getCanvasPosFromEvent(event);
         const hit = viewer.scene.pick({
-            canvasPos: e.canvasPos
+            canvasPos
         });
-
         if (hit && hit.entity.isObject) {
-
             objectContextMenu.context = { // Must set context before showing menu
-                viewer: viewer,
+                viewer,
                 entity: hit.entity
             };
-
-            objectContextMenu.show(e.pagePos[0], e.pagePos[1]);
+            objectContextMenu.show(event.pageX, event.pageY);
         } else {
-
             canvasContextMenu.context = { // Must set context before showing menu
-                viewer: viewer
+                viewer
             };
-
-            canvasContextMenu.show(e.pagePos[0], e.pagePos[1]);
+            canvasContextMenu.show(event.pageX, event.pageY);
         }
-
-        e.event.preventDefault();
+        event.preventDefault();
     });
+
+    const getCanvasPosFromEvent = function (event) {
+        const canvasPos = [];
+        if (!event) {
+            event = window.event;
+            canvasPos[0] = event.x;
+            canvasPos[1] = event.y;
+        } else {
+            let element = event.target;
+            let totalOffsetLeft = 0;
+            let totalOffsetTop = 0;
+            let totalScrollX = 0;
+            let totalScrollY = 0;
+            while (element.offsetParent) {
+                totalOffsetLeft += element.offsetLeft;
+                totalOffsetTop += element.offsetTop;
+                totalScrollX += element.scrollLeft;
+                totalScrollY += element.scrollTop;
+                element = element.offsetParent;
+            }
+            canvasPos[0] = event.pageX + totalScrollX - totalOffsetLeft;
+            canvasPos[1] = event.pageY + totalScrollY - totalOffsetTop;
+        }
+        return canvasPos;
+    };
+
 
 
 </script>

--- a/examples/measurement/angle_modelWithMeasurements.html
+++ b/examples/measurement/angle_modelWithMeasurements.html
@@ -134,6 +134,8 @@
     viewer.camera.look = [4.40, 3.72, 8.89];
     viewer.camera.up = [-0.01, 0.99, 0.039];
 
+    viewer.cameraControl.panRightClick = false; // Prevents right-click-drag panning interfering with ContextMenus
+
     viewer.cameraControl.followPointer = true;
 
     //------------------------------------------------------------------------------------------------------------------
@@ -158,17 +160,17 @@
             [
                 {
                     getTitle: (context) => {
-                        return context.measurement.labelsVisible ? "Hide Labels" : "Show Labels";
+                        return context.angleMeasurement.labelsVisible ? "Hide Labels" : "Show Labels";
                     },
                     doAction: function (context) {
-                        context.measurement.labelsVisible = !context.measurement.labelsVisible;
+                        context.angleMeasurement.labelsVisible = !context.angleMeasurement.labelsVisible;
                     }
                 }
             ], [
                 {
                     title: "Delete Measurement",
                     doAction: function (context) {
-                        context.measurement.destroy();
+                        context.angleMeasurement.destroy();
                     }
                 }
             ]
@@ -177,8 +179,8 @@
     });
 
     angleMeasurementsContextMenu.on("hidden", () => {
-        if (angleMeasurementsContextMenu.context.measurement) {
-            angleMeasurementsContextMenu.context.measurement.setHighlighted(false);
+        if (angleMeasurementsContextMenu.context.angleMeasurement) {
+            angleMeasurementsContextMenu.context.angleMeasurement.setHighlighted(false);
         }
     });
     
@@ -191,21 +193,21 @@
     });
 
     angleMeasurementsPlugin.on("mouseOver", (e) => {
-        e.measurement.setHighlighted(true);
+        e.angleMeasurement.setHighlighted(true);
     });
 
     angleMeasurementsPlugin.on("mouseLeave", (e) => {
-        if (angleMeasurementsContextMenu.shown && angleMeasurementsContextMenu.context.measurement.id === e.measurement.id) {
+        if (angleMeasurementsContextMenu.shown && angleMeasurementsContextMenu.context.angleMeasurement.id === e.angleMeasurement.id) {
             return;
         }
-        e.measurement.setHighlighted(false);
+        e.angleMeasurement.setHighlighted(false);
     });
 
     angleMeasurementsPlugin.on("contextMenu", (e) => {
         angleMeasurementsContextMenu.context = { // Must set context before showing menu
             viewer: viewer,
             angleMeasurementsPlugin: angleMeasurementsPlugin,
-            measurement: e.measurement
+            angleMeasurement: e.angleMeasurement
         };
         angleMeasurementsContextMenu.show(e.event.clientX, e.event.clientY);
         e.event.preventDefault();
@@ -729,31 +731,51 @@
         ]
     });
 
-    viewer.cameraControl.on("rightClick", (e) => {
-
+    viewer.scene.canvas.canvas.addEventListener('contextmenu', (event) => {
+        const canvasPos = getCanvasPosFromEvent(event);
         const hit = viewer.scene.pick({
-            canvasPos: e.canvasPos
+            canvasPos
         });
-
         if (hit && hit.entity.isObject) {
-
             objectContextMenu.context = { // Must set context before showing menu
-                viewer: viewer,
+                viewer,
                 entity: hit.entity
             };
-
-            objectContextMenu.show(e.pagePos[0], e.pagePos[1]);
+            objectContextMenu.show(event.pageX, event.pageY);
         } else {
-
             canvasContextMenu.context = { // Must set context before showing menu
-                viewer: viewer
+                viewer
             };
-
-            canvasContextMenu.show(e.pagePos[0], e.pagePos[1]);
+            canvasContextMenu.show(event.pageX, event.pageY);
         }
-
-        e.event.preventDefault();
+        event.preventDefault();
     });
+
+    const getCanvasPosFromEvent = function (event) {
+        const canvasPos = [];
+        if (!event) {
+            event = window.event;
+            canvasPos[0] = event.x;
+            canvasPos[1] = event.y;
+        } else {
+            let element = event.target;
+            let totalOffsetLeft = 0;
+            let totalOffsetTop = 0;
+            let totalScrollX = 0;
+            let totalScrollY = 0;
+            while (element.offsetParent) {
+                totalOffsetLeft += element.offsetLeft;
+                totalOffsetTop += element.offsetTop;
+                totalScrollX += element.scrollLeft;
+                totalScrollY += element.scrollTop;
+                element = element.offsetParent;
+            }
+            canvasPos[0] = event.pageX + totalScrollX - totalOffsetLeft;
+            canvasPos[1] = event.pageY + totalScrollY - totalOffsetTop;
+        }
+        return canvasPos;
+    };
+
 
     window.viewer = viewer;
 

--- a/examples/measurement/distance_createWithMouse_labelsNotOnWires.html
+++ b/examples/measurement/distance_createWithMouse_labelsNotOnWires.html
@@ -149,6 +149,8 @@
     viewer.camera.look = [4.40, 3.72, 8.89];
     viewer.camera.up = [-0.01, 0.99, 0.039];
 
+    viewer.cameraControl.panRightClick = false; // Prevents right-click-drag panning interfering with ContextMenus
+
     //------------------------------------------------------------------------------------------------------------------
     // Load a model
     //------------------------------------------------------------------------------------------------------------------
@@ -174,14 +176,14 @@
     distanceMeasurementsPlugin.defaultLabelsOnWires = false; // Changes the labels visibility mode, so one can be under the other.
 
     distanceMeasurementsPlugin.on("mouseOver", (e) => {
-        e.measurement.setHighlighted(true);
+        e.distanceMeasurement.setHighlighted(true);
     });
 
     distanceMeasurementsPlugin.on("mouseLeave", (e) => {
-        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.measurement.id === e.measurement.id) {
+        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.distanceMeasurement.id === e.distanceMeasurement.id) {
             return;
         }
-        e.measurement.setHighlighted(false);
+        e.distanceMeasurement.setHighlighted(false);
     });
 
     const distanceMeasurementsMouseControl  = new DistanceMeasurementsMouseControl(distanceMeasurementsPlugin, {

--- a/examples/measurement/distance_createWithMouse_nosnapping.html
+++ b/examples/measurement/distance_createWithMouse_nosnapping.html
@@ -143,6 +143,7 @@
     viewer.camera.look = [4.40, 3.72, 8.89];
     viewer.camera.up = [-0.01, 0.99, 0.039];
 
+    viewer.cameraControl.panRightClick = false; // Prevents right-click-drag panning interfering with ContextMenus
 
     //------------------------------------------------------------------------------------------------------------------
     // Vertex-snapping mode

--- a/examples/measurement/distance_createWithMouse_snapping.html
+++ b/examples/measurement/distance_createWithMouse_snapping.html
@@ -149,6 +149,8 @@
     viewer.camera.look = [4.40, 3.72, 8.89];
     viewer.camera.up = [-0.01, 0.99, 0.039];
 
+    viewer.cameraControl.panRightClick = false; // Prevents right-click-drag panning interfering with ContextMenus
+
     //------------------------------------------------------------------------------------------------------------------
     // Load a model
     //------------------------------------------------------------------------------------------------------------------
@@ -171,35 +173,35 @@
 
     const distanceMeasurementsPlugin = new DistanceMeasurementsPlugin(viewer);
 
-    distanceMeasurementsPlugin.on("measurementStart", (measurement) => {
+    distanceMeasurementsPlugin.on("measurementStart", (distanceMeasurement) => {
         console.log("measurementStart");
-        console.log("origin", measurement.origin.entity);
-        console.log("target", measurement.target.entity);
+        console.log("origin", distanceMeasurement.origin.entity);
+        console.log("target", distanceMeasurement.target.entity);
     });
 
-    distanceMeasurementsPlugin.on("measurementEnd", (measurement) => {
+    distanceMeasurementsPlugin.on("measurementEnd", (distanceMeasurement) => {
         console.log("measurementEnd");
-        console.log("origin", measurement.origin.entity);
-        console.log("target", measurement.target.entity);
+        console.log("origin", distanceMeasurement.origin.entity);
+        console.log("target", distanceMeasurement.target.entity);
     });
 
-    distanceMeasurementsPlugin.on("measurementCancel", (measurement) => {
+    distanceMeasurementsPlugin.on("measurementCancel", (distanceMeasurement) => {
         console.log("measurementCancel");
-        console.log("origin", measurement.origin.entity);
-        console.log("target", measurement.target.entity);
+        console.log("origin", distanceMeasurement.origin.entity);
+        console.log("target", distanceMeasurement.target.entity);
     });
 
     distanceMeasurementsPlugin.on("mouseOver", (e) => {
-        e.measurement.setHighlighted(true);
+        e.distanceMeasurement.setHighlighted(true);
     });
 
     distanceMeasurementsPlugin.on("mouseLeave", (e) => {
-        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.measurement.id === e.measurement.id) {
+        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.distanceMeasurement.id === e.distanceMeasurement.id) {
             return;
         }
-        e.measurement.setHighlighted(false);
+        e.distanceMeasurement.setHighlighted(false);
     });
-    
+
     const distanceMeasurementsMouseControl  = new DistanceMeasurementsMouseControl(distanceMeasurementsPlugin, {
         pointerLens : new PointerLens(viewer)
     })
@@ -286,8 +288,8 @@
        const canvasPos = getCanvasPosFromEvent(event);
         console.log("canvas context menu")
         canvasContextMenu.show(canvasPos[0], canvasPos[1]);
-        event.event.preventDefault();
-        event.event.stopPropagation();
+        event.preventDefault();
+       event.stopPropagation();
     });
 
     //------------------------------------------------------------------------------------------------------------------

--- a/examples/measurement/distance_createWithMouse_snapping_OpenProject_Hospital.html
+++ b/examples/measurement/distance_createWithMouse_snapping_OpenProject_Hospital.html
@@ -150,6 +150,8 @@
     viewer.camera.look = [4.40, 3.72, 8.89];
     viewer.camera.up = [-0.01, 0.99, 0.039];
 
+    viewer.cameraControl.panRightClick = false; // Prevents right-click-drag panning interfering with ContextMenus
+
     //------------------------------------------------------------------------------------------------------------------
     // Load a model
     //------------------------------------------------------------------------------------------------------------------
@@ -173,14 +175,14 @@
     const distanceMeasurementsPlugin = new DistanceMeasurementsPlugin(viewer);
 
     distanceMeasurementsPlugin.on("mouseOver", (e) => {
-        e.measurement.setHighlighted(true);
+        e.distanceMeasurement.setHighlighted(true);
     });
 
     distanceMeasurementsPlugin.on("mouseLeave", (e) => {
-        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.measurement.id === e.measurement.id) {
+        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.distanceMeasurement.id === e.distanceMeasurement.id) {
             return;
         }
-        e.measurement.setHighlighted(false);
+        e.distanceMeasurement.setHighlighted(false);
     });
 
     const distanceMeasurementsMouseControl  = new DistanceMeasurementsMouseControl(distanceMeasurementsPlugin, {

--- a/examples/measurement/distance_createWithMouse_snapping_canvasToPagePos.html
+++ b/examples/measurement/distance_createWithMouse_snapping_canvasToPagePos.html
@@ -156,6 +156,8 @@
     viewer.camera.look = [4.40, 3.72, 8.89];
     viewer.camera.up = [-0.01, 0.99, 0.039];
 
+    viewer.cameraControl.panRightClick = false; // Prevents right-click-drag panning interfering with ContextMenus
+
     //------------------------------------------------------------------------------------------------------------------
     // Load a model
     //------------------------------------------------------------------------------------------------------------------
@@ -179,14 +181,14 @@
     const distanceMeasurementsPlugin = new DistanceMeasurementsPlugin(viewer);
 
     distanceMeasurementsPlugin.on("mouseOver", (e) => {
-        e.measurement.setHighlighted(true);
+        e.distanceMeasurement.setHighlighted(true);
     });
 
     distanceMeasurementsPlugin.on("mouseLeave", (e) => {
-        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.measurement.id === e.measurement.id) {
+        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.distanceMeasurement.id === e.distanceMeasurement.id) {
             return;
         }
-        e.measurement.setHighlighted(false);
+        e.distanceMeasurement.setHighlighted(false);
     });
 
     const distanceMeasurementsMouseControl = new DistanceMeasurementsMouseControl(distanceMeasurementsPlugin, {

--- a/examples/measurement/distance_createWithMouse_snapping_dtx_batching.html
+++ b/examples/measurement/distance_createWithMouse_snapping_dtx_batching.html
@@ -159,6 +159,8 @@
     viewer.cameraControl.navMode = "orbit";
     viewer.cameraControl.followPointer = true;
 
+    viewer.cameraControl.panRightClick = false; // Prevents right-click-drag panning interfering with ContextMenus
+
     viewer.scene.pointsMaterial.roundPoints = true;
     viewer.scene.pointsMaterial.perspectivePoints = true;
     viewer.scene.pointsMaterial.pointSize = 2;
@@ -363,14 +365,14 @@
     const distanceMeasurementsPlugin = new DistanceMeasurementsPlugin(viewer);
 
     distanceMeasurementsPlugin.on("mouseOver", (e) => {
-        e.measurement.setHighlighted(true);
+        e.distanceMeasurement.setHighlighted(true);
     });
 
     distanceMeasurementsPlugin.on("mouseLeave", (e) => {
-        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.measurement.id === e.measurement.id) {
+        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.distanceMeasurement.id === e.distanceMeasurement.id) {
             return;
         }
-        e.measurement.setHighlighted(false);
+        e.distanceMeasurement.setHighlighted(false);
     });
 
     const distanceMeasurementsMouseControl = new DistanceMeasurementsMouseControl(distanceMeasurementsPlugin, {

--- a/examples/measurement/distance_createWithMouse_snapping_dtx_instancing.html
+++ b/examples/measurement/distance_createWithMouse_snapping_dtx_instancing.html
@@ -157,6 +157,8 @@
     viewer.cameraControl.navMode = "orbit";
     viewer.cameraControl.followPointer = true;
 
+    viewer.cameraControl.panRightClick = false; // Prevents right-click-drag panning interfering with ContextMenus
+
     viewer.scene.pointsMaterial.roundPoints = true;
     viewer.scene.pointsMaterial.perspectivePoints = true;
     viewer.scene.pointsMaterial.pointSize = 2;
@@ -400,14 +402,14 @@
     const distanceMeasurementsPlugin = new DistanceMeasurementsPlugin(viewer);
 
     distanceMeasurementsPlugin.on("mouseOver", (e) => {
-        e.measurement.setHighlighted(true);
+        e.distanceMeasurement.setHighlighted(true);
     });
 
     distanceMeasurementsPlugin.on("mouseLeave", (e) => {
-        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.measurement.id === e.measurement.id) {
+        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.distanceMeasurement.id === e.distanceMeasurement.id) {
             return;
         }
-        e.measurement.setHighlighted(false);
+        e.distanceMeasurement.setHighlighted(false);
     });
     
     const distanceMeasurementsMouseControl  = new DistanceMeasurementsMouseControl(distanceMeasurementsPlugin, {

--- a/examples/measurement/distance_createWithMouse_snapping_offsetCanvas.html
+++ b/examples/measurement/distance_createWithMouse_snapping_offsetCanvas.html
@@ -149,6 +149,8 @@
     viewer.camera.look = [4.40, 3.72, 8.89];
     viewer.camera.up = [-0.01, 0.99, 0.039];
 
+    viewer.cameraControl.panRightClick = false; // Prevents right-click-drag panning interfering with ContextMenus
+
     //------------------------------------------------------------------------------------------------------------------
     // Load a model
     //------------------------------------------------------------------------------------------------------------------
@@ -172,14 +174,14 @@
     const distanceMeasurementsPlugin = new DistanceMeasurementsPlugin(viewer);
 
     distanceMeasurementsPlugin.on("mouseOver", (e) => {
-        e.measurement.setHighlighted(true);
+        e.distanceMeasurement.setHighlighted(true);
     });
 
     distanceMeasurementsPlugin.on("mouseLeave", (e) => {
-        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.measurement.id === e.measurement.id) {
+        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.distanceMeasurement.id === e.distanceMeasurement.id) {
             return;
         }
-        e.measurement.setHighlighted(false);
+        e.distanceMeasurement.setHighlighted(false);
     });
     
     const distanceMeasurementsMouseControl  = new DistanceMeasurementsMouseControl(distanceMeasurementsPlugin, {

--- a/examples/measurement/distance_createWithMouse_snapping_vbo_batching.html
+++ b/examples/measurement/distance_createWithMouse_snapping_vbo_batching.html
@@ -155,6 +155,8 @@
     viewer.cameraControl.navMode = "orbit";
     viewer.cameraControl.followPointer = true;
 
+    viewer.cameraControl.panRightClick = false; // Prevents right-click-drag panning interfering with ContextMenus
+
     viewer.scene.pointsMaterial.roundPoints = true;
     viewer.scene.pointsMaterial.perspectivePoints = true;
     viewer.scene.pointsMaterial.pointSize = 2;
@@ -359,14 +361,14 @@
     const distanceMeasurementsPlugin = new DistanceMeasurementsPlugin(viewer);
 
     distanceMeasurementsPlugin.on("mouseOver", (e) => {
-        e.measurement.setHighlighted(true);
+        e.distanceMeasurement.setHighlighted(true);
     });
 
     distanceMeasurementsPlugin.on("mouseLeave", (e) => {
-        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.measurement.id === e.measurement.id) {
+        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.distanceMeasurement.id === e.distanceMeasurement.id) {
             return;
         }
-        e.measurement.setHighlighted(false);
+        e.distanceMeasurement.setHighlighted(false);
     });
     
     const distanceMeasurementsMouseControl  = new DistanceMeasurementsMouseControl(distanceMeasurementsPlugin, {

--- a/examples/measurement/distance_createWithMouse_snapping_vbo_instancing.html
+++ b/examples/measurement/distance_createWithMouse_snapping_vbo_instancing.html
@@ -159,6 +159,8 @@
     viewer.cameraControl.navMode = "orbit";
     viewer.cameraControl.followPointer = true;
 
+    viewer.cameraControl.panRightClick = false; // Prevents right-click-drag panning interfering with ContextMenus
+
     viewer.scene.pointsMaterial.roundPoints = true;
     viewer.scene.pointsMaterial.perspectivePoints = true;
     viewer.scene.pointsMaterial.pointSize = 2;
@@ -368,14 +370,14 @@
     const distanceMeasurementsPlugin = new DistanceMeasurementsPlugin(viewer);
 
     distanceMeasurementsPlugin.on("mouseOver", (e) => {
-        e.measurement.setHighlighted(true);
+        e.distanceMeasurement.setHighlighted(true);
     });
 
     distanceMeasurementsPlugin.on("mouseLeave", (e) => {
-        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.measurement.id === e.measurement.id) {
+        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.distanceMeasurement.id === e.distanceMeasurement.id) {
             return;
         }
-        e.measurement.setHighlighted(false);
+        e.distanceMeasurement.setHighlighted(false);
     });
     
     const distanceMeasurementsMouseControl  = new DistanceMeasurementsMouseControl(distanceMeasurementsPlugin, {

--- a/examples/measurement/distance_createWithTouch_snapping.html
+++ b/examples/measurement/distance_createWithTouch_snapping.html
@@ -142,6 +142,8 @@
     viewer.camera.look = [4.40, 3.72, 8.89];
     viewer.camera.up = [-0.01, 0.99, 0.039];
 
+    viewer.cameraControl.panRightClick = false; // Prevents right-click-drag panning interfering with ContextMenus
+
     //------------------------------------------------------------------------------------------------------------------
     // Load a model
     //------------------------------------------------------------------------------------------------------------------
@@ -164,22 +166,22 @@
 
     const distanceMeasurementsPlugin = new DistanceMeasurementsPlugin(viewer);
 
-    distanceMeasurementsPlugin.on("measurementStart", (measurement) => {
+    distanceMeasurementsPlugin.on("measurementStart", (distanceMeasurement) => {
         console.log("measurementStart");
-        console.log("origin", measurement.origin.entity);
-        console.log("target", measurement.target.entity);
+        console.log("origin", distanceMeasurement.origin.entity);
+        console.log("target", distanceMeasurement.target.entity);
     });
 
-    distanceMeasurementsPlugin.on("measurementEnd", (measurement) => {
+    distanceMeasurementsPlugin.on("measurementEnd", (distanceMeasurement) => {
         console.log("measurementEnd");
-        console.log("origin", measurement.origin.entity);
-        console.log("target", measurement.target.entity);
+        console.log("origin", distanceMeasurement.origin.entity);
+        console.log("target", distanceMeasurement.target.entity);
     });
 
-    distanceMeasurementsPlugin.on("measurementCancel", (measurement) => {
+    distanceMeasurementsPlugin.on("measurementCancel", (distanceMeasurement) => {
         console.log("measurementCancel");
-        console.log("origin", measurement.origin.entity);
-        console.log("target", measurement.target.entity);
+        console.log("origin", distanceMeasurement.origin.entity);
+        console.log("target", distanceMeasurement.target.entity);
     });
     
     const distanceMeasurementsTouchControl  = new DistanceMeasurementsTouchControl(distanceMeasurementsPlugin, {

--- a/examples/measurement/distance_modelWithMeasurements.html
+++ b/examples/measurement/distance_modelWithMeasurements.html
@@ -135,6 +135,8 @@
 
     viewer.cameraControl.followPointer = true;
 
+    viewer.cameraControl.panRightClick = false; // Prevents right-click-drag panning interfering with ContextMenus
+
     //------------------------------------------------------------------------------------------------------------------
     // Load a model
     //------------------------------------------------------------------------------------------------------------------
@@ -157,49 +159,49 @@
             [
                 {
                     getTitle: (context) => {
-                        return context.measurement.axisVisible ? "Hide Axis" : "Show Axis";
+                        return context.distanceMeasurement.axisVisible ? "Hide Axis" : "Show Axis";
                     },
                     doAction: function (context) {
-                        context.measurement.axisVisible = !context.measurement.axisVisible;
+                        context.distanceMeasurement.axisVisible = !context.distanceMeasurement.axisVisible;
                     }
                 },
                 {
                     getTitle: (context) => {
-                        return context.measurement.xAxisVisible ? "Hide X Axis" : "Show X Axis";
+                        return context.distanceMeasurement.xAxisVisible ? "Hide X Axis" : "Show X Axis";
                     },
                     doAction: function (context) {
-                        context.measurement.xAxisVisible = !context.measurement.xAxisVisible;
+                        context.distanceMeasurement.xAxisVisible = !context.distanceMeasurement.xAxisVisible;
                     }
                 },
                 {
                     getTitle: (context) => {
-                        return context.measurement.yAxisVisible ? "Hide Y Axis" : "Show Y Axis";
+                        return context.distanceMeasurement.yAxisVisible ? "Hide Y Axis" : "Show Y Axis";
                     },
                     doAction: function (context) {
-                        context.measurement.yAxisVisible = !context.measurement.yAxisVisible;
+                        context.distanceMeasurement.yAxisVisible = !context.distanceMeasurement.yAxisVisible;
                     }
                 },
                 {
                     getTitle: (context) => {
-                        return context.measurement.zAxisVisible ? "Hide Z Axis" : "Show Z Axis";
+                        return context.distanceMeasurement.zAxisVisible ? "Hide Z Axis" : "Show Z Axis";
                     },
                     doAction: function (context) {
-                        context.measurement.zAxisVisible = !context.measurement.zAxisVisible;
+                        context.distanceMeasurement.zAxisVisible = !context.distanceMeasurement.zAxisVisible;
                     }
                 },
                 {
                     getTitle: (context) => {
-                        return context.measurement.labelsVisible ? "Hide Labels" : "Show Labels";
+                        return context.distanceMeasurement.labelsVisible ? "Hide Labels" : "Show Labels";
                     },
                     doAction: function (context) {
-                        context.measurement.labelsVisible = !context.measurement.labelsVisible;
+                        context.distanceMeasurement.labelsVisible = !context.distanceMeasurement.labelsVisible;
                     }
                 }
             ], [
                 {
                     title: "Delete Measurement",
                     doAction: function (context) {
-                        context.measurement.destroy();
+                        context.distanceMeasurement.destroy();
                     }
                 }
             ]
@@ -208,8 +210,8 @@
     });
 
     distanceMeasurementsContextMenu.on("hidden", () => {
-        if (distanceMeasurementsContextMenu.context.measurement) {
-            distanceMeasurementsContextMenu.context.measurement.setHighlighted(false);
+        if (distanceMeasurementsContextMenu.context.distanceMeasurement) {
+            distanceMeasurementsContextMenu.context.distanceMeasurement.setHighlighted(false);
         }
     });
 
@@ -222,21 +224,21 @@
     });
 
     distanceMeasurementsPlugin.on("mouseOver", (e) => {
-        e.measurement.setHighlighted(true);
+        e.distanceMeasurement.setHighlighted(true);
     });
 
     distanceMeasurementsPlugin.on("mouseLeave", (e) => {
-        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.measurement.id === e.measurement.id) {
+        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.distanceMeasurement.id === e.distanceMeasurement.id) {
             return;
         }
-        e.measurement.setHighlighted(false);
+        e.distanceMeasurement.setHighlighted(false);
     });
 
     distanceMeasurementsPlugin.on("contextMenu", (e) => {
         distanceMeasurementsContextMenu.context = { // Must set context before showing menu
             viewer: viewer,
             distanceMeasurementsPlugin: distanceMeasurementsPlugin,
-            measurement: e.measurement
+            distanceMeasurement: e.distanceMeasurement
         };
         distanceMeasurementsContextMenu.show(e.event.clientX, e.event.clientY);
         e.event.preventDefault();
@@ -815,31 +817,50 @@
         ]
     });
 
-    viewer.cameraControl.on("rightClick", (e) => {
-
+    viewer.scene.canvas.canvas.addEventListener('contextmenu', (event) => {
+        const canvasPos = getCanvasPosFromEvent(event);
         const hit = viewer.scene.pick({
-            canvasPos: e.canvasPos
+            canvasPos
         });
-
         if (hit && hit.entity.isObject) {
-
             objectContextMenu.context = { // Must set context before showing menu
-                viewer: viewer,
+                viewer,
                 entity: hit.entity
             };
-
-            objectContextMenu.show(e.pagePos[0], e.pagePos[1]);
+            objectContextMenu.show(event.pageX, event.pageY);
         } else {
-
             canvasContextMenu.context = { // Must set context before showing menu
-                viewer: viewer
+                viewer
             };
-
-            canvasContextMenu.show(e.pagePos[0], e.pagePos[1]);
+            canvasContextMenu.show(event.pageX, event.pageY);
         }
-
-        e.event.preventDefault();
+        event.preventDefault();
     });
+
+    const getCanvasPosFromEvent = function (event) {
+        const canvasPos = [];
+        if (!event) {
+            event = window.event;
+            canvasPos[0] = event.x;
+            canvasPos[1] = event.y;
+        } else {
+            let element = event.target;
+            let totalOffsetLeft = 0;
+            let totalOffsetTop = 0;
+            let totalScrollX = 0;
+            let totalScrollY = 0;
+            while (element.offsetParent) {
+                totalOffsetLeft += element.offsetLeft;
+                totalOffsetTop += element.offsetTop;
+                totalScrollX += element.scrollLeft;
+                totalScrollY += element.scrollTop;
+                element = element.offsetParent;
+            }
+            canvasPos[0] = event.pageX + totalScrollX - totalOffsetLeft;
+            canvasPos[1] = event.pageY + totalScrollY - totalOffsetTop;
+        }
+        return canvasPos;
+    };
 
     window.viewer = viewer;
 

--- a/examples/measurement/distance_unitsAndScale.html
+++ b/examples/measurement/distance_unitsAndScale.html
@@ -7,8 +7,8 @@
     <title>xeokit Example</title>
     <link href="../css/pageStyle.css" rel="stylesheet"/>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
-    <script src="libs/dat.gui.min.js" type="text/javascript"></script>
-    <link href="../cssdat-gui-light-style.css" rel="stylesheet"/>
+    <script src="../libs/dat.gui.min.js" type="text/javascript"></script>
+    <link href="../css/dat-gui-light-style.css" rel="stylesheet"/>
 </head>
 <body>
 <input type="checkbox" id="info-button"/>
@@ -92,11 +92,11 @@
     const distanceMeasurementsPlugin = new DistanceMeasurementsPlugin(viewer);
 
     distanceMeasurementsPlugin.on("mouseOver", (e) => {
-        e.measurement.setHighlighted(true);
+        e.distanceMeasurement.setHighlighted(true);
     });
 
     distanceMeasurementsPlugin.on("mouseLeave", (e) => {
-        e.measurement.setHighlighted(false);
+        e.distanceMeasurement.setHighlighted(false);
     });
     
     sceneModel.on("loaded", () => {

--- a/examples/navigation/ContextMenu_Canvas_TreeViewPlugin_Custom.html
+++ b/examples/navigation/ContextMenu_Canvas_TreeViewPlugin_Custom.html
@@ -231,6 +231,8 @@
     viewer.camera.look = [13.44, 3.31, -14.83];
     viewer.camera.up = [0.10, 0.98, -0.14];
 
+    viewer.cameraControl.panRightClick = false; // Prevents right-click-drag panning interfering with ContextMenus
+
     viewer.scene.xrayMaterial.fill = true;
     viewer.scene.xrayMaterial.fillAlpha = 0.1;
     viewer.scene.xrayMaterial.fillColor = [0, 0, 0];
@@ -747,32 +749,50 @@
         enabled: true
     });
 
-    viewer.cameraControl.on("rightClick", function (e) {
+    const getCanvasPosFromEvent = function (event) {
+        const canvasPos = [];
+        if (!event) {
+            event = window.event;
+            canvasPos[0] = event.x;
+            canvasPos[1] = event.y;
+        } else {
+            let element = event.target;
+            let totalOffsetLeft = 0;
+            let totalOffsetTop = 0;
+            let totalScrollX = 0;
+            let totalScrollY = 0;
+            while (element.offsetParent) {
+                totalOffsetLeft += element.offsetLeft;
+                totalOffsetTop += element.offsetTop;
+                totalScrollX += element.scrollLeft;
+                totalScrollY += element.scrollTop;
+                element = element.offsetParent;
+            }
+            canvasPos[0] = event.pageX + totalScrollX - totalOffsetLeft;
+            canvasPos[1] = event.pageY + totalScrollY - totalOffsetTop;
+        }
+        return canvasPos;
+    };
 
-        var hit = viewer.scene.pick({
-            canvasPos: e.canvasPos
+    viewer.scene.canvas.canvas.addEventListener('contextmenu', (event) => {
+        const canvasPos = getCanvasPosFromEvent(event);
+        const hit = viewer.scene.pick({
+            canvasPos
         });
-
         if (hit && hit.entity.isObject) {
-
             objectContextMenu.context = { // Must set context before showing menu
-                viewer: viewer,
+                viewer,
                 treeViewPlugin: treeView,
                 entity: hit.entity
             };
-
-            objectContextMenu.show(e.pagePos[0], e.pagePos[1]);
-
+            objectContextMenu.show(event.pageX, event.pageY);
         } else {
-
             canvasContextMenu.context = { // Must set context before showing menu
-                viewer: viewer
+                viewer
             };
-
-            canvasContextMenu.show(e.pagePos[0], e.pagePos[1]);
+            canvasContextMenu.show(event.pageX, event.pageY);
         }
-
-        e.event.preventDefault();
+        event.preventDefault();
     });
 
     //----------------------------------------------------------------------------------------------------------------------

--- a/examples/navigation/ContextMenu_dynamicItemTitles.html
+++ b/examples/navigation/ContextMenu_dynamicItemTitles.html
@@ -133,6 +133,8 @@
     viewer.camera.look = [13.44, 3.31, -14.83];
     viewer.camera.up = [0.10, 0.98, -0.14];
 
+    viewer.cameraControl.panRightClick = false; // Prevents right-click-drag panning interfering with ContextMenus
+
     viewer.scene.xrayMaterial.fill = true;
     viewer.scene.xrayMaterial.fillAlpha = 0.1;
     viewer.scene.xrayMaterial.fillColor = [0, 0, 0];
@@ -230,23 +232,49 @@
         enabled: true
     });
 
-    viewer.cameraControl.on("rightClick", function (e) {
-        var hit = viewer.scene.pick({
-            canvasPos: e.canvasPos
+    const getCanvasPosFromEvent = function (event) {
+        const canvasPos = [];
+        if (!event) {
+            event = window.event;
+            canvasPos[0] = event.x;
+            canvasPos[1] = event.y;
+        } else {
+            let element = event.target;
+            let totalOffsetLeft = 0;
+            let totalOffsetTop = 0;
+            let totalScrollX = 0;
+            let totalScrollY = 0;
+            while (element.offsetParent) {
+                totalOffsetLeft += element.offsetLeft;
+                totalOffsetTop += element.offsetTop;
+                totalScrollX += element.scrollLeft;
+                totalScrollY += element.scrollTop;
+                element = element.offsetParent;
+            }
+            canvasPos[0] = event.pageX + totalScrollX - totalOffsetLeft;
+            canvasPos[1] = event.pageY + totalScrollY - totalOffsetTop;
+        }
+        return canvasPos;
+    };
+
+    viewer.scene.canvas.canvas.addEventListener('contextmenu', (event) => {
+        const canvasPos = getCanvasPosFromEvent(event);
+        const hit = viewer.scene.pick({
+            canvasPos
         });
         if (hit && hit.entity.isObject) {
             objectContextMenu.context = { // Must set context before showing menu
-                viewer: viewer,
+                viewer,
                 entity: hit.entity
             };
-            objectContextMenu.show(e.pagePos[0], e.pagePos[1]);
+            objectContextMenu.show(event.pageX, event.pageY);
         } else {
             canvasContextMenu.context = { // Must set context before showing menu
-                viewer: viewer
+                viewer
             };
-            canvasContextMenu.show(e.pagePos[0], e.pagePos[1]);
+            canvasContextMenu.show(event.pageX, event.pageY);
         }
-        e.event.preventDefault();
+        event.preventDefault();
     });
 
     //----------------------------------------------------------------------------------------------------------------------

--- a/examples/navigation/ContextMenu_dynamicItemVisibilities.html
+++ b/examples/navigation/ContextMenu_dynamicItemVisibilities.html
@@ -134,6 +134,8 @@
     viewer.camera.look = [13.44, 3.31, -14.83];
     viewer.camera.up = [0.10, 0.98, -0.14];
 
+    viewer.cameraControl.panRightClick = false; // Prevents right-click-drag panning interfering with ContextMenus
+
     viewer.scene.xrayMaterial.fill = true;
     viewer.scene.xrayMaterial.fillAlpha = 0.1;
     viewer.scene.xrayMaterial.fillColor = [0, 0, 0];
@@ -228,17 +230,44 @@
         enabled: true
     });
 
-    viewer.cameraControl.on("rightClick", function (e) {
-        const hit = viewer.scene.pick({
-            canvasPos: e.canvasPos
-        });
-        objectContextMenu.context = { // Must set context before showing menu
-            viewer: viewer,
-            entity: hit ? hit.entity : null
-        };
-        objectContextMenu.show(e.pagePos[0], e.pagePos[1]);
+    const getCanvasPosFromEvent = function (event) {
+        const canvasPos = [];
+        if (!event) {
+            event = window.event;
+            canvasPos[0] = event.x;
+            canvasPos[1] = event.y;
+        } else {
+            let element = event.target;
+            let totalOffsetLeft = 0;
+            let totalOffsetTop = 0;
+            let totalScrollX = 0;
+            let totalScrollY = 0;
+            while (element.offsetParent) {
+                totalOffsetLeft += element.offsetLeft;
+                totalOffsetTop += element.offsetTop;
+                totalScrollX += element.scrollLeft;
+                totalScrollY += element.scrollTop;
+                element = element.offsetParent;
+            }
+            canvasPos[0] = event.pageX + totalScrollX - totalOffsetLeft;
+            canvasPos[1] = event.pageY + totalScrollY - totalOffsetTop;
+        }
+        return canvasPos;
+    };
 
-        e.event.preventDefault();
+    viewer.scene.canvas.canvas.addEventListener('contextmenu', (event) => {
+        const canvasPos = getCanvasPosFromEvent(event);
+        const hit = viewer.scene.pick({
+            canvasPos
+        });
+        if (hit && hit.entity.isObject) {
+            objectContextMenu.context = { // Must set context before showing menu
+                viewer,
+                entity: hit.entity
+            };
+            objectContextMenu.show(event.pageX, event.pageY);
+        }
+        event.preventDefault();
     });
 
     //----------------------------------------------------------------------------------------------------------------------

--- a/examples/navigation/ContextMenu_subMenus.html
+++ b/examples/navigation/ContextMenu_subMenus.html
@@ -132,6 +132,8 @@
     viewer.camera.look = [13.44, 3.31, -14.83];
     viewer.camera.up = [0.10, 0.98, -0.14];
 
+    viewer.cameraControl.panRightClick = false; // Prevents right-click-drag panning interfering with ContextMenus
+
     viewer.scene.xrayMaterial.fill = true;
     viewer.scene.xrayMaterial.fillAlpha = 0.1;
     viewer.scene.xrayMaterial.fillColor = [0, 0, 0];
@@ -253,23 +255,44 @@
         enabled: true
     });
 
-    viewer.cameraControl.on("rightClick", (e) => {
+    const getCanvasPosFromEvent = function (event) {
+        const canvasPos = [];
+        if (!event) {
+            event = window.event;
+            canvasPos[0] = event.x;
+            canvasPos[1] = event.y;
+        } else {
+            let element = event.target;
+            let totalOffsetLeft = 0;
+            let totalOffsetTop = 0;
+            let totalScrollX = 0;
+            let totalScrollY = 0;
+            while (element.offsetParent) {
+                totalOffsetLeft += element.offsetLeft;
+                totalOffsetTop += element.offsetTop;
+                totalScrollX += element.scrollLeft;
+                totalScrollY += element.scrollTop;
+                element = element.offsetParent;
+            }
+            canvasPos[0] = event.pageX + totalScrollX - totalOffsetLeft;
+            canvasPos[1] = event.pageY + totalScrollY - totalOffsetTop;
+        }
+        return canvasPos;
+    };
 
+    viewer.scene.canvas.canvas.addEventListener('contextmenu', (event) => {
+        const canvasPos = getCanvasPosFromEvent(event);
         const hit = viewer.scene.pick({
-            canvasPos: e.canvasPos
+            canvasPos
         });
-
         if (hit && hit.entity.isObject) {
-
             objectContextMenu.context = { // Must set context before showing menu
-                viewer: viewer,
+                viewer,
                 entity: hit.entity
             };
-
-             objectContextMenu.show(e.pagePos[0], e.pagePos[1]);
-         }
-
-        e.event.preventDefault();
+            objectContextMenu.show(event.pageX, event.pageY);
+        }
+        event.preventDefault();
     });
 
     //----------------------------------------------------------------------------------------------------------------------

--- a/src/extras/ContextMenu/ContextMenu.js
+++ b/src/extras/ContextMenu/ContextMenu.js
@@ -766,6 +766,27 @@ class ContextMenu {
                                     self._updateItemsEnabledStatus();
                                 }
                             });
+                            item.itemElement.addEventListener("mouseup", (event) => {
+                                if (event.which !== 3) {
+                                    return;
+                                }
+                                event.preventDefault();
+                                if (!self._context) {
+                                    return;
+                                }
+                                if (item.enabled === false) {
+                                    return;
+                                }
+                                if (item.doAction) {
+                                    item.doAction(self._context);
+                                }
+                                if (this._hideOnAction) {
+                                    self.hide();
+                                } else {
+                                    self._updateItemsTitles();
+                                    self._updateItemsEnabledStatus();
+                                }
+                            });
                             item.itemElement.addEventListener("mouseenter", (event) => {
                                 event.preventDefault();
                                 if (item.enabled === false) {


### PR DESCRIPTION
* Select ContextMenu item on right-click release
* Make examples open canvas ContextMenus using native mouse events, to show how not to create event clashes between camera control, and between other ContextMenus
* Tidy up code in ContextMenu examples
* Fix DAT GUI for example of dynamic distance measurements unit configuration 