### PR TITLE
[FIX] Making optional control of precision of annotation occluding

### DIFF
--- a/examples/annotations/annotations_createWithMouse_orthoWithZMarkerOffset.html
+++ b/examples/annotations/annotations_createWithMouse_orthoWithZMarkerOffset.html
@@ -91,7 +91,7 @@
 <div class="slideout-sidebar">
     <img class="info-icon" src="../../assets/images/annotation_icon.png"/>
     <h1>AnnotationsPlugin</h1>
-    <h2>Click or tap the model to create annotations, control OcclusionTester.js precision</h2>
+    <h2>Click or tap the model to create annotations, control occlusion precision with markerZOffset</h2>
     <h3>Components Used</h3>
     <ul>
         <li>

--- a/examples/annotations/annotations_createWithMouse_orthoWithZMarkerOffset.html
+++ b/examples/annotations/annotations_createWithMouse_orthoWithZMarkerOffset.html
@@ -91,7 +91,7 @@
 <div class="slideout-sidebar">
     <img class="info-icon" src="../../assets/images/annotation_icon.png"/>
     <h1>AnnotationsPlugin</h1>
-    <h2>Click or tap the model to create annotations</h2>
+    <h2>Click or tap the model to create annotations, control OcclusionTester.js precision</h2>
     <h3>Components Used</h3>
     <ul>
         <li>
@@ -123,9 +123,7 @@
     // Import the modules we need for this example
     //------------------------------------------------------------------------------------------------------------------
 
-    import {XKTLoaderPlugin} from "../../dist/xeokit-sdk.min.es.js";
-    import {Viewer} from "../../src/viewer/Viewer.js";
-    import {AnnotationsPlugin} from "../../src/plugins/AnnotationsPlugin/AnnotationsPlugin.js";
+    import {Viewer, XKTLoaderPlugin, AnnotationsPlugin} from "../../dist/xeokit-sdk.min.es.js";
 
     //------------------------------------------------------------------------------------------------------------------
     // Create a Viewer and arrange the camera

