### PR TITLE
[FIX] snap picking

### DIFF
--- a/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesSnapInitRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesSnapInitRenderer.js
@@ -304,6 +304,14 @@ export class DTXTrianglesSnapInitRenderer {
         src.push("uvec4 flags = texelFetch (uObjectPerObjectColorsAndFlags, ivec2(objectIndexCoords.x*8+2, objectIndexCoords.y), 0);");
         src.push("uvec4 flags2 = texelFetch (uObjectPerObjectColorsAndFlags, ivec2(objectIndexCoords.x*8+3, objectIndexCoords.y), 0);");
 
+        // flags.w = NOT_RENDERED | PICK
+        // renderPass = PICK
+
+        src.push(`if (int(flags.w) != renderPass) {`);
+        src.push("   gl_Position = vec4(3.0, 3.0, 3.0, 1.0);"); // Cull vertex
+        src.push("   return;"); // Cull vertex
+        src.push("}");
+
         src.push("{");
 
         // get color

--- a/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesSnapRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesSnapRenderer.js
@@ -311,6 +311,14 @@ export class DTXTrianglesSnapRenderer {
         src.push("uvec4 flags = texelFetch (uObjectPerObjectColorsAndFlags, ivec2(objectIndexCoords.x*8+2, objectIndexCoords.y), 0);");
         src.push("uvec4 flags2 = texelFetch (uObjectPerObjectColorsAndFlags, ivec2(objectIndexCoords.x*8+3, objectIndexCoords.y), 0);");
 
+        // flags.w = NOT_RENDERED | PICK
+        // renderPass = PICK
+
+        src.push(`if (int(flags.w) != renderPass) {`);
+        src.push("   gl_Position = vec4(3.0, 3.0, 3.0, 1.0);"); // Cull vertex
+        src.push("   return;"); // Cull vertex
+        src.push("}");
+
         src.push("{");
 
         // get vertex base

--- a/src/viewer/scene/model/vbo/batching/lines/renderers/VBOBatchingLinesSnapRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/lines/renderers/VBOBatchingLinesSnapRenderer.js
@@ -215,7 +215,7 @@ export class VBOBatchingLinesSnapRenderer extends VBORenderer{
 
         src.push(`int pickFlag = int(flags) >> 12 & 0xF;`);
         src.push(`if (pickFlag != renderPass) {`);
-        src.push("      gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
+        src.push("      gl_Position = vec4(2.0, 0.0, 0.0, 0.0);"); // Cull vertex
         src.push("  } else {");
         src.push("      vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
         if (scene.entityOffsetsEnabled) {

--- a/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesSnapRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesSnapRenderer.js
@@ -214,7 +214,7 @@ export class TrianglesSnapRenderer extends VBORenderer{
 
         src.push(`int pickFlag = int(flags) >> 12 & 0xF;`);
         src.push(`if (pickFlag != renderPass) {`);
-        src.push("      gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
+        src.push("      gl_Position = vec4(2.0, 0.0, 0.0, 0.0);"); // Cull vertex
         src.push("  } else {");
         src.push("      vec4 worldPosition = worldMatrix * (positionsDecodeMatrix * vec4(position, 1.0)); ");
         if (scene.entityOffsetsEnabled) {

--- a/src/viewer/scene/model/vbo/instancing/lines/renderers/VBOInstancingLinesSnapRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/lines/renderers/VBOInstancingLinesSnapRenderer.js
@@ -221,7 +221,7 @@ export class VBOInstancingLinesSnapRenderer extends VBORenderer {
         // renderPass = PICK
         src.push(`int pickFlag = int(flags) >> 12 & 0xF;`);
         src.push(`if (pickFlag != renderPass) {`);
-        src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
+        src.push("   gl_Position = vec4(2.0, 0.0, 0.0, 0.0);"); // Cull vertex
         src.push("} else {");
         src.push("  vec4 worldPosition = positionsDecodeMatrix * vec4(position, 1.0); ");
         src.push("  worldPosition = worldMatrix * vec4(dot(worldPosition, modelMatrixCol0), dot(worldPosition, modelMatrixCol1), dot(worldPosition, modelMatrixCol2), 1.0);");

--- a/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesSnapRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesSnapRenderer.js
@@ -230,7 +230,7 @@ export class TrianglesSnapRenderer extends VBORenderer {
         // renderPass = PICK
         src.push(`int pickFlag = int(flags) >> 12 & 0xF;`);
         src.push(`if (pickFlag != renderPass) {`);
-        src.push("   gl_Position = vec4(0.0, 0.0, 0.0, 0.0);"); // Cull vertex
+        src.push("   gl_Position = vec4(2.0, 0.0, 0.0, 0.0);"); // Cull vertex
         src.push("} else {");
         src.push("  vec4 worldPosition = positionsDecodeMatrix * vec4(position, 1.0); ");
         src.push("  worldPosition = worldMatrix * vec4(dot(worldPosition, modelMatrixCol0), dot(worldPosition, modelMatrixCol1), dot(worldPosition, modelMatrixCol2), 1.0);");


### PR DESCRIPTION
This PR fixes two issues:
- it was possible to pick unpickable objects (`pickable: false`) when using snap picking on DTX scene models.
- VBO vertex snap picking was broken if a unpickable object was present on the model. The rest of the comment will focus on this second issue.

To reproduce, go on a snap to vertex example, get one model entity and set its `pickable` property to `false`.
-> The snap cursor is stuck somewhere around the origin of the model.

On this image, my mouse is hovering the model and the pink top element of the table is unpickable. The green circle is positioned on the `snappedCanvasPos` that is stuck:
<img width="528" alt="Screenshot 2024-07-26 at 00 35 34" src="https://github.com/user-attachments/assets/cbf4400f-aa49-4154-885f-cc5763864c22">

This issue was only present on VBO and only on snap to vertex picking.
It was not present in DTX because of the previous issue AND [vertex are culled](https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesPickMeshRenderer.js#L293) using `gl_Position = vec4(3, 3, 3, 1);`)

What **may** happen:

Unpickable vertex are culled using `gl_Position = vec4(0);` [here](https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesSnapRenderer.js#L217) (idem for instancing and lines)
Because of how the snap picking works, it may not be a good idea to cull a vertex this way.

I saw this formula [here](https://www.khronos.org/opengl/wiki/Vertex_Post-Processing):

<img width="166" alt="Screenshot 2024-07-26 at 01 07 15" src="https://github.com/user-attachments/assets/4a130ecb-ae9a-4290-9697-d3d1bc0bf923">

Vertex with a `vec4(0)` position ends into the NDC rectangle `[-1, -1, -1]` to `[1, 1, 1]` as its position is `[0, 0, 0]` and because `position.w` is `0`, it is not clipped/discarded as `0 <= 0 <= 0` for each `x, y, z` components.

Vertex snap picking uses point primitive. I assume "culling" a triangle with the same `vec4(0)` position for the three corner vertices may work because the triangle is too small to be rendered... but a point with [pointSize of 1](https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesSnapRenderer.js#L239) may still be rendered.

Because of that, unpickable objects vertices are always rendered as point of size 1 at the center of the snapping viewport.
Then, due to [this line](https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesSnapRenderer.js#L293), the returned `snappedCanvasPos` seems to be always the origin of the model. Indeed, `[0, 0, 0]` relative to origin is the origin... ?

I hope it makes sense. Even if what I described here is not 100% correct, moving the vertices at `vec4(2, 0, 0, 0)` seems to fix the issue. I think any value other that `0` may work du to the previous formula.

 
