### PR TITLE
[FEATURE] Progressive SceneModel loading

### DIFF
--- a/assets/models/xkt/v2/WestRiverSideHospital/model.xkt.manifest.json
+++ b/assets/models/xkt/v2/WestRiverSideHospital/model.xkt.manifest.json
@@ -5,13 +5,13 @@
   "conversionDate": "10-08-2023- 02-05-01",
   "outputDir": null,
   "xktFiles": [
-    "architectural.xkt",
+    "sprinklers.xkt",
     "electrical.xkt",
     "fireAlarms.xkt",
     "mechanical.xkt",
     "plumbing.xkt",
-    "sprinklers.xkt",
-    "structure.xkt"
+    "structure.xkt",
+    "architectural.xkt"
   ],
   "metaModelFiles": [
     "architectural.json",

--- a/src/viewer/scene/model/dtx/lines/DTXLinesLayer.js
+++ b/src/viewer/scene/model/dtx/lines/DTXLinesLayer.js
@@ -31,7 +31,7 @@ export class DTXLinesLayer {
 
     constructor(model, cfg) {
 
-        console.info("Creating DTXLinesLayer");
+      //  console.info("Creating DTXLinesLayer");
 
         dataTextureRamStats.numberOfLayers++;
 

--- a/src/viewer/scene/model/dtx/triangles/DTXTrianglesLayer.js
+++ b/src/viewer/scene/model/dtx/triangles/DTXTrianglesLayer.js
@@ -54,7 +54,7 @@ export class DTXTrianglesLayer {
 
     constructor(model, cfg) {
 
-        console.info("Creating DTXTrianglesLayer");
+        //console.info("Creating DTXTrianglesLayer");
 
         dataTextureRamStats.numberOfLayers++;
 

--- a/src/viewer/scene/model/vbo/batching/lines/VBOBatchingLinesLayer.js
+++ b/src/viewer/scene/model/vbo/batching/lines/VBOBatchingLinesLayer.js
@@ -24,7 +24,7 @@ export class VBOBatchingLinesLayer {
      */
     constructor(cfg) {
 
-        console.info("Creating VBOBatchingLinesLayer");
+       // console.info("Creating VBOBatchingLinesLayer");
 
         /**
          * Index of this LinesBatchingLayer in {@link VBOSceneModel#_layerList}.

--- a/src/viewer/scene/model/vbo/batching/points/VBOBatchingPointsLayer.js
+++ b/src/viewer/scene/model/vbo/batching/points/VBOBatchingPointsLayer.js
@@ -24,7 +24,7 @@ export class VBOBatchingPointsLayer {
      */
     constructor(cfg) {
 
-        console.info("Creating VBOBatchingPointsLayer");
+     //   console.info("Creating VBOBatchingPointsLayer");
 
         /**
          * Owner model

--- a/src/viewer/scene/model/vbo/batching/triangles/VBOBatchingTrianglesLayer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/VBOBatchingTrianglesLayer.js
@@ -41,7 +41,7 @@ export class VBOBatchingTrianglesLayer {
      */
     constructor(cfg) {
 
-        console.info("Creating VBOBatchingTrianglesLayer");
+     //   console.info("Creating VBOBatchingTrianglesLayer");
 
         /**
          * Owner model

--- a/src/viewer/scene/model/vbo/instancing/lines/VBOInstancingLinesLayer.js
+++ b/src/viewer/scene/model/vbo/instancing/lines/VBOInstancingLinesLayer.js
@@ -28,7 +28,7 @@ class VBOInstancingLinesLayer {
      */
     constructor(cfg) {
 
-        console.info("VBOInstancingLinesLayer");
+     //   console.info("VBOInstancingLinesLayer");
 
         /**
          * Owner model

--- a/src/viewer/scene/model/vbo/instancing/points/VBOInstancingPointsLayer.js
+++ b/src/viewer/scene/model/vbo/instancing/points/VBOInstancingPointsLayer.js
@@ -27,7 +27,7 @@ export class VBOInstancingPointsLayer {
      */
     constructor(cfg) {
 
-        console.info("VBOInstancingPointsLayer");
+      //  console.info("VBOInstancingPointsLayer");
 
         /**
          * Owner model

--- a/src/viewer/scene/model/vbo/instancing/triangles/VBOInstancingTrianglesLayer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/VBOInstancingTrianglesLayer.js
@@ -36,7 +36,7 @@ export class VBOInstancingTrianglesLayer {
      */
     constructor(cfg) {
 
-         console.info("Creating VBOInstancingTrianglesLayer");
+      //   console.info("Creating VBOInstancingTrianglesLayer");
 
         /**
          * Owner model


### PR DESCRIPTION
When XKTLoaderPlugin is loading a model from multiple parts via a manifest, this PR causes the plugin to pre-render the SceneModel after each part has been loaded. This gives the user something to look at while a multi-part model is loading.

In addition, the user has the ability to call `SceneModel.destroy()` at any time to abort loading. The intermittent render-forcing gives that method an opportunity to work after each part has been loaded, rather than blocking the main thread for the entire duration of loading.