### PR TITLE
Fix(measurements) Removed deletion of in progress measurement when us…

### DIFF
--- a/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsMouseControl.js
+++ b/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsMouseControl.js
@@ -353,27 +353,27 @@ export class DistanceMeasurementsMouseControl extends DistanceMeasurementsContro
         if (!this._active) {
             return;
         }
-
+        
         this.fire("activated", false);
 
         if (this.pointerLens) {
             this.pointerLens.visible = false;
         }
-        if (this._markerDiv) {
-            this._destroyMarkerDiv()
-        }
-        this.reset();
+        // if (this._markerDiv) {
+        //     this._destroyMarkerDiv()
+        // }
+        // this.reset();
         const canvas = this.scene.canvas.canvas;
         canvas.removeEventListener("mousedown", this._onMouseDown);
         canvas.removeEventListener("mouseup", this._onMouseUp);
         const cameraControl = this.distanceMeasurementsPlugin.viewer.cameraControl;
         cameraControl.off(this._onCameraControlHoverSnapOrSurface);
         cameraControl.off(this._onCameraControlHoverSnapOrSurfaceOff);
-        if (this._currentDistanceMeasurement) {
-            this.distanceMeasurementsPlugin.fire("measurementCancel", this._currentDistanceMeasurement);
-            this._currentDistanceMeasurement.destroy();
-            this._currentDistanceMeasurement = null;
-        }
+        // if (this._currentDistanceMeasurement) {
+        //     this.distanceMeasurementsPlugin.fire("measurementCancel", this._currentDistanceMeasurement);
+        //     this._currentDistanceMeasurement.destroy();
+        //     this._currentDistanceMeasurement = null;
+        // }
         this._active = false;
     }
 


### PR DESCRIPTION
How it worked previously:

When user starts a measurement and then change it's snapping mode before completing the measurement, the in-progress measurement is deleted and the new snapping mode takes place from the next measurement.

https://github.com/xeokit/xeokit-sdk/assets/154510203/96cf9c76-d174-46a3-85ac-daf118157dea

How it works now:

When user changes the snapping mode in middle of a measurement, the current measurement is kept and new snapping configuration is applied to that measurement.

https://github.com/xeokit/xeokit-sdk/assets/154510203/862f6fe8-5b0b-46f0-a899-79001c29ada2

