### PR TITLE
[FIX] Incorrect cached scene center

### DIFF
--- a/src/viewer/scene/scene/Scene.js
+++ b/src/viewer/scene/scene/Scene.js
@@ -2099,10 +2099,10 @@ class Scene extends Component {
      */
     get center() {
         if (this._aabbDirty || !this._center) {
-            if (!this._center || !this._center) {
+            const aabb = this.aabb;
+            if (!this._center) {
                 this._center = math.vec3();
             }
-            const aabb = this.aabb;
             this._center[0] = (aabb[0] + aabb[3]) / 2;
             this._center[1] = (aabb[1] + aabb[4]) / 2;
             this._center[2] = (aabb[2] + aabb[5]) / 2;
@@ -2177,6 +2177,7 @@ class Scene extends Component {
             this._aabb[4] = ymax;
             this._aabb[5] = zmax;
             this._aabbDirty = false;
+            this._center = null;
         }
         return this._aabb;
     }


### PR DESCRIPTION
**Steps to reproduce :**
- load a model
- request the scene center
- unload the model
- load another model (with a different aabb to see the issue)
- request the scene aabb

**What happens:**
- requesting the scene center [computes the scene aabb](https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/scene/scene/Scene.js#L2105) and [set the scene center (`_center`)](https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/scene/scene/Scene.js#L2103)
- when the models change ([unload](https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/scene/model/SceneModel.js#L3963) / [load](https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/scene/model/SceneModel.js#L3536)), the `scene._aabbDirty` is set to `true`.
- requesting the `scene.aabb` (in my use case due to a fitview) compute the aabb and set the `scene._aabbDirty` to `false`.
- At this moment, the `scene._aabbDirty` is false and the `scene._center` truthy, which means that [the center is not recalculated if requested](https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/scene/scene/Scene.js#L2101C18-L2101C28) and still represent the previous scene.aabb center :/

**Solution: (this PR)**
- When the `scene.aabb` is computed, the `scene_center` must be set to a falsy value (like `null`) 
- WARNING: In the scene center getter, the `this.aabb` must be done BEFORE the `if (!this._center)`, because the scene aabb getter may set the _center to null if recomputed.