### PR TITLE
[FEATURE] Cache busting for loader plugin data sources

### DIFF
--- a/src/plugins/CityJSONLoaderPlugin/CityJSONDefaultDataSource.js
+++ b/src/plugins/CityJSONLoaderPlugin/CityJSONDefaultDataSource.js
@@ -5,7 +5,20 @@ import {utils} from "../../viewer/index.js";
  */
 class CityJSONDefaultDataSource {
 
-    constructor() {
+    constructor(cfg = {}) {
+        this.cacheBuster = (cfg.cacheBuster !== false);
+    }
+
+    _cacheBusterURL(url) {
+        if (!this.cacheBuster) {
+            return url;
+        }
+        const timestamp = new Date().getTime();
+        if (url.indexOf('?') > -1) {
+            return url + '&_=' + timestamp;
+        } else {
+            return url + '?_=' + timestamp;
+        }
     }
 
     /**
@@ -16,7 +29,7 @@ class CityJSONDefaultDataSource {
      * @param {Function} error Callback fired on error.
      */
     getCityJSON(src, ok, error) {
-        utils.loadJSON(src,
+        utils.loadJSON(this._cacheBusterURL(src),
             (json) => {
                 ok(json);
             },

--- a/src/plugins/DotBIMLoaderPlugin/DotBIMDefaultDataSource.js
+++ b/src/plugins/DotBIMLoaderPlugin/DotBIMDefaultDataSource.js
@@ -7,7 +7,20 @@ import {utils} from "../../viewer/scene/utils.js";
  */
 export class DotBIMDefaultDataSource {
 
-    constructor() {
+    constructor(cfg = {}) {
+        this.cacheBuster = (cfg.cacheBuster !== false);
+    }
+
+    _cacheBusterURL(url) {
+        if (!this.cacheBuster) {
+            return url;
+        }
+        const timestamp = new Date().getTime();
+        if (url.indexOf('?') > -1) {
+            return url + '&_=' + timestamp;
+        } else {
+            return url + '?_=' + timestamp;
+        }
     }
 
     /**
@@ -18,7 +31,7 @@ export class DotBIMDefaultDataSource {
      * @param {Function} error Fired on error while loading the .BIM JSON asset.
      */
     getDotBIM(dotBIMSrc, ok, error) {
-        utils.loadJSON(dotBIMSrc,
+        utils.loadJSON(this._cacheBusterURL(dotBIMSrc),
             (json) => {
                 ok(json);
             },

--- a/src/plugins/GLTFLoaderPlugin/GLTFDefaultDataSource.js
+++ b/src/plugins/GLTFLoaderPlugin/GLTFDefaultDataSource.js
@@ -8,7 +8,20 @@ import {core} from "../../viewer/scene/core.js";
  */
 class GLTFDefaultDataSource {
 
-    constructor() {
+    constructor(cfg = {}) {
+        this.cacheBuster = (cfg.cacheBuster !== false);
+    }
+
+    _cacheBusterURL(url) {
+        if (!this.cacheBuster) {
+            return url;
+        }
+        const timestamp = new Date().getTime();
+        if (url.indexOf('?') > -1) {
+            return url + '&_=' + timestamp;
+        } else {
+            return url + '?_=' + timestamp;
+        }
     }
 
     /**
@@ -19,7 +32,7 @@ class GLTFDefaultDataSource {
      * @param {Function} error Fired on error while loading the metamodel JSON asset.
      */
     getMetaModel(metaModelSrc, ok, error) {
-        utils.loadJSON(metaModelSrc,
+        utils.loadJSON(this._cacheBusterURL(metaModelSrc),
             (json) => {
                 ok(json);
             },
@@ -36,7 +49,7 @@ class GLTFDefaultDataSource {
      * @param {Function} error Fired on error while loading the glTF JSON asset.
      */
     getGLTF(glTFSrc, ok, error) {
-        utils.loadArraybuffer(glTFSrc,
+        utils.loadArraybuffer(this._cacheBusterURL(glTFSrc),
             (gltf) => {
                 ok(gltf);
             },
@@ -53,7 +66,7 @@ class GLTFDefaultDataSource {
      * @param {Function} error Fired on error while loading the .glb asset.
      */
     getGLB(glbSrc, ok, error) {
-        utils.loadArraybuffer(glbSrc,
+        utils.loadArraybuffer(this._cacheBusterURL(glbSrc),
             (arraybuffer) => {
                 ok(arraybuffer);
             },
@@ -74,7 +87,7 @@ class GLTFDefaultDataSource {
      * @param {Function} error Fired on error while loading the glTF binary asset.
      */
     getArrayBuffer(glTFSrc, binarySrc, ok, error) {
-        loadArraybuffer(glTFSrc, binarySrc,
+        loadArraybuffer(this._cacheBusterURL(glTFSrc), binarySrc,
             (arrayBuffer) => {
                 ok(arrayBuffer);
             },

--- a/src/plugins/LASLoaderPlugin/LASDefaultDataSource.js
+++ b/src/plugins/LASLoaderPlugin/LASDefaultDataSource.js
@@ -3,7 +3,20 @@
  */
 class LASDefaultDataSource {
 
-    constructor() {
+    constructor(cfg = {}) {
+        this.cacheBuster = (cfg.cacheBuster !== false);
+    }
+
+    _cacheBusterURL(url) {
+        if (!this.cacheBuster) {
+            return url;
+        }
+        const timestamp = new Date().getTime();
+        if (url.indexOf('?') > -1) {
+            return url + '&_=' + timestamp;
+        } else {
+            return url + '?_=' + timestamp;
+        }
     }
 
     /**
@@ -14,6 +27,7 @@ class LASDefaultDataSource {
      * @param {Function} error Callback fired on error.
      */
     getLAS(src, ok, error) {
+        src = this._cacheBusterURL(src);
         var defaultCallback = () => {
         };
         ok = ok || defaultCallback;

--- a/src/plugins/STLLoaderPlugin/STLDefaultDataSource.js
+++ b/src/plugins/STLLoaderPlugin/STLDefaultDataSource.js
@@ -5,6 +5,22 @@
  */
 class STLDefaultDataSource {
 
+    constructor(cfg = {}) {
+        this.cacheBuster = (cfg.cacheBuster !== false);
+    }
+
+    _cacheBusterURL(url) {
+        if (!this.cacheBuster) {
+            return url;
+        }
+        const timestamp = new Date().getTime();
+        if (url.indexOf('?') > -1) {
+            return url + '&_=' + timestamp;
+        } else {
+            return url + '?_=' + timestamp;
+        }
+    }
+
     /**
      * Gets STL data.
      *
@@ -13,6 +29,7 @@ class STLDefaultDataSource {
      * @param {Function} error Fired on error while loading the STL file.
      */
     getSTL(src, ok, error) {
+        src = this._cacheBusterURL(src);
         const request = new XMLHttpRequest();
         request.overrideMimeType("application/json");
         request.open('GET', src, true);

--- a/src/plugins/WebIFCLoaderPlugin/WebIFCDefaultDataSource.js
+++ b/src/plugins/WebIFCLoaderPlugin/WebIFCDefaultDataSource.js
@@ -3,7 +3,20 @@
  */
 class WebIFCDefaultDataSource {
 
-    constructor() {
+    constructor(cfg = {}) {
+        this.cacheBuster = (cfg.cacheBuster !== false);
+    }
+
+    _cacheBusterURL(url) {
+        if (!this.cacheBuster) {
+            return url;
+        }
+        const timestamp = new Date().getTime();
+        if (url.indexOf('?') > -1) {
+            return url + '&_=' + timestamp;
+        } else {
+            return url + '?_=' + timestamp;
+        }
     }
 
     /**
@@ -14,6 +27,8 @@ class WebIFCDefaultDataSource {
      * @param {Function} error Callback fired on error.
      */
     getIFC(src, ok, error) {
+        src = this._cacheBusterURL(src);
+
         var defaultCallback = () => {
         };
         ok = ok || defaultCallback;

--- a/src/plugins/XKTLoaderPlugin/XKTDefaultDataSource.js
+++ b/src/plugins/XKTLoaderPlugin/XKTDefaultDataSource.js
@@ -1,11 +1,25 @@
 import {utils} from "../../viewer/scene/utils.js";
+import {math} from "../../viewer";
 
 /**
  * Default data access strategy for {@link XKTLoaderPlugin}.
  */
 class XKTDefaultDataSource {
 
-    constructor() {
+    constructor(cfg = {}) {
+        this.cacheBuster = (cfg.cacheBuster !== false);
+    }
+
+    _cacheBusterURL(url) {
+        if (!this.cacheBuster) {
+            return url;
+        }
+        const timestamp = new Date().getTime();
+        if (url.indexOf('?') > -1) {
+            return url + '&_=' + timestamp;
+        } else {
+            return url + '?_=' + timestamp;
+        }
     }
 
     /**
@@ -16,7 +30,7 @@ class XKTDefaultDataSource {
      * @param {Function} error Fired on error while loading the manifest JSON asset.
      */
     getManifest(manifestSrc, ok, error) {
-        utils.loadJSON(manifestSrc,
+        utils.loadJSON(this._cacheBusterURL(manifestSrc),
             (json) => {
                 ok(json);
             },
@@ -33,7 +47,7 @@ class XKTDefaultDataSource {
      * @param {Function} error Fired on error while loading the metamodel JSON asset.
      */
     getMetaModel(metaModelSrc, ok, error) {
-        utils.loadJSON(metaModelSrc,
+        utils.loadJSON(this._cacheBusterURL(metaModelSrc),
             (json) => {
                 ok(json);
             },
@@ -75,7 +89,7 @@ class XKTDefaultDataSource {
             }
         } else {
             const request = new XMLHttpRequest();
-            request.open('GET', src, true);
+            request.open('GET', this._cacheBusterURL(src), true);
             request.responseType = 'arraybuffer';
             request.onreadystatechange = function () {
                 if (request.readyState === 4) {


### PR DESCRIPTION
This PR adds cache busting to the default implementations of the data source strategies that are used by the various loader plugins. 

Cache busting works by appending time stamps to the HTTP GET URLs that are used within the strategies. 

This is enabled by default, but may be disabled by users if they feel masochistic and don't mind the browser caching old model versions. 

## Disabling

The example below shows how to disable cache busting for `XKTLoaderPlugin` default data source, `XKTDefaultDataSource`:

````javascript
const xktLoader = new XKTLoaderPlugin(viewer);

xktLoader.dataSource.cacheBuster = false; // Default is true

const sceneModel =  xktLoader.load({
     manifestSrc: "../../assets/models/xkt/v10/split/Karhumaki-Bridge/manifest.json",
     id: "myModel"
});
````

