### PR TITLE
[FEATURE] Extend pattern to end point

### DIFF
--- a/examples/scenegraph/buildLineGeometry.html
+++ b/examples/scenegraph/buildLineGeometry.html
@@ -112,17 +112,49 @@
     });
 
     //------------------------------------------------------------------------------------------------------------------
-    // Create a mesh with simple 2d line shape with black color and more complex pattern
+    // Create a mesh with simple 2d line shape with blue color and simple pattern extended to end
     //------------------------------------------------------------------------------------------------------------------
 
     new Mesh(viewer.scene, {
         geometry: new ReadableGeometry(viewer.scene, buildLineGeometry({
             startPoint: [-2,-2,0],
             endPoint: [-2,2,0],
+            pattern: [0.10],
+            extendToEnd: true,
+        })),
+        material: new PhongMaterial(viewer.scene, {
+            emissive: [0, 0, 1]
+        })
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a mesh with simple 2d line shape with black color and more complex pattern
+    //------------------------------------------------------------------------------------------------------------------
+
+    new Mesh(viewer.scene, {
+        geometry: new ReadableGeometry(viewer.scene, buildLineGeometry({
+            startPoint: [-1,-2,0],
+            endPoint: [-1,2,0],
             pattern: [0.15, 0.05],
         })),
         material: new PhongMaterial(viewer.scene, {
             emissive: [0, 0, 0]
+        })
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a mesh with simple 2d line shape with blue color and more complex pattern extended to end
+    //------------------------------------------------------------------------------------------------------------------
+
+    new Mesh(viewer.scene, {
+        geometry: new ReadableGeometry(viewer.scene, buildLineGeometry({
+            startPoint: [0,-2,0],
+            endPoint: [0,2,0],
+            pattern: [0.15, 0.05],
+            extendToEnd: true,
+        })),
+        material: new PhongMaterial(viewer.scene, {
+            emissive: [0, 0, 1]
         })
     });
 
@@ -132,12 +164,28 @@
 
     new Mesh(viewer.scene, {
         geometry: new ReadableGeometry(viewer.scene, buildLineGeometry({
-            startPoint: [-1,-2,0],
-            endPoint: [-1,2,0],
+            startPoint: [1,-2,0],
+            endPoint: [1,2,0],
             pattern: [0.15, 0.05, 0.50],
         })),
         material: new PhongMaterial(viewer.scene, {
             emissive: [0, 0, 0]
+        })
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a mesh with simple 2d line shape with blue color and complex pattern extended to end
+    //------------------------------------------------------------------------------------------------------------------
+
+    new Mesh(viewer.scene, {
+        geometry: new ReadableGeometry(viewer.scene, buildLineGeometry({
+            startPoint: [2,-2,0],
+            endPoint: [2,2,0],
+            pattern: [0.15, 0.05, 0.50],
+            extendToEnd: true,
+        })),
+        material: new PhongMaterial(viewer.scene, {
+            emissive: [0, 0, 1]
         })
     });
 
@@ -147,8 +195,8 @@
 
     new Mesh(viewer.scene, {
         geometry: new ReadableGeometry(viewer.scene, buildLineGeometry({
-            startPoint: [0,-2,-1],
-            endPoint: [2,2,1],
+            startPoint: [3,-2,-1],
+            endPoint: [5,2,1],
             pattern: [0.10],
         })),
         material: new PhongMaterial(viewer.scene, {
@@ -162,8 +210,8 @@
 
     new Mesh(viewer.scene, {
         geometry: new ReadableGeometry(viewer.scene, buildLineGeometry({
-            startPoint: [2,-2,-1],
-            endPoint: [4,2,1],
+            startPoint: [5,-2,-1],
+            endPoint: [7,2,1],
             pattern: [0.03],
         })),
         material: new PhongMaterial(viewer.scene, {

--- a/src/viewer/scene/geometry/builders/buildLineGeometry.js
+++ b/src/viewer/scene/geometry/builders/buildLineGeometry.js
@@ -72,17 +72,49 @@ import {utils} from '../../utils.js';
  * });
  *
  * //------------------------------------------------------------------------------------------------------------------
- * // Create a mesh with simple 2d line shape with black color and more complex pattern
+ * // Create a mesh with simple 2d line shape with blue color and simple pattern extended to end
  * //------------------------------------------------------------------------------------------------------------------
  *
  * new Mesh(viewer.scene, {
  *     geometry: new ReadableGeometry(viewer.scene, buildLineGeometry({
  *         startPoint: [-2,-2,0],
  *         endPoint: [-2,2,0],
+ *         pattern: [0.10],
+ *         extendToEnd: true,
+ *     })),
+ *     material: new PhongMaterial(viewer.scene, {
+ *         emissive: [0, 0, 1]
+ *     })
+ * });
+ *
+ * //------------------------------------------------------------------------------------------------------------------
+ * // Create a mesh with simple 2d line shape with black color and more complex pattern
+ * //------------------------------------------------------------------------------------------------------------------
+ *
+ * new Mesh(viewer.scene, {
+ *     geometry: new ReadableGeometry(viewer.scene, buildLineGeometry({
+ *         startPoint: [-1,-2,0],
+ *         endPoint: [-1,2,0],
  *         pattern: [0.15, 0.05],
  *     })),
  *     material: new PhongMaterial(viewer.scene, {
  *         emissive: [0, 0, 0]
+ *     })
+ * });
+ *
+ * //------------------------------------------------------------------------------------------------------------------
+ * // Create a mesh with simple 2d line shape with blue color and more complex pattern extended to end
+ * //------------------------------------------------------------------------------------------------------------------
+ *
+ * new Mesh(viewer.scene, {
+ *     geometry: new ReadableGeometry(viewer.scene, buildLineGeometry({
+ *         startPoint: [0,-2,0],
+ *         endPoint: [0,2,0],
+ *         pattern: [0.15, 0.05],
+ *         extendToEnd: true,
+ *     })),
+ *     material: new PhongMaterial(viewer.scene, {
+ *         emissive: [0, 0, 1]
  *     })
  * });
  *
@@ -92,12 +124,28 @@ import {utils} from '../../utils.js';
  *
  * new Mesh(viewer.scene, {
  *     geometry: new ReadableGeometry(viewer.scene, buildLineGeometry({
- *         startPoint: [-1,-2,0],
- *         endPoint: [-1,2,0],
+ *         startPoint: [1,-2,0],
+ *         endPoint: [1,2,0],
  *         pattern: [0.15, 0.05, 0.50],
  *     })),
  *     material: new PhongMaterial(viewer.scene, {
  *         emissive: [0, 0, 0]
+ *     })
+ * });
+ *
+ * //------------------------------------------------------------------------------------------------------------------
+ * // Create a mesh with simple 2d line shape with blue color and complex pattern extended to end
+ * //------------------------------------------------------------------------------------------------------------------
+ *
+ * new Mesh(viewer.scene, {
+ *     geometry: new ReadableGeometry(viewer.scene, buildLineGeometry({
+ *         startPoint: [2,-2,0],
+ *         endPoint: [2,2,0],
+ *         pattern: [0.15, 0.05, 0.50],
+ *         extendToEnd: true,
+ *     })),
+ *     material: new PhongMaterial(viewer.scene, {
+ *         emissive: [0, 0, 1]
  *     })
  * });
  *
@@ -107,8 +155,8 @@ import {utils} from '../../utils.js';
  *
  * new Mesh(viewer.scene, {
  *     geometry: new ReadableGeometry(viewer.scene, buildLineGeometry({
- *         startPoint: [0,-2,-1],
- *         endPoint: [2,2,1],
+ *         startPoint: [3,-2,-1],
+ *         endPoint: [5,2,1],
  *         pattern: [0.10],
  *     })),
  *     material: new PhongMaterial(viewer.scene, {
@@ -122,8 +170,8 @@ import {utils} from '../../utils.js';
  *
  * new Mesh(viewer.scene, {
  *     geometry: new ReadableGeometry(viewer.scene, buildLineGeometry({
- *         startPoint: [2,-2,-1],
- *         endPoint: [4,2,1],
+ *         startPoint: [5,-2,-1],
+ *         endPoint: [7,2,1],
  *         pattern: [0.03],
  *     })),
  *     material: new PhongMaterial(viewer.scene, {
@@ -138,6 +186,8 @@ import {utils} from '../../utils.js';
  * @param {Number[]} [cfg.startPoint]  3D start point (x0, y0, z0).
  * @param {Number[]} [cfg.endPoint]  3D end point (x1, y1, z1).
  * @param {Number[]} [cfg.pattern] Lengths of segments that describe a pattern.
+ * @param {Bool} [cfg.extendToEnd] If true: it will try to make sure the line doesn't end up with a gap, as it will
+ * extend the last segment.
  * @returns {Object} Configuration for a {@link Geometry} subtype.
  */
 function buildLineGeometry(cfg = {}) {
@@ -198,6 +248,12 @@ function buildLineGeometry(cfg = {}) {
             }
             segmentFilled += currentPatternLength;
             currentPatternLength = cfg.pattern[idOfCurrentPatternLength];
+        }
+
+        if (cfg.extendToEnd) {
+            points.push(x1, y1, z1);
+            indices.push(indices.length - 2);
+            indices.push(indices.length - 1);
         }
     }
 

--- a/src/viewer/scene/geometry/builders/buildLineGeometry.js
+++ b/src/viewer/scene/geometry/builders/buildLineGeometry.js
@@ -138,7 +138,6 @@ import {utils} from '../../utils.js';
  * @param {Number[]} [cfg.startPoint]  3D start point (x0, y0, z0).
  * @param {Number[]} [cfg.endPoint]  3D end point (x1, y1, z1).
  * @param {Number[]} [cfg.pattern] Lengths of segments that describe a pattern.
- * There should be at least 2 to start a pattern.
  * @returns {Object} Configuration for a {@link Geometry} subtype.
  */
 function buildLineGeometry(cfg = {}) {

--- a/types/viewer/scene/geometry/builders/buildLineGeometry.d.ts
+++ b/types/viewer/scene/geometry/builders/buildLineGeometry.d.ts
@@ -9,6 +9,8 @@ export declare type buildLineGeometryConfiguration = {
     endPoint?: number[];
     /* Lengths of segments that describe a pattern. */
     pattern?: number[];
+    /* If true: it will try to make sure the line doesn't end up with a gap, as it will extend the last segment. */
+    extendToEnd?: boolean;
 };
 
 /**


### PR DESCRIPTION
Here I just wanted to add an option to extend the last segment to end point (this option is turned on for blue lines below). It could be helpful if someone wants to see the real length / start and end point of the line, but can deal with the fact pattern at the end is slightly different. It is a usual practice in different programs, but handled in a various different ways.

![2024-06-11_23h44_16](https://github.com/xeokit/xeokit-sdk/assets/47977819/dba3d5cf-22d0-472e-bbde-17514c6d5f52)
