### PR TITLE
[FIX] marker occlusion

### DIFF
--- a/src/viewer/scene/webgl/occlusion/OcclusionLayer.js
+++ b/src/viewer/scene/webgl/occlusion/OcclusionLayer.js
@@ -99,7 +99,7 @@ class OcclusionLayer {
         for (let i = 0; i < this.numMarkers; i++) {
             if (this.markerList[i]) {
                 const marker = this.markerList[i];
-                const worldPos = marker.worldPos;
+                const worldPos = marker.rtcPos;
                 this.positions[j++] = worldPos[0];
                 this.positions[j++] = worldPos[1];
                 this.positions[j++] = worldPos[2];

--- a/src/viewer/scene/webgl/occlusion/OcclusionTester.js
+++ b/src/viewer/scene/webgl/occlusion/OcclusionTester.js
@@ -333,10 +333,7 @@ class OcclusionTester {
                 continue;
             }
 
-            // The `origin` has been changed from `occlusionLayer.origin` to `[ 0, 0, 0 ]`
-            // because OcclusionLayer markers' transformation is being applied through the
-            // OcclusionLayer::positions array. See XEOK-33
-            const origin = [ 0, 0, 0 ];
+            const origin = occlusionLayer.origin;
 
             gl.uniformMatrix4fv(this._uViewMatrix, false, createRTCViewMat(camera.viewMatrix, origin));
 


### PR DESCRIPTION
There is two parts here:

- If I am correct, `marker.worldPos` = `marker.origin` + marker.rtcPos`. Because the occlusion layers uses the `marker.origin` in the shader, the `marker.rtcPos` should be used to build positions instead of `marker.worldPos`. 

- The commit [XEOK-33](https://github.com/xeokit/xeokit-sdk/commit/1c06e71bf3ae6468cac846cf5fda9816fa7f16e8) seems to introduce a bug in the occlusion tester because "OcclusionLayer markers' transformation is being applied through the OcclusionLayer::positions array" is not correct... ??