--- a/examples/annotations/annotations_createWithMouse_orthoWithZMarkerOffset.html
+++ b/examples/annotations/annotations_createWithMouse_orthoWithZMarkerOffset.html
@@ -1,0 +1,225 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>xeokit Example</title>
+    <link href="../css/pageStyle.css" rel="stylesheet"/>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
+
+    <style>
+
+        .annotation-marker {
+            color: #ffffff;
+            line-height: 1.8;
+            text-align: center;
+            font-family: "monospace";
+            font-weight: bold;
+            position: absolute;
+            width: 25px;
+            height: 25px;
+            border-radius: 15px;
+            border: 2px solid #ffffff;
+            background: black;
+            visibility: hidden;
+            box-shadow: 5px 5px 15px 1px #000000;
+            z-index: 0;
+        }
+
+        .annotation-label {
+            position: absolute;
+            max-width: 250px;
+            min-height: 50px;
+            padding: 8px;
+            padding-left: 12px;
+            padding-right: 12px;
+            background: #ffffff;
+            color: #000000;
+            -webkit-border-radius: 3px;
+            -moz-border-radius: 3px;
+            border-radius: 8px;
+            border: #ffffff solid 2px;
+            box-shadow: 5px 5px 15px 1px #000000;
+            z-index: 90000;
+        }
+
+        .annotation-label:after {
+            content: '';
+            position: absolute;
+            border-style: solid;
+            border-width: 8px 12px 8px 0;
+            border-color: transparent white;
+            display: block;
+            width: 0;
+            z-index: 1;
+            margin-top: -11px;
+            left: -12px;
+            top: 20px;
+        }
+
+        .annotation-label:before {
+            content: '';
+            position: absolute;
+            border-style: solid;
+            border-width: 9px 13px 9px 0;
+            border-color: transparent #ffffff;
+            display: block;
+            width: 0;
+            z-index: 0;
+            margin-top: -12px;
+            left: -15px;
+            top: 20px;
+        }
+
+        .annotation-title {
+            font: normal 20px arial, serif;
+            margin-bottom: 8px;
+        }
+
+        .annotation-desc {
+            font: normal 14px arial, serif;
+        }
+
+    </style>
+</head>
+
+<body>
+<input type="checkbox" id="info-button"/>
+<label for="info-button" class="info-button"><i class="far fa-3x fa-question-circle"></i></label>
+<canvas id="myCanvas"></canvas>
+<div class="slideout-sidebar">
+    <img class="info-icon" src="../../assets/images/annotation_icon.png"/>
+    <h1>AnnotationsPlugin</h1>
+    <h2>Click or tap the model to create annotations</h2>
+    <h3>Components Used</h3>
+    <ul>
+        <li>
+            <a href="../../docs/class/src/viewer/Viewer.js~Viewer.html"
+               target="_other">Viewer</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js~XKTLoaderPlugin.html"
+               target="_other">XKTLoaderPlugin</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/AnnotationsPlugin/AnnotationsPlugin.js~AnnotationsPlugin.html"
+               target="_other">AnnotationsPlugin</a>
+        </li>
+    </ul>
+    <h3>Resources</h3>
+    <ul>
+        <li>
+            <a href="http://openifcmodel.cs.auckland.ac.nz/Model/Details/274"
+               target="_other">Model source</a>
+        </li>
+    </ul>
+</div>
+</body>
+
+<script type="module">
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Import the modules we need for this example
+    //------------------------------------------------------------------------------------------------------------------
+
+    import {XKTLoaderPlugin} from "../../dist/xeokit-sdk.min.es.js";
+    import {Viewer} from "../../src/viewer/Viewer.js";
+    import {AnnotationsPlugin} from "../../src/plugins/AnnotationsPlugin/AnnotationsPlugin.js";
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a Viewer and arrange the camera
+    //------------------------------------------------------------------------------------------------------------------
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas",
+        markerZOffset: -0.0001, // Changing marker Z offset to be more precise
+    });
+
+    viewer.camera.eye = [-3.93, 2.85, 27.01];
+    viewer.camera.look = [4.40, 3.72, 8.89];
+    viewer.camera.up = [-0.01, 0.99, 0.039];
+    viewer.camera.projection = "ortho";
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Load a model
+    //------------------------------------------------------------------------------------------------------------------
+
+    const xktLoader = new XKTLoaderPlugin(viewer);
+
+    const sceneModel = xktLoader.load({
+        id: "myModel",
+        src: "../../assets/models/xkt/v10/glTF-Embedded/Duplex_A_20110505.glTFEmbedded.xkt",
+        edges: true
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create an AnnotationsPlugin, with which we'll create annotations
+    //------------------------------------------------------------------------------------------------------------------
+
+    const annotations = new AnnotationsPlugin(viewer, {
+
+        markerHTML: "<div class='annotation-marker' style='background-color: {{markerBGColor}};'>{{glyph}}</div>",
+        labelHTML: "<div class='annotation-label' style='background-color: {{labelBGColor}};'><div class='annotation-title'>{{title}}</div><div class='annotation-desc'>{{description}}</div></div>",
+
+        values: {
+            markerBGColor: "red",
+            glyph: "X",
+            title: "Untitled",
+            description: "No description"
+        },
+
+        // Amount to offset each Annotation from its Entity surface (0.3 is the default value).
+        // This is useful when the Annotation is occludable, which is when it is hidden when occluded
+        // by other objects. When occludable, there is potential for the Annotation#worldPos to become
+        // visually embedded within the surface of its Entity when viewed from a distance. This happens
+        // as a result of limited GPU accuracy GPU accuracy, especially when the near and far view-space clipping planes,
+        // specified by Perspective#near and Perspective#far, or Ortho#near and Perspective#far, are far away from each other.
+        //
+        // Offsetting the Annotation may ensure that it does become visually embedded within its Entity. We may also
+        // prevent this by keeping the distance between the view-space clipping planes to a minimum. In general, a good
+        // default value for Perspective#far and Ortho#far is around ````2.000````.
+
+        surfaceOffset: 0.1
+    });
+
+    annotations.on("markerClicked", (annotation) => {
+        annotation.labelShown = !annotation.labelShown;
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Use the AnnotationsPlugin to create an annotation wherever we click on an object
+    //------------------------------------------------------------------------------------------------------------------
+
+    var i = 1;
+
+    viewer.scene.input.on("mouseclicked", (coords) => {
+
+        const pickResult = viewer.scene.pick({
+            canvasPos: coords,
+            pickSurface: true  // <<------ This causes picking to find the intersection point on the entity
+        });
+
+        if (pickResult) {
+
+            const annotation = annotations.createAnnotation({
+                id: "myAnnotation" + i,
+                pickResult: pickResult, // <<------- initializes worldPos and entity from PickResult
+                occludable: true,       // Optional, default is true
+                markerShown: true,      // Optional, default is true
+                labelShown: true,       // Optional, default is true
+                values: {               // HTML template values
+                    glyph: "A" + i,
+                    title: "My annotation " + i,
+                    description: "My description " + i
+                },
+            });
+
+            i++;
+        }
+    });
+
+    window.viewer = viewer;
+
+</script>
+</html>

--- a/examples/annotations/annotations_createWithMouse_orthoWithZMarkerOffsetZero.html
+++ b/examples/annotations/annotations_createWithMouse_orthoWithZMarkerOffsetZero.html
@@ -91,7 +91,7 @@
 <div class="slideout-sidebar">
     <img class="info-icon" src="../../assets/images/annotation_icon.png"/>
     <h1>AnnotationsPlugin</h1>
-    <h2>Click or tap the model to create annotations</h2>
+    <h2>Click or tap the model to create annotations, control OcclusionTester.js precision</h2>
     <h3>Components Used</h3>
     <ul>
         <li>
@@ -123,9 +123,7 @@
     // Import the modules we need for this example
     //------------------------------------------------------------------------------------------------------------------
 
-    import {XKTLoaderPlugin} from "../../dist/xeokit-sdk.min.es.js";
-    import {Viewer} from "../../src/viewer/Viewer.js";
-    import {AnnotationsPlugin} from "../../src/plugins/AnnotationsPlugin/AnnotationsPlugin.js";
+    import {Viewer, XKTLoaderPlugin, AnnotationsPlugin} from "../../dist/xeokit-sdk.min.es.js";
 
     //------------------------------------------------------------------------------------------------------------------
     // Create a Viewer and arrange the camera
@@ -225,8 +223,6 @@
         viewer.cameraFlight.jumpTo({
             aabb: sceneModel.aabb
         });
-        const t1 = performance.now();
-        document.getElementById("time").innerHTML = "Model loaded in " + Math.floor(t1 - t0) / 1000.0 + " seconds<br>Objects: " + sceneModel.numEntities;
     });
 
 </script>

--- a/examples/annotations/annotations_createWithMouse_orthoWithZMarkerOffsetZero.html
+++ b/examples/annotations/annotations_createWithMouse_orthoWithZMarkerOffsetZero.html
@@ -1,0 +1,233 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>xeokit Example</title>
+    <link href="../css/pageStyle.css" rel="stylesheet"/>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
+
+    <style>
+
+        .annotation-marker {
+            color: #ffffff;
+            line-height: 1.8;
+            text-align: center;
+            font-family: "monospace";
+            font-weight: bold;
+            position: absolute;
+            width: 25px;
+            height: 25px;
+            border-radius: 15px;
+            border: 2px solid #ffffff;
+            background: black;
+            visibility: hidden;
+            box-shadow: 5px 5px 15px 1px #000000;
+            z-index: 0;
+        }
+
+        .annotation-label {
+            position: absolute;
+            max-width: 250px;
+            min-height: 50px;
+            padding: 8px;
+            padding-left: 12px;
+            padding-right: 12px;
+            background: #ffffff;
+            color: #000000;
+            -webkit-border-radius: 3px;
+            -moz-border-radius: 3px;
+            border-radius: 8px;
+            border: #ffffff solid 2px;
+            box-shadow: 5px 5px 15px 1px #000000;
+            z-index: 90000;
+        }
+
+        .annotation-label:after {
+            content: '';
+            position: absolute;
+            border-style: solid;
+            border-width: 8px 12px 8px 0;
+            border-color: transparent white;
+            display: block;
+            width: 0;
+            z-index: 1;
+            margin-top: -11px;
+            left: -12px;
+            top: 20px;
+        }
+
+        .annotation-label:before {
+            content: '';
+            position: absolute;
+            border-style: solid;
+            border-width: 9px 13px 9px 0;
+            border-color: transparent #ffffff;
+            display: block;
+            width: 0;
+            z-index: 0;
+            margin-top: -12px;
+            left: -15px;
+            top: 20px;
+        }
+
+        .annotation-title {
+            font: normal 20px arial, serif;
+            margin-bottom: 8px;
+        }
+
+        .annotation-desc {
+            font: normal 14px arial, serif;
+        }
+
+    </style>
+</head>
+
+<body>
+<input type="checkbox" id="info-button"/>
+<label for="info-button" class="info-button"><i class="far fa-3x fa-question-circle"></i></label>
+<canvas id="myCanvas"></canvas>
+<div class="slideout-sidebar">
+    <img class="info-icon" src="../../assets/images/annotation_icon.png"/>
+    <h1>AnnotationsPlugin</h1>
+    <h2>Click or tap the model to create annotations</h2>
+    <h3>Components Used</h3>
+    <ul>
+        <li>
+            <a href="../../docs/class/src/viewer/Viewer.js~Viewer.html"
+               target="_other">Viewer</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js~XKTLoaderPlugin.html"
+               target="_other">XKTLoaderPlugin</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/AnnotationsPlugin/AnnotationsPlugin.js~AnnotationsPlugin.html"
+               target="_other">AnnotationsPlugin</a>
+        </li>
+    </ul>
+    <h3>Resources</h3>
+    <ul>
+        <li>
+            <a href="../../assets/models/gltf/Roadworks/license.txt"
+               target="_other">Model source</a>
+        </li>
+    </ul>
+</div>
+</body>
+
+<script type="module">
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Import the modules we need for this example
+    //------------------------------------------------------------------------------------------------------------------
+
+    import {XKTLoaderPlugin} from "../../dist/xeokit-sdk.min.es.js";
+    import {Viewer} from "../../src/viewer/Viewer.js";
+    import {AnnotationsPlugin} from "../../src/plugins/AnnotationsPlugin/AnnotationsPlugin.js";
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a Viewer and arrange the camera
+    //------------------------------------------------------------------------------------------------------------------
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas",
+        markerZOffset: 0.000, // Changing marker Z offset to be more precise
+    });
+
+    viewer.camera.eye = [-3.93, 2.85, 27.01];
+    viewer.camera.look = [4.40, 3.72, 8.89];
+    viewer.camera.up = [-0.01, 0.99, 0.039];
+    viewer.camera.projection = "ortho";
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Load a model
+    //------------------------------------------------------------------------------------------------------------------
+
+    const xktLoader = new XKTLoaderPlugin(viewer);
+
+    const sceneModel = xktLoader.load({
+        id: "myModel",
+        src: "../../assets/models/xkt/v10/glb/Roadworks.glb.xkt",
+        edges: true
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create an AnnotationsPlugin, with which we'll create annotations
+    //------------------------------------------------------------------------------------------------------------------
+
+    const annotations = new AnnotationsPlugin(viewer, {
+
+        markerHTML: "<div class='annotation-marker' style='background-color: {{markerBGColor}};'>{{glyph}}</div>",
+        labelHTML: "<div class='annotation-label' style='background-color: {{labelBGColor}};'><div class='annotation-title'>{{title}}</div><div class='annotation-desc'>{{description}}</div></div>",
+
+        values: {
+            markerBGColor: "red",
+            glyph: "X",
+            title: "Untitled",
+            description: "No description"
+        },
+
+        // Amount to offset each Annotation from its Entity surface (0.3 is the default value).
+        // This is useful when the Annotation is occludable, which is when it is hidden when occluded
+        // by other objects. When occludable, there is potential for the Annotation#worldPos to become
+        // visually embedded within the surface of its Entity when viewed from a distance. This happens
+        // as a result of limited GPU accuracy GPU accuracy, especially when the near and far view-space clipping planes,
+        // specified by Perspective#near and Perspective#far, or Ortho#near and Perspective#far, are far away from each other.
+        //
+        // Offsetting the Annotation may ensure that it does become visually embedded within its Entity. We may also
+        // prevent this by keeping the distance between the view-space clipping planes to a minimum. In general, a good
+        // default value for Perspective#far and Ortho#far is around ````2.000````.
+
+        surfaceOffset: 0.1
+    });
+
+    annotations.on("markerClicked", (annotation) => {
+        annotation.labelShown = !annotation.labelShown;
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Use the AnnotationsPlugin to create an annotation wherever we click on an object
+    //------------------------------------------------------------------------------------------------------------------
+
+    var i = 1;
+
+    viewer.scene.input.on("mouseclicked", (coords) => {
+
+        const pickResult = viewer.scene.pick({
+            canvasPos: coords,
+            pickSurface: true  // <<------ This causes picking to find the intersection point on the entity
+        });
+
+        if (pickResult) {
+
+            const annotation = annotations.createAnnotation({
+                id: "myAnnotation" + i,
+                pickResult: pickResult, // <<------- initializes worldPos and entity from PickResult
+                occludable: true,       // Optional, default is true
+                markerShown: true,      // Optional, default is true
+                labelShown: true,       // Optional, default is true
+                values: {               // HTML template values
+                    glyph: "A" + i,
+                    title: "My annotation " + i,
+                    description: "My description " + i
+                },
+            });
+
+            i++;
+        }
+    });
+
+    window.viewer = viewer;
+
+    sceneModel.on("loaded", function () {
+        viewer.cameraFlight.jumpTo({
+            aabb: sceneModel.aabb
+        });
+        const t1 = performance.now();
+        document.getElementById("time").innerHTML = "Model loaded in " + Math.floor(t1 - t0) / 1000.0 + " seconds<br>Objects: " + sceneModel.numEntities;
+    });
+
+</script>
+</html>

--- a/examples/annotations/annotations_createWithMouse_orthoWithZMarkerOffsetZero.html
+++ b/examples/annotations/annotations_createWithMouse_orthoWithZMarkerOffsetZero.html
@@ -91,7 +91,7 @@
 <div class="slideout-sidebar">
     <img class="info-icon" src="../../assets/images/annotation_icon.png"/>
     <h1>AnnotationsPlugin</h1>
-    <h2>Click or tap the model to create annotations, control OcclusionTester.js precision</h2>
+    <h2>Click or tap the model to create annotations, control occlusion precision with markerZOffset=0.0</h2>
     <h3>Components Used</h3>
     <ul>
         <li>

--- a/examples/annotations/index.html
+++ b/examples/annotations/index.html
@@ -264,6 +264,8 @@
             ["annotations_hoverShowLabels", "Hover annotation markers to show labels"],
             ["annotations_clickFlyToPosition", "Click annotation markers to go to vantage points"],
             ["annotations_createWithMouse", "Click on the model to create annotations"],
+            ["annotations_createWithMouse_orthoWithZMarkerOffset", "Click on the model to create annotations, control OcclusionTester.js precision"],
+            ["annotations_createWithMouse_orthoWithZMarkerOffsetZero", "Click on the model to create annotations, control OcclusionTester.js precision"],
             ["annotations_createAtCenterOfClickedObject", "Click objects to create annotations at their centers"],
             ["annotations_externalElements", "Annotations with externally-provided DOM elements"],
             ["annotations_occlusionDisabled", "Annotations with occlusion culling disabled"],

--- a/src/viewer/Viewer.js
+++ b/src/viewer/Viewer.js
@@ -57,6 +57,7 @@ class Viewer {
      * store geometry on the GPU for triangle meshes that don't have textures. This gives a much lower memory footprint for these types of model element. This mode may not perform well on low-end GPUs that are optimized
      * to use textures to hold geometry data. Works great on most medium/high-end GPUs found in desktop computers, including the nVIDIA and Intel HD chipsets. Set this false to use the default vertex buffer object (VBO)
      * mode for storing geometry, which is the standard technique used in most graphics engines, and will work adequately on most low-end GPUs.
+     * @param {Number} [cfg.markerZOffset=-0.001] The Z value of offset for Marker's OcclusionTester. The closest the value is to 0.000 the more precise OcclusionTester will be, but at the same time the less precise it will behave for Markers that are located exactly on the Surface.
      * @param {number} [cfg.numCachedSectionPlanes=0] Enhances the efficiency of SectionPlane creation by proactively allocating Viewer resources for a specified quantity
      * of SectionPlanes. Introducing this parameter streamlines the initial creation speed of SectionPlanes, particularly up to the designated quantity. This parameter internally
      * configures renderer logic for the specified number of SectionPlanes, eliminating the need for setting up logic with each SectionPlane creation and thereby enhancing
@@ -120,6 +121,7 @@ class Viewer {
             pbrEnabled: (!!cfg.pbrEnabled),
             colorTextureEnabled: (cfg.colorTextureEnabled !== false),
             dtxEnabled: (!!cfg.dtxEnabled),
+            markerZOffset: cfg.markerZOffset,
             numCachedSectionPlanes: cfg.numCachedSectionPlanes
         });
 

--- a/src/viewer/scene/scene/Scene.js
+++ b/src/viewer/scene/scene/Scene.js
@@ -864,6 +864,7 @@ class Scene extends Component {
         this._pbrEnabled = !!cfg.pbrEnabled;
         this._colorTextureEnabled = (cfg.colorTextureEnabled !== false);
         this._dtxEnabled = !!cfg.dtxEnabled;
+        this._markerZOffset = cfg.markerZOffset;
 
         // Register Scene on xeokit
         // Do this BEFORE we add components below
@@ -1425,6 +1426,22 @@ class Scene extends Component {
      */
     get colorTextureEnabled() {
         return this._colorTextureEnabled;
+    }
+
+    /**
+     * Gets the Z value of offset for Marker's OcclusionTester.
+     * The closest the value is to 0.000 the more precise OcclusionTester will be, but at the same time the less
+     * precise it will behave for Markers that are located exactly on the Surface.
+     *
+     * Default is ````-0.001````.
+     *
+     * @returns {Number} Z offset for Marker
+     */
+    get markerZOffset() {
+        if (this._markerZOffset == null) {
+            return -0.001;
+        }
+        return this._markerZOffset;
     }
 
     /**

--- a/src/viewer/scene/webgl/occlusion/OcclusionTester.js
+++ b/src/viewer/scene/webgl/occlusion/OcclusionTester.js
@@ -216,6 +216,10 @@ class OcclusionTester {
         src.push("   gl_PointSize = " + POINT_SIZE + ".0;");
         if (scene.logarithmicDepthBufferEnabled) {
            src.push("vFragDepth = 1.0 + clipPos.w;");
+        } else {
+            if (scene.markerZOffset < 0.000) {
+                src.push("clipPos.z += " + scene.markerZOffset + ";");
+            }
         }
         src.push("   gl_Position = clipPos;");
         src.push("}");

--- a/types/viewer/Viewer.d.ts
+++ b/types/viewer/Viewer.d.ts
@@ -63,6 +63,8 @@ export declare type ViewerConfiguration = {
   localeService?: LocaleService;
   /** Whether to enable data texture-based (DTX) scene representation within the Viewer. */
   dtxEnabled?: boolean;
+  /** The Z value of offset for Marker's OcclusionTester. The closest the value is to 0.000 the more precise OcclusionTester will be, but at the same time the less precise it will behave for Markers that are located exactly on the Surface. */
+  markerZOffset?: number;
   /** Enhances the efficiency of SectionPlane creation by proactively allocating Viewer resources for a specified quantity of SectionPlanes.*/
   numCachedSectionPlanes?: number;
 };

--- a/types/viewer/scene/scene/Scene.d.ts
+++ b/types/viewer/scene/scene/Scene.d.ts
@@ -219,6 +219,17 @@ export declare class Scene extends Component {
   get pbrEnabled(): boolean
 
   /**
+   * Gets the Z value of offset for Marker's OcclusionTester.
+   * The closest the value is to 0.000 the more precise OcclusionTester will be, but at the same time the less
+   * precise it will behave for Markers that are located exactly on the Surface.
+   *
+   * Default is ````-0.001````.
+   *
+   * @returns {Number} Z offset for Marker
+   */
+  get markerZOffset(): number
+
+  /**
    * Gets the IDs of the {@link Entity}s in {@link Scene.models}.
    *
    * @type {String[]}


### PR DESCRIPTION
This PR includes:
- revert of offset in a shader to make existing behaviour unchanged
- adding parameter for the user to control the offset, so he can decide if he want to make it more precise or not
- 2 new examples with usage of this additional parameter, for which changing of the offset parameter makes occluding better
- update of d.ts file

Looking forward for review.