### PR TITLE
show correct distance for z axis when useRotationAdjustment is false

### DIFF
--- a/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
+++ b/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
@@ -539,7 +539,7 @@ class DistanceMeasurement extends Component {
                 }
 
                 if (!this._zAxisLabelCulled) {
-                    if(this._measurementOrientation === 'Vertical') {
+                    if(this._measurementOrientation === 'Vertical' && this.useRotationAdjustment) {
                         this._zAxisLabel.setPrefix("");
                         this._zAxisLabel.setText(tilde + Math.abs(math.lenVec3(math.subVec3(this._targetWorld, [this._originWorld[0], this._targetWorld[1], this._originWorld[2]], distVec3)) * scale).toFixed(2) + unitAbbrev);
                     }


### PR DESCRIPTION
Update measurement to show correct distance and label for z axis when `useRotationAdjustment` is false

Before:

![Screenshot 2024-06-26 at 11 24 16 AM](https://github.com/xeokit/xeokit-sdk/assets/12035748/7c980095-7480-4c9c-8438-4201dff16ecf)

Note that the total distance comes to `sqrt(5.19^2 + 5.43^2 + 6.60^2) = 9.99905` and not 8.55 as expected.
Also note that the prefix is missing for the Z axis.

After:
![Screenshot 2024-06-26 at 11 27 57 AM](https://github.com/xeokit/xeokit-sdk/assets/12035748/9c0d3ec5-c989-4fba-b878-f2c8cf2026a6)

Total distance is `sqrt(5.19^2 + 5.43^2 + 4.10^2) = 8.55` and prefix is `Z` as expected.
