### PR TITLE
Fix/measurement controls

### DIFF
--- a/examples/measurement/distance_createWithMouse_nosnapping.html
+++ b/examples/measurement/distance_createWithMouse_nosnapping.html
@@ -1,15 +1,15 @@
 <!doctype html>
 <html>
+
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>xeokit Example</title>
-    <link href="../css/pageStyle.css" rel="stylesheet"/>
+    <link href="../css/pageStyle.css" rel="stylesheet" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
 
     <style>
-
         .viewer-ruler-wire-highlighted {
             border: 2px solid white !important;
         }
@@ -76,51 +76,50 @@
             background: #eeeeee;
             font-weight: normal;
         }
-
     </style>
 </head>
-<body>
-<input type="checkbox" id="info-button"/>
-<label for="info-button" class="info-button"><i class="far fa-3x fa-question-circle"></i></label>
-<canvas id="myCanvas"></canvas>
-<div class="slideout-sidebar">
-    <img class="info-icon" src="../../assets/images/measure_distance_icon.png"/>
-    <h1>DistanceMeasurementPlugin with DistanceMeasurementsMouseControl and PointerLens</h1>
-    <h2>Click on the model to create distance measurements, with no vertex and edge snapping</h2>
-    <p>In this example, we're loading a BIM model from the file system, then creating distance measurements wherever the
-        user clicks on the model with the mouse.</p>
-    <h3>Components Used</h3>
-    <ul>
-        <li>
-            <a href="../../docs/class/src/viewer/Viewer.js~Viewer.html"
-               target="_other">Viewer</a>
-        </li>
-        <li>
-            <a href="../../docs/class/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsPlugin.js~DistanceMeasurementsPlugin.html"
-               target="_other">DistanceMeasurementsPlugin</a>
-        </li>
-        <li>
-            <a href="../../docs/class/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsMouseControl.js~DistanceMeasurementsMouseControl.html"
-               target="_other">DistanceMeasurementsMouseControl</a>
-        </li>
-        <li>
-            <a href="../../docs/class/src/extras/PointerLens/PointerLens.js~PointerLens.html"
-               target="_other">PointerLens</a>
-        </li>
-        <li>
-            <a href="../../docs/class/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js~XKTLoaderPlugin.html"
-               target="_other">XKTLoaderPlugin</a>
-        </li>
-    </ul>
 
-    <h3>Assets</h3>
-    <ul>
-        <li>
-            <a href="http://openifcmodel.cs.auckland.ac.nz/Model/Details/274"
-               target="_other">Model source</a>
-        </li>
-    </ul>
-</div>
+<body>
+    <input type="checkbox" id="info-button" />
+    <label for="info-button" class="info-button"><i class="far fa-3x fa-question-circle"></i></label>
+    <canvas id="myCanvas"></canvas>
+    <div class="slideout-sidebar">
+        <img class="info-icon" src="../../assets/images/measure_distance_icon.png" />
+        <h1>DistanceMeasurementPlugin with DistanceMeasurementsMouseControl and PointerLens</h1>
+        <h2>Click on the model to create distance measurements, with no vertex and edge snapping</h2>
+        <p>In this example, we're loading a BIM model from the file system, then creating distance measurements wherever
+            the
+            user clicks on the model with the mouse.</p>
+        <h3>Components Used</h3>
+        <ul>
+            <li>
+                <a href="../../docs/class/src/viewer/Viewer.js~Viewer.html" target="_other">Viewer</a>
+            </li>
+            <li>
+                <a href="../../docs/class/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsPlugin.js~DistanceMeasurementsPlugin.html"
+                    target="_other">DistanceMeasurementsPlugin</a>
+            </li>
+            <li>
+                <a href="../../docs/class/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsMouseControl.js~DistanceMeasurementsMouseControl.html"
+                    target="_other">DistanceMeasurementsMouseControl</a>
+            </li>
+            <li>
+                <a href="../../docs/class/src/extras/PointerLens/PointerLens.js~PointerLens.html"
+                    target="_other">PointerLens</a>
+            </li>
+            <li>
+                <a href="../../docs/class/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js~XKTLoaderPlugin.html"
+                    target="_other">XKTLoaderPlugin</a>
+            </li>
+        </ul>
+
+        <h3>Assets</h3>
+        <ul>
+            <li>
+                <a href="http://openifcmodel.cs.auckland.ac.nz/Model/Details/274" target="_other">Model source</a>
+            </li>
+        </ul>
+    </div>
 </body>
 <script type="module">
 
@@ -128,7 +127,9 @@
     // Import the modules we need for this example
     //------------------------------------------------------------------------------------------------------------------
 
-    import {Viewer, XKTLoaderPlugin, ContextMenu, DistanceMeasurementsPlugin, DistanceMeasurementsMouseControl, PointerLens} from "../../dist/xeokit-sdk.min.es.js";
+    import { Viewer, XKTLoaderPlugin, ContextMenu, /*DistanceMeasurementsPlugin, DistanceMeasurementsMouseControl,*/ PointerLens } from "../../dist/xeokit-sdk.min.es.js";
+    import { DistanceMeasurementsPlugin } from '../../src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsPlugin.js';
+    import { DistanceMeasurementsMouseControl } from '../../src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsMouseControl.js';
 
     //------------------------------------------------------------------------------------------------------------------
     // Create a Viewer and arrange the camera
@@ -165,7 +166,7 @@
         edges: true
     });
 
-    sceneModel.on("loaded", ()=>{
+    sceneModel.on("loaded", () => {
         viewer.cameraFlight.jumpTo(sceneModel);
     });
 
@@ -173,10 +174,10 @@
     // DistanceMeasurementsPlugin, DistanceMeasurementsMouseControl and PointerLens
     //------------------------------------------------------------------------------------------------------------------
 
-    const distanceMeasurements = new DistanceMeasurementsPlugin(viewer, {useRotationAdjustment: true});
+    const distanceMeasurements = new DistanceMeasurementsPlugin(viewer, {});
 
-    const distanceMeasurementsMouseControl  = new DistanceMeasurementsMouseControl(distanceMeasurements, {
-        pointerLens : new PointerLens(viewer)
+    const distanceMeasurementsMouseControl = new DistanceMeasurementsMouseControl(distanceMeasurements, {
+        pointerLens: new PointerLens(viewer)
     })
 
     distanceMeasurementsMouseControl.snapping = false;
@@ -294,6 +295,14 @@
                     }
                 },
                 {
+                    getTitle: (context) => {
+                        return distanceMeasurements.useRotationAdjustment ? "Disable Rotation Adjustment" : "Enable Rotation Adjustment";
+                    },
+                    doAction: function (context) {
+                        distanceMeasurements.useRotationAdjustment = !distanceMeasurements.useRotationAdjustment;
+                    }
+                },
+                {
                     getTitle: () => {
                         return "Cancel Measurement";
                     },
@@ -312,6 +321,46 @@
     //     canvasContextMenu.show(e.pagePos[0], e.pagePos[1]);
     //     e.event.preventDefault();
     // });
+
+    viewer.scene.canvas.canvas.addEventListener('contextmenu', (event) => {
+        const canvasPos = getCanvasPosFromEvent(event);
+        //show the context menu if users clicks on empty screen
+        const hit = viewer.scene.pick({
+            canvasPos
+        });
+        if (!hit) {
+            canvasContextMenu.context = { // Must set context before showing menu
+                viewer
+            };
+            canvasContextMenu.show(event.pageX, event.pageY);
+        }
+        event.preventDefault();
+    });
+
+    const getCanvasPosFromEvent = function (event) {
+        const canvasPos = [];
+        if (!event) {
+            event = window.event;
+            canvasPos[0] = event.x;
+            canvasPos[1] = event.y;
+        } else {
+            let element = event.target;
+            let totalOffsetLeft = 0;
+            let totalOffsetTop = 0;
+            let totalScrollX = 0;
+            let totalScrollY = 0;
+            while (element.offsetParent) {
+                totalOffsetLeft += element.offsetLeft;
+                totalOffsetTop += element.offsetTop;
+                totalScrollX += element.scrollLeft;
+                totalScrollY += element.scrollTop;
+                element = element.offsetParent;
+            }
+            canvasPos[0] = event.pageX + totalScrollX - totalOffsetLeft;
+            canvasPos[1] = event.pageY + totalScrollY - totalOffsetTop;
+        }
+        return canvasPos;
+    };
 
     //------------------------------------------------------------------------------------------------------------------
     // Create an DistanceMeasurementsPlugin, activate its DistanceMeasuremntsControl
@@ -341,4 +390,5 @@
     window.viewer = viewer;
 
 </script>
+
 </html>

--- a/examples/measurement/distance_createWithMouse_useRotationAdjustment.html
+++ b/examples/measurement/distance_createWithMouse_useRotationAdjustment.html
@@ -112,7 +112,13 @@
                     target="_other">XKTLoaderPlugin</a>
             </li>
         </ul>
-
+        <h3>Tutorials</h3>
+        <ul>
+            <li>
+                <a href="https://www.notion.so/xeokit/Accurate-Measurements-with-Snapping-5e6606afef20428f9b319ea0e82270f9"
+                    target="_other">Accurate Measurements with Snapping</a>
+            </li>
+        </ul>
         <h3>Assets</h3>
         <ul>
             <li>
@@ -145,13 +151,6 @@
     viewer.cameraControl.panRightClick = false; // Prevents right-click-drag panning interfering with ContextMenus
 
     //------------------------------------------------------------------------------------------------------------------
-    // Vertex-snapping mode
-    //------------------------------------------------------------------------------------------------------------------
-
-    viewer.cameraControl.snapMode = "vertex"; // Snap to nearest vertex
-    viewer.cameraControl.snapRadius = 30; // 30 pixels snapping radius
-
-    //------------------------------------------------------------------------------------------------------------------
     // Load a model
     //------------------------------------------------------------------------------------------------------------------
 
@@ -172,13 +171,43 @@
     // DistanceMeasurementsPlugin, DistanceMeasurementsMouseControl and PointerLens
     //------------------------------------------------------------------------------------------------------------------
 
-    const distanceMeasurements = new DistanceMeasurementsPlugin(viewer, {});
+    const distanceMeasurementsPlugin = new DistanceMeasurementsPlugin(viewer, { useRotationAdjustment: true });
 
-    const distanceMeasurementsMouseControl = new DistanceMeasurementsMouseControl(distanceMeasurements, {
-        pointerLens: new PointerLens(viewer)
+    distanceMeasurementsPlugin.on("measurementStart", (distanceMeasurement) => {
+        console.log("measurementStart");
+        console.log("origin", distanceMeasurement.origin.entity);
+        console.log("target", distanceMeasurement.target.entity);
+    });
+
+    distanceMeasurementsPlugin.on("measurementEnd", (distanceMeasurement) => {
+        console.log("measurementEnd");
+        console.log("origin", distanceMeasurement.origin.entity);
+        console.log("target", distanceMeasurement.target.entity);
+    });
+
+    distanceMeasurementsPlugin.on("measurementCancel", (distanceMeasurement) => {
+        console.log("measurementCancel");
+        console.log("origin", distanceMeasurement.origin.entity);
+        console.log("target", distanceMeasurement.target.entity);
+    });
+
+    distanceMeasurementsPlugin.on("mouseOver", (e) => {
+        e.distanceMeasurement.setHighlighted(true);
+    });
+
+    distanceMeasurementsPlugin.on("mouseLeave", (e) => {
+        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.distanceMeasurement.id === e.distanceMeasurement.id) {
+            return;
+        }
+        e.distanceMeasurement.setHighlighted(false);
+    });
+
+    const distanceMeasurementsMouseControl = new DistanceMeasurementsMouseControl(distanceMeasurementsPlugin, {
+        pointerLens: new PointerLens(viewer),
+        snapping: true // Default
     })
 
-    distanceMeasurementsMouseControl.snapping = false;
+    distanceMeasurementsMouseControl.snapping = true;
 
     distanceMeasurementsMouseControl.activate();
 
@@ -293,14 +322,6 @@
                     }
                 },
                 {
-                    getTitle: (context) => {
-                        return distanceMeasurements.useRotationAdjustment ? "Disable Rotation Adjustment" : "Enable Rotation Adjustment";
-                    },
-                    doAction: function (context) {
-                        distanceMeasurements.useRotationAdjustment = !distanceMeasurements.useRotationAdjustment;
-                    }
-                },
-                {
                     getTitle: () => {
                         return "Cancel Measurement";
                     },
@@ -315,24 +336,37 @@
         ]
     });
 
