### PR TITLE
[FEATURE] Added SceneModel.renderOrder and Mesh.renderOrder

### DIFF
--- a/src/viewer/scene/mesh/Mesh.js
+++ b/src/viewer/scene/mesh/Mesh.js
@@ -216,10 +216,15 @@ class Mesh extends Component {
      * @param {EmphasisMaterial} [cfg.highlightMaterial] {@link EmphasisMaterial} to define the xrayed appearance for this Mesh. Inherits {@link Scene#highlightMaterial} by default.
      * @param {EmphasisMaterial} [cfg.selectedMaterial] {@link EmphasisMaterial} to define the selected appearance for this Mesh. Inherits {@link Scene#selectedMaterial} by default.
      * @param {EmphasisMaterial} [cfg.edgeMaterial] {@link EdgeMaterial} to define the appearance of enhanced edges for this Mesh. Inherits {@link Scene#edgeMaterial} by default.
+     * @param {Number} [cfg.renderOrder=0] Specifies the rendering order for this mESH. This is used to control the order in which
+     * mESHES are drawn when they have transparent objects, to give control over the order in which those objects are blended within the transparent
+     * render pass.
      */
     constructor(owner, cfg = {}) {
 
         super(owner, cfg);
+
+        this.renderOrder = cfg.renderOrder || 0;
 
         /**
          * ID of the corresponding object within the originating system, if any.

--- a/src/viewer/scene/model/SceneModel.js
+++ b/src/viewer/scene/model/SceneModel.js
@@ -1123,10 +1123,15 @@ export class SceneModel extends Component {
      * represent the returned model. Set false to always use vertex buffer objects (VBOs). Note that DTX is only applicable
      * to non-textured triangle meshes, and that VBOs are always used for meshes that have textures, line segments, or point
      * primitives. Only works while {@link DTX#enabled} is also ````true````.
+     * @param {Number} [cfg.renderOrder=0] Specifies the rendering order for this SceneModel. This is used to control the order in which
+     * SceneModels are drawn when they have transparent objects, to give control over the order in which those objects are blended within the transparent
+     * render pass.
      */
     constructor(owner, cfg = {}) {
 
         super(owner, cfg);
+
+        this.renderOrder = cfg.renderOrder || 0;
 
         this._dtxEnabled = this.scene.dtxEnabled && (cfg.dtxEnabled !== false);
 
@@ -3194,6 +3199,7 @@ export class SceneModel extends Component {
     _getVBOBatchingLayer(cfg) {
         const model = this;
         const origin = cfg.origin;
+        const renderLayer = cfg.renderLayer || 0;
         const positionsDecodeHash = cfg.positionsDecodeMatrix || cfg.positionsDecodeBoundary ?
             this._createHashStringFromMatrix(cfg.positionsDecodeMatrix || cfg.positionsDecodeBoundary)
             : "-";
@@ -3680,7 +3686,7 @@ export class SceneModel extends Component {
     // -------------- RENDERING ---------------------------------------------------------------------------------------
 
     /** @private */
-    drawColorOpaque(frameCtx) {
+    drawColorOpaque(frameCtx, layerList) {
         const renderFlags = this.renderFlags;
         for (let i = 0, len = renderFlags.visibleLayers.length; i < len; i++) {
             const layerIndex = renderFlags.visibleLayers[i];


### PR DESCRIPTION
This PR adds a new `renderOrder` property to `SceneModel` and `Mesh`, settable via the constructors. 

`XKTLoaderPlugin.load()` also gets the ability to pass a value into `SceneModel` as it loads a model.

The purpose of this new property is to force the order in which the `SceneModels` or `Meshes` are rendered with respect to each other while rendering their transparent objects, to give some control over the alpha blending order between their objects.
  
 
````javascript
const xktLoader = new XKTLoaderPlugin(viewer);

const sceneModel2 = xktLoader.load({
    id: "myModel",
    renderOrder: 0, // Default 
   //....
 });

const sceneModel2 = xktLoader.load({
    id: "myModel2",
    renderOrder: 1,
    //...  
});
````