-    // viewer.cameraControl.on("rightClick", function (e) {
-    //     canvasContextMenu.show(e.pagePos[0], e.pagePos[1]);
-    //     e.event.preventDefault();
-    // });
-
     viewer.scene.canvas.canvas.addEventListener('contextmenu', (event) => {
         const canvasPos = getCanvasPosFromEvent(event);
-        //show the context menu if users clicks on empty screen
-        const hit = viewer.scene.pick({
-            canvasPos
-        });
-        if (!hit) {
-            canvasContextMenu.context = { // Must set context before showing menu
-                viewer
-            };
-            canvasContextMenu.show(event.pageX, event.pageY);
-        }
+        console.log("canvas context menu")
+        canvasContextMenu.show(canvasPos[0], canvasPos[1]);
         event.preventDefault();
+        event.stopPropagation();
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create an DistanceMeasurementsPlugin, activate its DistanceMeasuremntsControl
+    //------------------------------------------------------------------------------------------------------------------
+
+    distanceMeasurementsPlugin.on("mouseOver", (e) => {
+        e.distanceMeasurement.setHighlighted(true);
+    });
+
+    distanceMeasurementsPlugin.on("mouseLeave", (e) => {
+        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.distanceMeasurement.id === e.distanceMeasurement.id) {
+            return;
+        }
+        e.distanceMeasurement.setHighlighted(false);
+    });
+
+    distanceMeasurementsPlugin.on("contextMenu", (e) => {
+        distanceMeasurementsContextMenu.context = { // Must set context before showing menu
+            viewer: viewer,
+            distanceMeasurementsPlugin: distanceMeasurementsPlugin,
+            distanceMeasurement: e.distanceMeasurement
+        };
+        distanceMeasurementsContextMenu.show(e.event.clientX, e.event.clientY);
+        e.event.preventDefault();
     });
 
     const getCanvasPosFromEvent = function (event) {
@@ -359,31 +393,6 @@
         }
         return canvasPos;
     };
-
-    //------------------------------------------------------------------------------------------------------------------
-    // Create an DistanceMeasurementsPlugin, activate its DistanceMeasuremntsControl
-    //------------------------------------------------------------------------------------------------------------------
-
-    distanceMeasurements.on("mouseOver", (e) => {
-        e.distanceMeasurement.setHighlighted(true);
-    });
-
-    distanceMeasurements.on("mouseLeave", (e) => {
-        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.distanceMeasurement.id === e.distanceMeasurement.id) {
-            return;
-        }
-        e.distanceMeasurement.setHighlighted(false);
-    });
-
-    distanceMeasurements.on("contextMenu", (e) => {
-        distanceMeasurementsContextMenu.context = { // Must set context before showing menu
-            viewer: viewer,
-            distanceMeasurementsPlugin: distanceMeasurements,
-            distanceMeasurement: e.distanceMeasurement
-        };
-        distanceMeasurementsContextMenu.show(e.event.clientX, e.event.clientY);
-        e.event.preventDefault();
-    });
 
     window.viewer = viewer;
 

--- a/examples/measurement/distance_modelWithMeasurements_useRotationAdjustment.html
+++ b/examples/measurement/distance_modelWithMeasurements_useRotationAdjustment.html
@@ -1,0 +1,869 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>xeokit Example</title>
+    <link href="../css/pageStyle.css" rel="stylesheet" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
+
+    <style>
+        .viewer-ruler-wire-highlighted {
+            border: 2px solid white !important;
+        }
+
+        .viewer-ruler-label-highlighted {
+            border: 2px solid white !important;
+        }
+
+        .viewer-ruler-dot-highlighted {
+            border: 2px solid white !important;
+        }
+
+        .xeokit-context-menu {
+            font-family: 'Roboto', sans-serif;
+            font-size: 15px;
+            display: none;
+            z-index: 300000;
+            background: rgba(255, 255, 255, 0.46);
+            border: 1px solid black;
+            border-radius: 6px;
+            padding: 0;
+            width: 200px;
+        }
+
+        .xeokit-context-menu ul {
+            list-style: none;
+            margin-left: 0;
+            padding: 0;
+        }
+
+        .xeokit-context-menu ul li {
+            list-style-type: none;
+            padding-left: 10px;
+            padding-right: 20px;
+            padding-top: 4px;
+            padding-bottom: 4px;
+            color: black;
+            border-bottom: 1px solid gray;
+            background: rgba(255, 255, 255, 0.46);
+            cursor: pointer;
+            width: calc(100% - 30px);
+        }
+
+        .xeokit-context-menu ul li:hover {
+            background: black;
+            color: white;
+            font-weight: normal;
+        }
+
+        .xeokit-context-menu ul li span {
+            display: inline-block;
+        }
+
+        .xeokit-context-menu .disabled {
+            display: inline-block;
+            color: gray;
+            cursor: default;
+            font-weight: normal;
+        }
+
+        .xeokit-context-menu .disabled:hover {
+            color: gray;
+            cursor: default;
+            background: #eeeeee;
+            font-weight: normal;
+        }
+    </style>
+</head>
+
+<body>
+    <input type="checkbox" id="info-button" />
+    <label for="info-button" class="info-button"><i class="far fa-3x fa-question-circle"></i></label>
+    <canvas id="myCanvas"></canvas>
+    <div class="slideout-sidebar">
+        <img class="info-icon" src="../../assets/images/measure_distance_icon.png" />
+        <h1>DistanceMeasurementPlugin</h1>
+        <h2>Creating distance measurements programmatically</h2>
+        <p>In this example, we're loading a BIM model from the file system, then programmatically creating a couple of
+            distance measurements on the model's surface.</p>
+        <h3>Components Used</h3>
+        <ul>
+            <li>
+                <a href="../../docs/class/src/viewer/Viewer.js~Viewer.html" target="_other">Viewer</a>
+            </li>
+            <li>
+                <a href="../../docs/class/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsPlugin.js~DistanceMeasurementsPlugin.html"
+                    target="_other">DistanceMeasurementsPlugin</a>
+            </li>
+            <li>
+                <a href="../../docs/class/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js~XKTLoaderPlugin.html"
+                    target="_other">XKTLoaderPlugin</a>
+            </li>
+        </ul>
+        <h3>Assets</h3>
+        <ul>
+            <li>
+                <a href="http://openifcmodel.cs.auckland.ac.nz/Model/Details/274" target="_other">Model source</a>
+            </li>
+        </ul>
+    </div>
+</body>
+<script type="module">
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Import the modules we need for this example
+    //------------------------------------------------------------------------------------------------------------------
+
+    import { Viewer, XKTLoaderPlugin, ContextMenu, DistanceMeasurementsPlugin } from "../../dist/xeokit-sdk.min.es.js";
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a Viewer and arrange the camera
+    //------------------------------------------------------------------------------------------------------------------
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas"
+    });
+
+    viewer.camera.eye = [-3.93, 2.85, 27.01];
+    viewer.camera.look = [4.40, 3.72, 8.89];
+    viewer.camera.up = [-0.01, 0.99, 0.039];
+
+    viewer.cameraControl.followPointer = true;
+
+    viewer.cameraControl.panRightClick = false; // Prevents right-click-drag panning interfering with ContextMenus
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Load a model
+    //------------------------------------------------------------------------------------------------------------------
+
+    const xktLoader = new XKTLoaderPlugin(viewer);
+
+    const sceneModel = xktLoader.load({
+        id: "myModel",
+        src: "../../assets/models/xkt/v10/glTF-Embedded/Duplex_A_20110505.glTFEmbedded.xkt", // Creates a MetaObject instances in scene.metaScene.metaObjects
+        rotation: [0, 50, 0],
+        edges: true
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a context menu to delete and configure measurements
+    //------------------------------------------------------------------------------------------------------------------
+
+    const distanceMeasurementsContextMenu = new ContextMenu({
+        items: [
+
+            [
+                {
+                    getTitle: (context) => {
+                        return context.distanceMeasurement.axisVisible ? "Hide Axis" : "Show Axis";
+                    },
+                    doAction: function (context) {
+                        context.distanceMeasurement.axisVisible = !context.distanceMeasurement.axisVisible;
+                    }
+                },
+                {
+                    getTitle: (context) => {
+                        return context.distanceMeasurement.xAxisVisible ? "Hide X Axis" : "Show X Axis";
+                    },
+                    doAction: function (context) {
+                        context.distanceMeasurement.xAxisVisible = !context.distanceMeasurement.xAxisVisible;
+                    }
+                },
+                {
+                    getTitle: (context) => {
+                        return context.distanceMeasurement.yAxisVisible ? "Hide Y Axis" : "Show Y Axis";
+                    },
+                    doAction: function (context) {
+                        context.distanceMeasurement.yAxisVisible = !context.distanceMeasurement.yAxisVisible;
+                    }
+                },
+                {
+                    getTitle: (context) => {
+                        return context.distanceMeasurement.zAxisVisible ? "Hide Z Axis" : "Show Z Axis";
+                    },
+                    doAction: function (context) {
+                        context.distanceMeasurement.zAxisVisible = !context.distanceMeasurement.zAxisVisible;
+                    }
+                },
+                {
+                    getTitle: (context) => {
+                        return context.distanceMeasurement.labelsVisible ? "Hide Labels" : "Show Labels";
+                    },
+                    doAction: function (context) {
+                        context.distanceMeasurement.labelsVisible = !context.distanceMeasurement.labelsVisible;
+                    }
+                }
+            ], [
+                {
+                    title: "Delete Measurement",
+                    doAction: function (context) {
+                        context.distanceMeasurement.destroy();
+                    }
+                }
+            ]
+
+        ]
+    });
+
+    distanceMeasurementsContextMenu.on("hidden", () => {
+        if (distanceMeasurementsContextMenu.context.distanceMeasurement) {
+            distanceMeasurementsContextMenu.context.distanceMeasurement.setHighlighted(false);
+        }
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a DistanceMeasurementsPlugin, with which we'll create DistanceMeasurements
+    //------------------------------------------------------------------------------------------------------------------
+
+    const distanceMeasurementsPlugin = new DistanceMeasurementsPlugin(viewer, {
+        zIndex: 100000, // If set, the wires, dots and labels will have this zIndex (+1 for dots and +2 for labels).
+        useRotationAdjustment: true
+    });
+
+    distanceMeasurementsPlugin.on("mouseOver", (e) => {
+        e.distanceMeasurement.setHighlighted(true);
+    });
+
+    distanceMeasurementsPlugin.on("mouseLeave", (e) => {
+        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.distanceMeasurement.id === e.distanceMeasurement.id) {
+            return;
+        }
+        e.distanceMeasurement.setHighlighted(false);
+    });
+
+    distanceMeasurementsPlugin.on("contextMenu", (e) => {
+        distanceMeasurementsContextMenu.context = { // Must set context before showing menu
+            viewer: viewer,
+            distanceMeasurementsPlugin: distanceMeasurementsPlugin,
+            distanceMeasurement: e.distanceMeasurement
+        };
+        distanceMeasurementsContextMenu.show(e.event.clientX, e.event.clientY);
+        e.event.preventDefault();
+    });
+
+    sceneModel.on("loaded", () => {
+
+        viewer.cameraFlight.jumpTo(sceneModel);
+
+        //------------------------------------------------------------------------------------------------------------------
+        // Create some DistanceMeasurements
+        //------------------------------------------------------------------------------------------------------------------
+
+        const myMeasurement1 = distanceMeasurementsPlugin.createMeasurement({
+            id: "distanceMeasurement1",
+            origin: {
+                entity: viewer.scene.objects["0jf0rYHfX3RAB3bSIRjmoa"],
+                worldPos: [13.635431762140094, 5.999974121361841, 11.441655162826033]
+            },
+            target: {
+                entity: viewer.scene.objects["2O2Fr$t4X7Zf8NOew3FLOH"],
+                worldPos: [16.64046542009156, 3.1998935945993194, 7.860396083102097]
+            },
+            visible: true,
+            wireVisible: true
+        });
+
+        const myMeasurement2 = distanceMeasurementsPlugin.createMeasurement({
+            id: "distanceMeasurement2",
+            origin: {
+                entity: viewer.scene.objects["2O2Fr$t4X7Zf8NOew3FNr2"],
+                worldPos: [13.929456220092561, 2.4569390427805735, 11.061528072217364]
+            },
+            target: {
+                entity: viewer.scene.objects["1CZILmCaHETO8tf3SgGEXu"],
+                worldPos: [16.95635586745851, 0.16294332738025696, 7.4542093759014865]
+            },
+            visible: true,
+            wireVisible: true,
+            labelsOnWires: false,
+        });
+    });
+
+
+    const objectContextMenu = new ContextMenu({
+
+        items: [
+            // [
+            //     {
+            //         title: "X-Ray",
+            //         getEnabled: function (context) {
+            //             return false;
+            //         },
+            //         doAction: function (context) {
+            //           //  context.entity.xrayed = !context.entity.xrayed;
+            //         }
+            //     },
+            //     {
+            //         title: "Select",
+            //         getEnabled: function (context) {
+            //             return false;
+            //         },
+            //         doAction: function (context) {
+            //             //  context.entity.xrayed = !context.entity.xrayed;
+            //         }
+            //     },
+            //     {
+            //         title: "Hide",
+            //         getEnabled: function (context) {
+            //             return false;
+            //         },
+            //         doAction: function (context) {
+            //             //  context.entity.xrayed = !context.entity.xrayed;
+            //         }
+            //     }
+            // ],
+            //
+
+
+            [
+                {
+                    getTitle: function (context) {
+                        return (!context.entity.xrayed) ? "X-Ray" : "Undo X-Ray";
+                    },
+                    doAction: function (context) {
+                        context.entity.xrayed = !context.entity.xrayed;
+                    }
+                },
+                {
+                    title: "X-Ray Others",
+                    doAction: function (context) {
+                        const viewer = context.viewer;
+                        const scene = viewer.scene;
+                        const entity = context.entity;
+                        const metaObject = viewer.metaScene.metaObjects[entity.id];
+                        if (!metaObject) {
+                            return;
+                        }
+                        scene.setObjectsVisible(scene.objectIds, true);
+                        scene.setObjectsXRayed(scene.objectIds, true);
+                        scene.setObjectsSelected(scene.selectedObjectIds, false);
+                        scene.setObjectsHighlighted(scene.highlightedObjectIds, false);
+                        metaObject.withMetaObjectsInSubtree((metaObject) => {
+                            const entity = scene.objects[metaObject.id];
+                            if (entity) {
+                                entity.xrayed = false;
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "X-Ray All",
+                    getEnabled: function (context) {
+                        const scene = context.viewer.scene;
+                        return (scene.numXRayedObjects < scene.numObjects);
+                    },
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        scene.setObjectsXRayed(scene.objectIds, true);
+                    }
+                },
+                {
+                    title: "X-Ray None",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.numXRayedObjects > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsXRayed(context.viewer.scene.xrayedObjectIds, false);
+                    }
+                }
+            ],
+            [
+                {
+                    title: "Hide",
+                    getEnabled: function (context) {
+                        return context.entity.visible;
+                    },
+                    doAction: function (context) {
+                        context.entity.visible = false;
+                    }
+                },
+                {
+                    title: "Hide Others",
+                    doAction: function (context) {
+                        const viewer = context.viewer;
+                        const scene = viewer.scene;
+                        const entity = context.entity;
+                        const metaObject = viewer.metaScene.metaObjects[entity.id];
+                        if (!metaObject) {
+                            return;
+                        }
+                        scene.setObjectsVisible(scene.visibleObjectIds, false);
+                        scene.setObjectsXRayed(scene.xrayedObjectIds, false);
+                        scene.setObjectsSelected(scene.selectedObjectIds, false);
+                        scene.setObjectsHighlighted(scene.highlightedObjectIds, false);
+                        metaObject.withMetaObjectsInSubtree((metaObject) => {
+                            const entity = scene.objects[metaObject.id];
+                            if (entity) {
+                                entity.visible = true;
+                            }
+                        });
+                    }
+                },
+                {
+                    title: "Hide All",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.numVisibleObjects > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsVisible(context.viewer.scene.visibleObjectIds, false);
+                    }
+                },
+                {
+                    title: "Show All",
+                    getEnabled: function (context) {
+                        const scene = context.viewer.scene;
+                        return (scene.numVisibleObjects < scene.numObjects);
+                    },
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        scene.setObjectsVisible(scene.objectIds, true);
+                    }
+                }
+            ],
+
+            [
+                {
+                    getTitle: function (context) {
+                        return (!context.entity.selected) ? "Select" : "Undo Select";
+                    },
+                    doAction: function (context) {
+                        context.entity.selected = !context.entity.selected;
+                    }
+                },
+                {
+                    title: "Select All",
+                    getEnabled: function (context) {
+                        const scene = context.viewer.scene;
+                        return (scene.numSelectedObjects < scene.numObjects);
+                    },
+                    doAction: function (context) {
+                        const scene = context.viewer.scene;
+                        scene.setObjectsSelected(scene.objectIds, true);
+                    }
+                },
+                {
+                    title: "Select None",
+                    getEnabled: function (context) {
+                        return (context.viewer.scene.numSelectedObjects > 0);
+                    },
+                    doAction: function (context) {
+                        context.viewer.scene.setObjectsSelected(context.viewer.scene.selectedObjectIds, false);
+                    }
+                }
+            ],
+
+            [
+                {
+                    title: "Camera..",
+                    items: [
+                        [
+                            {
+                                title: "View Fit",
+                                doAction: function (context) {
+                                    const viewer = context.viewer;
+                                    const scene = viewer.scene;
+                                    const entity = context.entity;
+                                    viewer.cameraFlight.flyTo({
+                                        aabb: entity.aabb,
+                                        duration: 0.5
+                                    }, () => {
+                                        setTimeout(function () {
+                                            scene.setObjectsHighlighted(scene.highlightedObjectIds, false);
+                                        }, 500);
+                                    });
+                                }
+                            },
+                            {
+                                title: "View Fit All",
+                                doAction: function (context) {
+                                    const scene = context.viewer.scene;
+                                    context.viewer.cameraFlight.flyTo({
+                                        projection: "perspective",
+                                        aabb: scene.getAABB(),
+                                        duration: 0.5
+                                    });
+                                }
+                            }
+                        ],
+                        [
+                            {
+                                title: "Perspective",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.camera.projection !== "perspective");
+                                },
+                                doAction: function (context) {
+                                    context.viewer.cameraFlight.flyTo({
+                                        projection: "perspective"
+                                    });
+                                }
+                            },
+                            {
+                                title: "Orthographic",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.camera.projection !== "ortho");
+                                },
+                                doAction: function (context) {
+                                    context.viewer.cameraFlight.flyTo({
+                                        projection: "ortho"
+                                    });
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ],
+
+            [
+                {
+                    title: "Effects..",
+                    items: [
+                        [
+                            {
+                                getTitle: (context) => {
+                                    return context.viewer.scene.edgeMaterial.edges ? "Disable Edges" : "Enable Edges";
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.edgeMaterial.edges = !context.viewer.scene.edgeMaterial.edges;
+                                }
+                            },
+                            {
+                                getTitle: (context) => {
+                                    return context.viewer.scene.sao.enabled ? "Disable SAO" : "Enable SAO";
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.sao.enabled = !context.viewer.scene.sao.enabled;
+                                }
+                            },
+                            {
+                                getTitle: (context) => {
+                                    return context.viewer.scene.pbrEnabled ? "Disable PBR" : "Enable PBR";
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.pbrEnabled = !context.viewer.scene.pbrEnabled;
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ],
+
+            [
+                {
+                    title: "Measurements..",
+                    getEnabled: function (context) {
+                        return (Object.keys(distanceMeasurementsPlugin.measurements).length > 0);
+                    },
+                    items: [
+                        [
+                            {
+                                title: "Show all Labels",
+                                doAction: function (context) {
+                                    distanceMeasurementsPlugin.setLabelsShown(true);
+                                }
+                            },
+                            {
+                                title: "Hide all Labels",
+                                doAction: function (context) {
+                                    distanceMeasurementsPlugin.setLabelsShown(false);
+                                }
+                            },
+                            {
+                                title: "Show all Axis",
+                                doAction: function (context) {
+                                    distanceMeasurementsPlugin.setAxisVisible(true);
+                                }
+                            },
+                            {
+                                title: "Hide all Axis",
+                                doAction: function (context) {
+                                    distanceMeasurementsPlugin.setAxisVisible(false);
+                                }
+                            },
+                            {
+                                title: "Delete All",
+                                getEnabled: function (context) {
+                                    return (Object.keys(distanceMeasurementsPlugin.measurements).length > 0);
+                                },
+                                doAction: function (context) {
+                                    distanceMeasurementsPlugin.clear();
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ]
+        ],
+        enabled: true
+    });
+
+    const canvasContextMenu = new ContextMenu({
+        enabled: true,
+        context: {
+            viewer: viewer
+        },
+        items: [
+            [
+                {
+                    title: "Objects..",
+                    items: [
+                        [
+                            {
+                                title: "X-Ray All",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.numXRayedObjects < scene.numObjects);
+                                },
+                                doAction: function (context) {
+                                    const scene = context.viewer.scene;
+                                    scene.setObjectsXRayed(scene.objectIds, true);
+                                }
+                            },
+                            {
+                                title: "X-Ray None",
+                                getEnabled: function (context) {
+                                    return (context.viewer.scene.numXRayedObjects > 0);
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.setObjectsXRayed(context.viewer.scene.xrayedObjectIds, false);
+                                }
+                            }
+                        ],
+                        [
+                            {
+                                title: "Hide All",
+                                getEnabled: function (context) {
+                                    return (context.viewer.scene.numVisibleObjects > 0);
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.setObjectsVisible(context.viewer.scene.visibleObjectIds, false);
+                                }
+                            },
+                            {
+                                title: "Show All",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.numVisibleObjects < scene.numObjects);
+                                },
+                                doAction: function (context) {
+                                    const scene = context.viewer.scene;
+                                    scene.setObjectsVisible(scene.objectIds, true);
+                                    scene.setObjectsXRayed(scene.xrayedObjectIds, false);
+                                    scene.setObjectsSelected(scene.selectedObjectIds, false);
+                                }
+                            }
+                        ],
+
+                        [
+                            {
+                                title: "Select All",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.numSelectedObjects < scene.numObjects);
+                                },
+                                doAction: function (context) {
+                                    const scene = context.viewer.scene;
+                                    scene.setObjectsSelected(scene.objectIds, true);
+                                }
+                            },
+                            {
+                                title: "Select None",
+                                getEnabled: function (context) {
+                                    return (context.viewer.scene.numSelectedObjects > 0);
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.setObjectsSelected(context.viewer.scene.selectedObjectIds, false);
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ],
+            [
+                {
+                    title: "Camera..",
+                    items: [
+                        [
+                            {
+                                title: "View Fit All",
+                                doAction: function (context) {
+                                    context.viewer.cameraFlight.flyTo({
+                                        aabb: context.viewer.scene.getAABB()
+                                    });
+                                }
+                            }
+                        ],
+                        [
+                            {
+                                title: "Perspective",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.camera.projection !== "perspective");
+                                },
+                                doAction: function (context) {
+                                    context.viewer.cameraFlight.flyTo({
+                                        projection: "perspective"
+                                    });
+                                }
+                            },
+                            {
+                                title: "Orthographic",
+                                getEnabled: function (context) {
+                                    const scene = context.viewer.scene;
+                                    return (scene.camera.projection !== "ortho");
+                                },
+                                doAction: function (context) {
+                                    context.viewer.cameraFlight.flyTo({
+                                        projection: "ortho"
+                                    });
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ],
+
+            [
+                {
+                    title: "Effects..",
+                    items: [
+                        [
+                            {
+                                getTitle: (context) => {
+                                    return context.viewer.scene.edgeMaterial.edges ? "Disable Edges" : "Enable Edges";
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.edgeMaterial.edges = !context.viewer.scene.edgeMaterial.edges;
+                                }
+                            },
+                            {
+                                getTitle: (context) => {
+                                    return context.viewer.scene.sao.enabled ? "Disable SAO" : "Enable SAO";
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.sao.enabled = !context.viewer.scene.sao.enabled;
+                                }
+                            },
+                            {
+                                getTitle: (context) => {
+                                    return context.viewer.scene.pbrEnabled ? "Disable PBR" : "Enable PBR";
+                                },
+                                doAction: function (context) {
+                                    context.viewer.scene.pbrEnabled = !context.viewer.scene.pbrEnabled;
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ],
+            [
+                {
+                    title: "Measurements..",
+                    getEnabled: function (context) {
+                        return (Object.keys(distanceMeasurementsPlugin.measurements).length > 0);
+                    },
+                    items: [
+                        [
+                            {
+                                getTitle: function (context) {
+                                    return (Object.keys(distanceMeasurementsPlugin.measurements).length > 0) ? "Show All Labels" : "Hide All Labels";
+                                },
+                                getEnabled: function (context) {
+                                    return (Object.keys(distanceMeasurementsPlugin.measurements).length > 0);
+                                },
+                                doAction: function (context) {
+                                    //distanceMeasurementsPlugin.clear();
+                                }
+                            },
+                            {
+                                getTitle: function (context) {
+                                    return (Object.keys(distanceMeasurementsPlugin.measurements).length > 0) ? "Show All Axis" : "Hide All Axis";
+                                },
+                                getEnabled: function (context) {
+                                    return (Object.keys(distanceMeasurementsPlugin.measurements).length > 0);
+                                },
+                                doAction: function (context) {
+                                    distanceMeasurementsPlugin.setAxisVisible(true);
+                                }
+                            },
+                            {
+                                getTitle: function (context) {
+                                    return (Object.keys(distanceMeasurementsPlugin.measurements).length > 0) ? "Hide All Axis" : "Hide All Axis";
+                                },
+                                getEnabled: function (context) {
+                                    return (Object.keys(distanceMeasurementsPlugin.measurements).length > 0);
+                                },
+                                doAction: function (context) {
+                                    distanceMeasurementsPlugin.setAxisVisible(false);
+                                }
+                            },
+                            {
+                                title: "Delete All",
+                                getEnabled: function (context) {
+                                    return (Object.keys(distanceMeasurementsPlugin.measurements).length > 0);
+                                },
+                                doAction: function (context) {
+                                    distanceMeasurementsPlugin.clear();
+                                }
+                            }
+                        ]
+                    ]
+                }
+            ]
+        ]
+    });
+
+    viewer.scene.canvas.canvas.addEventListener('contextmenu', (event) => {
+        const canvasPos = getCanvasPosFromEvent(event);
+        const hit = viewer.scene.pick({
+            canvasPos
+        });
+        if (hit && hit.entity.isObject) {
+            objectContextMenu.context = { // Must set context before showing menu
+                viewer,
+                entity: hit.entity
+            };
+            objectContextMenu.show(event.pageX, event.pageY);
+        } else {
+            canvasContextMenu.context = { // Must set context before showing menu
+                viewer
+            };
+            canvasContextMenu.show(event.pageX, event.pageY);
+        }
+        event.preventDefault();
+    });
+
+    const getCanvasPosFromEvent = function (event) {
+        const canvasPos = [];
+        if (!event) {
+            event = window.event;
+            canvasPos[0] = event.x;
+            canvasPos[1] = event.y;
+        } else {
+            let element = event.target;
+            let totalOffsetLeft = 0;
+            let totalOffsetTop = 0;
+            let totalScrollX = 0;
+            let totalScrollY = 0;
+            while (element.offsetParent) {
+                totalOffsetLeft += element.offsetLeft;
+                totalOffsetTop += element.offsetTop;
+                totalScrollX += element.scrollLeft;
+                totalScrollY += element.scrollTop;
+                element = element.offsetParent;
+            }
+            canvasPos[0] = event.pageX + totalScrollX - totalOffsetLeft;
+            canvasPos[1] = event.pageY + totalScrollY - totalOffsetTop;
+        }
+        return canvasPos;
+    };
+
+    window.viewer = viewer;
+
+</script>
+
+</html>

--- a/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
+++ b/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
@@ -318,6 +318,7 @@ class DistanceMeasurement extends Component {
         this.lengthLabelEnabled = cfg.lengthLabelEnabled;
         this.labelsVisible = cfg.labelsVisible;
         this.labelsOnWires = cfg.labelsOnWires;
+        this.useRotationAdjustment = cfg.useRotationAdjustment;
     }
 
     _update() {
@@ -331,7 +332,7 @@ class DistanceMeasurement extends Component {
         if (this._wpDirty) {
 
             this._measurementOrientation = determineMeasurementOrientation(this._originWorld, this._targetWorld, 1);
-            if(this._measurementOrientation === 'Vertical'){
+            if(this._measurementOrientation === 'Vertical' && this.useRotationAdjustment){
                 this._wp[0] = this._originWorld[0];
                 this._wp[1] = this._originWorld[1];
                 this._wp[2] = this._originWorld[2];

--- a/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsPlugin.js
+++ b/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsPlugin.js
@@ -283,7 +283,7 @@ class DistanceMeasurementsPlugin extends Plugin {
    * @param {boolean} [cfg.defaultXAxisVisible=true] The default value of the DistanceMeasurements `xAxisVisible` property.
    * @param {boolean} [cfg.defaultYAxisVisible=true] The default value of the DistanceMeasurements `yAxisVisible` property.
    * @param {boolean} [cfg.defaultZAxisVisible=true] The default value of the DistanceMeasurements `zAxisVisible` property.
-   * @param {boolean} [cfg.defaultUseRotationAdjustment=true] The default value of DistanceMeasurements `useRotationAdjustment` property.
+   * @param {boolean} [cfg.useRotationAdjustment=false] The default value of DistanceMeasurements `useRotationAdjustment` property.
    * @param {string} [cfg.defaultColor=#00BBFF] The default color of the length dots, wire and label.
    * @param {number} [cfg.zIndex] If set, the wires, dots and labels will have this zIndex (+1 for dots and +2 for labels).
    * @param {boolean} [cfg.defaultLabelsOnWires=true] The default value of the DistanceMeasurements `labelsOnWires` property.
@@ -317,8 +317,7 @@ class DistanceMeasurementsPlugin extends Plugin {
     this.defaultColor =cfg.defaultColor !== undefined ? cfg.defaultColor : "#00BBFF";
     this.zIndex = cfg.zIndex || 10000;
     this.defaultLabelsOnWires = cfg.defaultLabelsOnWires !== false;
-    this.defaultUseRotationAdjustment = cfg.defaultUseRotationAdjustment !== false;
-    this.useRotationAdjustment = cfg.defaultUseRotationAdjustment !== false;
+    this.useRotationAdjustment = cfg.useRotationAdjustment !== undefined ? cfg.useRotationAdjustment !== false : false;
 
     this._onMouseOver = (event, measurement) => {
       this.fire("mouseOver", {
@@ -424,7 +423,7 @@ class DistanceMeasurementsPlugin extends Plugin {
    * @type {boolean}
    */
   set useRotationAdjustment(_useRotationAdjustment) {
-    _useRotationAdjustment = _useRotationAdjustment !== undefined ? Boolean(_useRotationAdjustment) : this.defaultUseRotationAdjustment;
+    _useRotationAdjustment = _useRotationAdjustment !== undefined ? Boolean(_useRotationAdjustment) : false;
     this._useRotationAdjustment = _useRotationAdjustment;
   }
 

--- a/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsPlugin.js
+++ b/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsPlugin.js
@@ -1,6 +1,6 @@
-import {Plugin} from "../../viewer/Plugin.js";
-import {DistanceMeasurement} from "./DistanceMeasurement.js";
-import {DistanceMeasurementsMouseControl} from "./DistanceMeasurementsMouseControl.js";
+import { Plugin } from "../../viewer/Plugin.js";
+import { DistanceMeasurement } from "./DistanceMeasurement.js";
+import { DistanceMeasurementsMouseControl } from "./DistanceMeasurementsMouseControl.js";
 
 /**
  * {@link Viewer} plugin for measuring point-to-point distances.
@@ -263,304 +263,323 @@ import {DistanceMeasurementsMouseControl} from "./DistanceMeasurementsMouseContr
  * ````
  */
 class DistanceMeasurementsPlugin extends Plugin {
+  /**
+   * @constructor
+   * @param {Viewer} viewer The Viewer.
+   * @param {Object} [cfg]  Plugin configuration.
+   * @param {String} [cfg.id="DistanceMeasurements"] Optional ID for this plugin, so that we can find it within {@link Viewer#plugins}.
+   * @param {Number} [cfg.labelMinAxisLength=25] The minimum length, in pixels, of an axis wire beyond which its label is shown.
+   * @param {HTMLElement} [cfg.container] Container DOM element for markers and labels. Defaults to ````document.body````.
+   * @param {boolean} [cfg.defaultVisible=true] The default value of the DistanceMeasurements `visible` property.
+   * @param {boolean} [cfg.defaultOriginVisible=true] The default value of the DistanceMeasurements `originVisible` property.
+   * @param {boolean} [cfg.defaultTargetVisible=true] The default value of the DistanceMeasurements `targetVisible` property.
+   * @param {boolean} [cfg.defaultWireVisible=true] The default value of the DistanceMeasurements `wireVisible` property.
+   * @param {boolean} [cfg.defaultLabelsVisible=true] The default value of the DistanceMeasurements `labelsVisible` property.
+   * @param {boolean} [cfg.defaultXLabelEnabled=true] The default value of the DistanceMeasurements `xLabelEnabled` property.
+   * @param {boolean} [cfg.defaultYLabelEnabled=true] The default value of the DistanceMeasurements `yLabelEnabled` property.
+   * @param {boolean} [cfg.defaultZLabelEnabled=true] The default value of the DistanceMeasurements `zLabelEnabled` property.
+   * @param {boolean} [cfg.defaultLengthLabelEnabled=true] The default value of the DistanceMeasurements `lengthLabelEnabled` property.
+   * @param {boolean} [cfg.defaultAxisVisible=true] The default value of the DistanceMeasurements `axisVisible` property.
+   * @param {boolean} [cfg.defaultXAxisVisible=true] The default value of the DistanceMeasurements `xAxisVisible` property.
+   * @param {boolean} [cfg.defaultYAxisVisible=true] The default value of the DistanceMeasurements `yAxisVisible` property.
+   * @param {boolean} [cfg.defaultZAxisVisible=true] The default value of the DistanceMeasurements `zAxisVisible` property.
+   * @param {boolean} [cfg.defaultUseRotationAdjustment=true] The default value of DistanceMeasurements `useRotationAdjustment` property.
+   * @param {string} [cfg.defaultColor=#00BBFF] The default color of the length dots, wire and label.
+   * @param {number} [cfg.zIndex] If set, the wires, dots and labels will have this zIndex (+1 for dots and +2 for labels).
+   * @param {boolean} [cfg.defaultLabelsOnWires=true] The default value of the DistanceMeasurements `labelsOnWires` property.
+   * @param {PointerCircle} [cfg.pointerLens] A PointerLens to help the user position the pointer. This can be shared with other plugins.
+   */
+  constructor(viewer, cfg = {}) {
+    super("DistanceMeasurements", viewer);
 
-    /**
-     * @constructor
-     * @param {Viewer} viewer The Viewer.
-     * @param {Object} [cfg]  Plugin configuration.
-     * @param {String} [cfg.id="DistanceMeasurements"] Optional ID for this plugin, so that we can find it within {@link Viewer#plugins}.
-     * @param {Number} [cfg.labelMinAxisLength=25] The minimum length, in pixels, of an axis wire beyond which its label is shown.
-     * @param {HTMLElement} [cfg.container] Container DOM element for markers and labels. Defaults to ````document.body````.
-     * @param {boolean} [cfg.defaultVisible=true] The default value of the DistanceMeasurements `visible` property.
-     * @param {boolean} [cfg.defaultOriginVisible=true] The default value of the DistanceMeasurements `originVisible` property.
-     * @param {boolean} [cfg.defaultTargetVisible=true] The default value of the DistanceMeasurements `targetVisible` property.
-     * @param {boolean} [cfg.defaultWireVisible=true] The default value of the DistanceMeasurements `wireVisible` property.
-     * @param {boolean} [cfg.defaultLabelsVisible=true] The default value of the DistanceMeasurements `labelsVisible` property.
-     * @param {boolean} [cfg.defaultXLabelEnabled=true] The default value of the DistanceMeasurements `xLabelEnabled` property.
-     * @param {boolean} [cfg.defaultYLabelEnabled=true] The default value of the DistanceMeasurements `yLabelEnabled` property.
-     * @param {boolean} [cfg.defaultZLabelEnabled=true] The default value of the DistanceMeasurements `zLabelEnabled` property.
-     * @param {boolean} [cfg.defaultLengthLabelEnabled=true] The default value of the DistanceMeasurements `lengthLabelEnabled` property.
-     * @param {boolean} [cfg.defaultAxisVisible=true] The default value of the DistanceMeasurements `axisVisible` property.
-     * @param {boolean} [cfg.defaultXAxisVisible=true] The default value of the DistanceMeasurements `xAxisVisible` property.
-     * @param {boolean} [cfg.defaultYAxisVisible=true] The default value of the DistanceMeasurements `yAxisVisible` property.
-     * @param {boolean} [cfg.defaultZAxisVisible=true] The default value of the DistanceMeasurements `zAxisVisible` property.
-     * @param {string} [cfg.defaultColor=#00BBFF] The default color of the length dots, wire and label.
-     * @param {number} [cfg.zIndex] If set, the wires, dots and labels will have this zIndex (+1 for dots and +2 for labels).
-     * @param {boolean} [cfg.defaultLabelsOnWires=true] The default value of the DistanceMeasurements `labelsOnWires` property.
-     * @param {PointerCircle} [cfg.pointerLens] A PointerLens to help the user position the pointer. This can be shared with other plugins.
-     */
-    constructor(viewer, cfg = {}) {
+    this._pointerLens = cfg.pointerLens;
 
-        super("DistanceMeasurements", viewer);
+    this._container = cfg.container || document.body;
 
-        this._pointerLens = cfg.pointerLens;
+    this._defaultControl = null;
 
-        this._container = cfg.container || document.body;
+    this._measurements = {};
 
-        this._defaultControl = null;
+    this.labelMinAxisLength = cfg.labelMinAxisLength;
+    this.defaultVisible = cfg.defaultVisible !== false;
+    this.defaultOriginVisible = cfg.defaultOriginVisible !== false;
+    this.defaultTargetVisible = cfg.defaultTargetVisible !== false;
+    this.defaultWireVisible = cfg.defaultWireVisible !== false;
+    this.defaultXLabelEnabled = cfg.defaultXLabelEnabled !== false;
+    this.defaultYLabelEnabled = cfg.defaultYLabelEnabled !== false;
+    this.defaultZLabelEnabled = cfg.defaultZLabelEnabled !== false;
+    this.defaultLengthLabelEnabled = cfg.defaultLengthLabelEnabled !== false;
+    this.defaultLabelsVisible = cfg.defaultLabelsVisible !== false;
+    this.defaultAxisVisible = cfg.defaultAxisVisible !== false;
+    this.defaultXAxisVisible = cfg.defaultXAxisVisible !== false;
+    this.defaultYAxisVisible = cfg.defaultYAxisVisible !== false;
+    this.defaultZAxisVisible = cfg.defaultZAxisVisible !== false;
+    this.defaultColor =cfg.defaultColor !== undefined ? cfg.defaultColor : "#00BBFF";
+    this.zIndex = cfg.zIndex || 10000;
+    this.defaultLabelsOnWires = cfg.defaultLabelsOnWires !== false;
+    this.defaultUseRotationAdjustment = cfg.defaultUseRotationAdjustment !== false;
+    this.useRotationAdjustment = cfg.defaultUseRotationAdjustment !== false;
 
-        this._measurements = {};
+    this._onMouseOver = (event, measurement) => {
+      this.fire("mouseOver", {
+        plugin: this,
+        distanceMeasurement: measurement,
+        measurement,
+        event,
+      });
+    };
 
-        this.labelMinAxisLength = cfg.labelMinAxisLength;
-        this.defaultVisible = cfg.defaultVisible !== false;
-        this.defaultOriginVisible = cfg.defaultOriginVisible !== false;
-        this.defaultTargetVisible = cfg.defaultTargetVisible !== false;
-        this.defaultWireVisible = cfg.defaultWireVisible !== false;
-        this.defaultXLabelEnabled = cfg.defaultXLabelEnabled !== false;
-        this.defaultYLabelEnabled = cfg.defaultYLabelEnabled !== false;
-        this.defaultZLabelEnabled = cfg.defaultZLabelEnabled !== false;
-        this.defaultLengthLabelEnabled = cfg.defaultLengthLabelEnabled !== false;
-        this.defaultLabelsVisible = cfg.defaultLabelsVisible !== false;
-        this.defaultAxisVisible = cfg.defaultAxisVisible !== false;
-        this.defaultXAxisVisible = cfg.defaultXAxisVisible !== false;
-        this.defaultYAxisVisible = cfg.defaultYAxisVisible !== false;
-        this.defaultZAxisVisible = cfg.defaultZAxisVisible !== false;
-        this.defaultColor = cfg.defaultColor !== undefined ? cfg.defaultColor : "#00BBFF";
-        this.zIndex = cfg.zIndex || 10000;
-        this.defaultLabelsOnWires = cfg.defaultLabelsOnWires !== false;
+    this._onMouseLeave = (event, measurement) => {
+      this.fire("mouseLeave", {
+        plugin: this,
+        distanceMeasurement: measurement,
+        measurement,
+        event,
+      });
+    };
 
-        this._onMouseOver = (event, measurement) => {
-            this.fire("mouseOver", {
-                plugin: this,
-                distanceMeasurement: measurement,
-                measurement,
-                event
-            });
-        }
+    this._onContextMenu = (event, measurement) => {
+      this.fire("contextMenu", {
+        plugin: this,
+        distanceMeasurement: measurement,
+        measurement,
+        event,
+      });
+    };
+  }
 
-        this._onMouseLeave = (event, measurement) => {
-            this.fire("mouseLeave", {
-                plugin: this,
-                distanceMeasurement: measurement,
-                measurement,
-                event
-            });
-        };
+  /**
+   * Gets the plugin's HTML container element, if any.
+   * @returns {*|HTMLElement|HTMLElement}
+   */
+  getContainerElement() {
+    return this._container;
+  }
 
-        this._onContextMenu = (event, measurement) => {
-            this.fire("contextMenu", {
-                plugin: this,
-                distanceMeasurement: measurement,
-                measurement,
-                event
-            });
-        };
+  /**
+   * @private
+   */
+  send(name, value) {}
+
+  /**
+   * Gets the PointerLens attached to this DistanceMeasurementsPlugin.
+   * @returns {PointerCircle}
+   */
+  get pointerLens() {
+    return this._pointerLens;
+  }
+
+  /**
+   * Gets the default {@link DistanceMeasurementsControl}.
+   *
+   * @type {DistanceMeasurementsControl}
+   * @deprecated
+   */
+  get control() {
+    if (!this._defaultControl) {
+      this._defaultControl = new DistanceMeasurementsMouseControl(this, {});
     }
+    return this._defaultControl;
+  }
 
-    /**
-     * Gets the plugin's HTML container element, if any.
-     * @returns {*|HTMLElement|HTMLElement}
-     */
-    getContainerElement() {
-        return this._container;
+  /**
+   * Gets the existing {@link DistanceMeasurement}s, each mapped to its {@link DistanceMeasurement#id}.
+   *
+   * @type {{String:DistanceMeasurement}}
+   */
+  get measurements() {
+    return this._measurements;
+  }
+
+  /**
+   * Sets the minimum length, in pixels, of an axis wire beyond which its label is shown.
+   *
+   * The axis wire's label is not shown when its length is less than this value.
+   *
+   * This is ````25```` pixels by default.
+   *
+   * Must not be less than ````1````.
+   *
+   * @type {number}
+   */
+  set labelMinAxisLength(labelMinAxisLength) {
+    if (labelMinAxisLength < 1) {
+      this.error("labelMinAxisLength must be >= 1; defaulting to 25");
+      labelMinAxisLength = 25;
     }
+    this._labelMinAxisLength = labelMinAxisLength || 25;
+  }
 
-    /**
-     * @private
-     */
-    send(name, value) {
+  /**
+   * Gets the minimum length, in pixels, of an axis wire beyond which its label is shown.
+   * @returns {number}
+   */
+  get labelMinAxisLength() {
+    return this._labelMinAxisLength;
+  }
 
+  /**
+   * Sets whether the measurement added is rotation adjusted or not.
+   *
+   * @type {boolean}
+   */
+  set useRotationAdjustment(_useRotationAdjustment) {
+    _useRotationAdjustment = _useRotationAdjustment !== undefined ? Boolean(_useRotationAdjustment) : this.defaultUseRotationAdjustment;
+    this._useRotationAdjustment = _useRotationAdjustment;
+  }
+
+  /**
+   * Gets whether the measurement added is rotation adjusted or not.
+   * @returns {number}
+   */
+  get useRotationAdjustment(){
+    return this._useRotationAdjustment;
+  }
+  /**
+   * Creates a {@link DistanceMeasurement}.
+   *
+   * The DistanceMeasurement is then registered by {@link DistanceMeasurement#id} in {@link DistanceMeasurementsPlugin#measurements}.
+   *
+   * @param {Object} params {@link DistanceMeasurement} configuration.
+   * @param {String} params.id Unique ID to assign to {@link DistanceMeasurement#id}. The DistanceMeasurement will be registered by this in {@link DistanceMeasurementsPlugin#measurements} and {@link Scene.components}. Must be unique among all components in the {@link Viewer}.
+   * @param {Number[]} params.origin.worldPos Origin World-space 3D position.
+   * @param {Entity} params.origin.entity Origin Entity.
+   * @param {Number[]} params.target.worldPos Target World-space 3D position.
+   * @param {Entity} params.target.entity Target Entity.
+   * @param {Boolean} [params.visible=true] Whether to initially show the {@link DistanceMeasurement}.
+   * @param {Boolean} [params.originVisible=true] Whether to initially show the {@link DistanceMeasurement} origin.
+   * @param {Boolean} [params.targetVisible=true] Whether to initially show the {@link DistanceMeasurement} target.
+   * @param {Boolean} [params.wireVisible=true] Whether to initially show the direct point-to-point wire between {@link DistanceMeasurement#origin} and {@link DistanceMeasurement#target}.
+   * @param {Boolean} [params.axisVisible=true] Whether to initially show the axis-aligned wires between {@link DistanceMeasurement#origin} and {@link DistanceMeasurement#target}.
+   * @param {Boolean} [params.xAxisVisible=true] Whether to initially show the X-axis-aligned wires between {@link DistanceMeasurement#origin} and {@link DistanceMeasurement#target}.
+   * @param {Boolean} [params.yAxisVisible=true] Whether to initially show the Y-axis-aligned wires between {@link DistanceMeasurement#origin} and {@link DistanceMeasurement#target}.
+   * @param {Boolean} [params.zAxisVisible=true] Whether to initially show the Z-axis-aligned wires between {@link DistanceMeasurement#origin} and {@link DistanceMeasurement#target}.
+   * @param {Boolean} [params.xLabelEnabled=true] Whether to initially show the x label.
+   * @param {Boolean} [params.yLabelEnabled=true] Whether to initially show the y label.
+   * @param {Boolean} [params.zLabelEnabled=true] Whether to initially show the z label.
+   * @param {Boolean} [params.lengthLabelEnabled=true] Whether to initially show the length label.
+   * @param {Boolean} [params.labelsVisible=true] Whether to initially show the labels.
+   * @param {Boolean} [params.lengthLabelVisible=true] Whether to initially show the labels.
+   * @param {string} [params.color] The color of the length dot, wire and label.
+   * @param {Boolean} [params.labelsOnWires=true] Determines if labels will be set on wires or one below the other.
+   * @returns {DistanceMeasurement} The new {@link DistanceMeasurement}.
+   */
+  createMeasurement(params = {}) {
+    if (this.viewer.scene.components[params.id]) {
+      this.error(
+        "Viewer scene component with this ID already exists: " + params.id
+      );
+      delete params.id;
     }
+    const origin = params.origin;
+    const target = params.target;
+    const measurement = new DistanceMeasurement(this, {
+      id: params.id,
+      plugin: this,
+      container: this._container,
+      origin: {
+        entity: origin.entity,
+        worldPos: origin.worldPos,
+      },
+      target: {
+        entity: target.entity,
+        worldPos: target.worldPos,
+      },
+      visible: params.visible,
+      wireVisible: params.wireVisible,
+      axisVisible: params.axisVisible !== false && this.defaultAxisVisible !== false,
+      xAxisVisible: params.xAxisVisible !== false && this.defaultXAxisVisible !== false,
+      yAxisVisible: params.yAxisVisible !== false && this.defaultYAxisVisible !== false,
+      zAxisVisibld: params.zAxisVisible !== false && this.defaultZAxisVisible !== false,
+      xLabelEnabled: params.xLabelEnabled !== false && this.defaultXLabelEnabled !== false,
+      yLabelEnabled: params.yLabelEnabled !== false && this.defaultYLabelEnabled !== false,
+      zLabelEnabled: params.zLabelEnabled !== false && this.defaultZLabelEnabled !== false,
+      lengthLabelEnabled: params.lengthLabelEnabled !== false && this.defaultLengthLabelEnabled !== false,
+      labelsVisible: params.labelsVisible !== false && this.defaultLabelsVisible !== false,
+      useRotationAdjustment: this.useRotationAdjustment,
+      originVisible: params.originVisible,
+      targetVisible: params.targetVisible,
+      color: params.color,
+      labelsOnWires:params.labelsOnWires !== false && this.defaultLabelsOnWires !== false,
+      onMouseOver: this._onMouseOver,
+      onMouseLeave: this._onMouseLeave,
+      onContextMenu: this._onContextMenu,
+    });
+    this._measurements[measurement.id] = measurement;
+    measurement.clickable = true;
+    measurement.on("destroyed", () => {
+      delete this._measurements[measurement.id];
+    });
+    this.fire("measurementCreated", measurement);
+    return measurement;
+  }
 
-    /**
-     * Gets the PointerLens attached to this DistanceMeasurementsPlugin.
-     * @returns {PointerCircle}
-     */
-    get pointerLens() {
-        return this._pointerLens;
+  /**
+   * Destroys a {@link DistanceMeasurement}.
+   *
+   * @param {String} id ID of DistanceMeasurement to destroy.
+   */
+  destroyMeasurement(id) {
+    const measurement = this._measurements[id];
+    if (!measurement) {
+      this.log("DistanceMeasurement not found: " + id);
+      return;
     }
+    measurement.destroy();
+    this.fire("measurementDestroyed", measurement);
+  }
 
-    /**
-     * Gets the default {@link DistanceMeasurementsControl}.
-     *
-     * @type {DistanceMeasurementsControl}
-     * @deprecated
-     */
-    get control() {
-        if (!this._defaultControl) {
-            this._defaultControl = new DistanceMeasurementsMouseControl(this, {});
-        }
-        return this._defaultControl;
+  /**
+   * Shows all or hides the distance label of each {@link DistanceMeasurement}.
+   *
+   * @param {Boolean} labelsShown Whether or not to show the labels.
+   */
+  setLabelsShown(labelsShown) {
+    for (const [key, measurement] of Object.entries(this.measurements)) {
+      measurement.labelShown = labelsShown;
     }
+  }
 
-    /**
-     * Gets the existing {@link DistanceMeasurement}s, each mapped to its {@link DistanceMeasurement#id}.
-     *
-     * @type {{String:DistanceMeasurement}}
-     */
-    get measurements() {
-        return this._measurements;
+  /**
+   * Shows all or hides the axis wires of each {@link DistanceMeasurement}.
+   *
+   * @param {Boolean} labelsShown Whether or not to show the axis wires.
+   */
+  setAxisVisible(axisVisible) {
+    for (const [key, measurement] of Object.entries(this.measurements)) {
+      measurement.axisVisible = axisVisible;
     }
+    this.defaultAxisVisible = axisVisible;
+  }
 
-    /**
-     * Sets the minimum length, in pixels, of an axis wire beyond which its label is shown.
-     *
-     * The axis wire's label is not shown when its length is less than this value.
-     *
-     * This is ````25```` pixels by default.
-     *
-     * Must not be less than ````1````.
-     *
-     * @type {number}
-     */
-    set labelMinAxisLength(labelMinAxisLength) {
-        if (labelMinAxisLength < 1) {
-            this.error("labelMinAxisLength must be >= 1; defaulting to 25");
-            labelMinAxisLength = 25;
-        }
-        this._labelMinAxisLength = labelMinAxisLength || 25;
-    }
+  /**
+   * Gets if the axis wires of each {@link DistanceMeasurement} are visible.
+   *
+   * @returns {Boolean} Whether or not the axis wires are visible.
+   */
+  getAxisVisible() {
+    return this.defaultAxisVisible;
+  }
 
-    /**
-     * Gets the minimum length, in pixels, of an axis wire beyond which its label is shown.
-     * @returns {number}
-     */
-    get labelMinAxisLength() {
-        return this._labelMinAxisLength;
+  /**
+   * Destroys all {@link DistanceMeasurement}s.
+   */
+  clear() {
+    const ids = Object.keys(this._measurements);
+    for (var i = 0, len = ids.length; i < len; i++) {
+      this.destroyMeasurement(ids[i]);
     }
+  }
 
-    /**
-     * Creates a {@link DistanceMeasurement}.
-     *
-     * The DistanceMeasurement is then registered by {@link DistanceMeasurement#id} in {@link DistanceMeasurementsPlugin#measurements}.
-     *
-     * @param {Object} params {@link DistanceMeasurement} configuration.
-     * @param {String} params.id Unique ID to assign to {@link DistanceMeasurement#id}. The DistanceMeasurement will be registered by this in {@link DistanceMeasurementsPlugin#measurements} and {@link Scene.components}. Must be unique among all components in the {@link Viewer}.
-     * @param {Number[]} params.origin.worldPos Origin World-space 3D position.
-     * @param {Entity} params.origin.entity Origin Entity.
-     * @param {Number[]} params.target.worldPos Target World-space 3D position.
-     * @param {Entity} params.target.entity Target Entity.
-     * @param {Boolean} [params.visible=true] Whether to initially show the {@link DistanceMeasurement}.
-     * @param {Boolean} [params.originVisible=true] Whether to initially show the {@link DistanceMeasurement} origin.
-     * @param {Boolean} [params.targetVisible=true] Whether to initially show the {@link DistanceMeasurement} target.
-     * @param {Boolean} [params.wireVisible=true] Whether to initially show the direct point-to-point wire between {@link DistanceMeasurement#origin} and {@link DistanceMeasurement#target}.
-     * @param {Boolean} [params.axisVisible=true] Whether to initially show the axis-aligned wires between {@link DistanceMeasurement#origin} and {@link DistanceMeasurement#target}.
-     * @param {Boolean} [params.xAxisVisible=true] Whether to initially show the X-axis-aligned wires between {@link DistanceMeasurement#origin} and {@link DistanceMeasurement#target}.
-     * @param {Boolean} [params.yAxisVisible=true] Whether to initially show the Y-axis-aligned wires between {@link DistanceMeasurement#origin} and {@link DistanceMeasurement#target}.
-     * @param {Boolean} [params.zAxisVisible=true] Whether to initially show the Z-axis-aligned wires between {@link DistanceMeasurement#origin} and {@link DistanceMeasurement#target}.
-     * @param {Boolean} [params.xLabelEnabled=true] Whether to initially show the x label.
-     * @param {Boolean} [params.yLabelEnabled=true] Whether to initially show the y label.
-     * @param {Boolean} [params.zLabelEnabled=true] Whether to initially show the z label.
-     * @param {Boolean} [params.lengthLabelEnabled=true] Whether to initially show the length label.
-     * @param {Boolean} [params.labelsVisible=true] Whether to initially show the labels.
-     * @param {Boolean} [params.lengthLabelVisible=true] Whether to initially show the labels.
-     * @param {string} [params.color] The color of the length dot, wire and label.
-     * @param {Boolean} [params.labelsOnWires=true] Determines if labels will be set on wires or one below the other.
-     * @returns {DistanceMeasurement} The new {@link DistanceMeasurement}.
-     */
-    createMeasurement(params = {}) {
-        if (this.viewer.scene.components[params.id]) {
-            this.error("Viewer scene component with this ID already exists: " + params.id);
-            delete params.id;
-        }
-        const origin = params.origin;
-        const target = params.target;
-        const measurement = new DistanceMeasurement(this, {
-            id: params.id,
-            plugin: this,
-            container: this._container,
-            origin: {
-                entity: origin.entity,
-                worldPos: origin.worldPos
-            },
-            target: {
-                entity: target.entity,
-                worldPos: target.worldPos
-            },
-            visible: params.visible,
-            wireVisible: params.wireVisible,
-            axisVisible: params.axisVisible !== false && this.defaultAxisVisible !== false,
-            xAxisVisible: params.xAxisVisible !== false && this.defaultXAxisVisible !== false,
-            yAxisVisible: params.yAxisVisible !== false && this.defaultYAxisVisible !== false,
-            zAxisVisible: params.zAxisVisible !== false && this.defaultZAxisVisible !== false,
-            xLabelEnabled: params.xLabelEnabled !== false && this.defaultXLabelEnabled !== false,
-            yLabelEnabled: params.yLabelEnabled !== false && this.defaultYLabelEnabled !== false,
-            zLabelEnabled: params.zLabelEnabled !== false && this.defaultZLabelEnabled !== false,
-            lengthLabelEnabled: params.lengthLabelEnabled !== false && this.defaultLengthLabelEnabled !== false,
-            labelsVisible: params.labelsVisible !== false && this.defaultLabelsVisible !== false,
-            originVisible: params.originVisible,
-            targetVisible: params.targetVisible,
-            color: params.color,
-            labelsOnWires: params.labelsOnWires !== false && this.defaultLabelsOnWires !== false,
-            onMouseOver: this._onMouseOver,
-            onMouseLeave: this._onMouseLeave,
-            onContextMenu: this._onContextMenu
-        });
-        this._measurements[measurement.id] = measurement;
-        measurement.clickable = true;
-        measurement.on("destroyed", () => {
-            delete this._measurements[measurement.id];
-        });
-        this.fire("measurementCreated", measurement);
-        return measurement;
-    }
-
-    /**
-     * Destroys a {@link DistanceMeasurement}.
-     *
-     * @param {String} id ID of DistanceMeasurement to destroy.
-     */
-    destroyMeasurement(id) {
-        const measurement = this._measurements[id];
-        if (!measurement) {
-            this.log("DistanceMeasurement not found: " + id);
-            return;
-        }
-        measurement.destroy();
-        this.fire("measurementDestroyed", measurement);
-    }
-
-    /**
-     * Shows all or hides the distance label of each {@link DistanceMeasurement}.
-     *
-     * @param {Boolean} labelsShown Whether or not to show the labels.
-     */
-    setLabelsShown(labelsShown) {
-        for (const [key, measurement] of Object.entries(this.measurements)) {
-            measurement.labelShown = labelsShown;
-        }
-    }
-
-    /**
-     * Shows all or hides the axis wires of each {@link DistanceMeasurement}.
-     *
-     * @param {Boolean} labelsShown Whether or not to show the axis wires.
-     */
-    setAxisVisible(axisVisible) {
-        for (const [key, measurement] of Object.entries(this.measurements)) {
-            measurement.axisVisible = axisVisible;
-        }
-        this.defaultAxisVisible = axisVisible;
-    }
-
-    /**
-     * Gets if the axis wires of each {@link DistanceMeasurement} are visible.
-     *
-     * @returns {Boolean} Whether or not the axis wires are visible.
-     */
-    getAxisVisible() {
-        return this.defaultAxisVisible;
-    }
-
-    /**
-     * Destroys all {@link DistanceMeasurement}s.
-     */
-    clear() {
-        const ids = Object.keys(this._measurements);
-        for (var i = 0, len = ids.length; i < len; i++) {
-            this.destroyMeasurement(ids[i]);
-        }
-    }
-
-    /**
-     * Destroys this DistanceMeasurementsPlugin.
-     *
-     * Destroys all {@link DistanceMeasurement}s first.
-     */
-    destroy() {
-        this.clear();
-        super.destroy();
-    }
+  /**
+   * Destroys this DistanceMeasurementsPlugin.
+   *
+   * Destroys all {@link DistanceMeasurement}s first.
+   */
+  destroy() {
+    this.clear();
+    super.destroy();
+  }
 }
 
-export {DistanceMeasurementsPlugin}
+export { DistanceMeasurementsPlugin };


### PR DESCRIPTION
- Updated distance measurement plugin with the ability to switch between the mode of measurements
- Updated 'distance_createWithMouse_noSnapping.html' example with the option of switch between measurements modes on runtime
- Added two new examples to show rotation adjusted measurements, 'distance_createWithMouse_useRotationAdjustment' and 'distance_modelWithMeasurements_useRotationAdjustment'

https://github.com/xeokit/xeokit-sdk/assets/154510203/7768fe2b-a4cf-441a-8591-adb8789dd419


