### PR TITLE
Allow to set different wireframe axes for distance measurements

### DIFF
--- a/examples/measurement/distance_createWithMouse_scenegraph_OBB.html
+++ b/examples/measurement/distance_createWithMouse_scenegraph_OBB.html
@@ -1,0 +1,617 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>xeokit Example</title>
+    <link href="../css/pageStyle.css" rel="stylesheet"/>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
+
+    <style>
+
+        .viewer-ruler-wire-highlighted {
+            border: 2px solid white !important;
+        }
+
+        .viewer-ruler-label-highlighted {
+            border: 2px solid white !important;
+        }
+
+        .viewer-ruler-dot-highlighted {
+            border: 2px solid white !important;
+        }
+
+        .xeokit-context-menu {
+            font-family: 'Roboto', sans-serif;
+            font-size: 15px;
+            display: none;
+            z-index: 300000;
+            background: rgba(255, 255, 255, 0.46);
+            border: 1px solid black;
+            border-radius: 6px;
+            padding: 0;
+            width: 200px;
+        }
+
+        .xeokit-context-menu ul {
+            list-style: none;
+            margin-left: 0;
+            padding: 0;
+        }
+
+        .xeokit-context-menu ul li {
+            list-style-type: none;
+            padding-left: 10px;
+            padding-right: 20px;
+            padding-top: 4px;
+            padding-bottom: 4px;
+            color: black;
+            border-bottom: 1px solid gray;
+            background: rgba(255, 255, 255, 0.46);
+            cursor: pointer;
+            width: calc(100% - 30px);
+        }
+
+        .xeokit-context-menu ul li:hover {
+            background: black;
+            color: white;
+            font-weight: normal;
+        }
+
+        .xeokit-context-menu ul li span {
+            display: inline-block;
+        }
+
+        .xeokit-context-menu .disabled {
+            display: inline-block;
+            color: gray;
+            cursor: default;
+            font-weight: normal;
+        }
+
+        .xeokit-context-menu .disabled:hover {
+            color: gray;
+            cursor: default;
+            background: #eeeeee;
+            font-weight: normal;
+        }
+
+    </style>
+</head>
+<body>
+<input type="checkbox" id="info-button"/>
+<label for="info-button" class="info-button"><i class="far fa-3x fa-question-circle"></i></label>
+<canvas id="myCanvas"></canvas>
+<div class="slideout-sidebar">
+    <img class="info-icon" src="../../assets/images/measure_distance_icon.png"/>
+    <h1>DistanceMeasurementPlugin with Mesh, Node, DistanceMeasurementsMouseControl and PointerLens</h1>
+    <h2>Click on the model to create distance measurements, with no vertex and edge snapping</h2>
+    <p>In this example, we're building a scene graph, then creating distance measurements wherever the
+        user clicks on the model with the mouse.</p>
+    <h3>Components Used</h3>
+    <ul>
+        <li>
+            <a href="../../docs/class/src/viewer/Viewer.js~Viewer.html"
+               target="_other">Viewer</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsPlugin.js~DistanceMeasurementsPlugin.html"
+               target="_other">DistanceMeasurementsPlugin</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsMouseControl.js~DistanceMeasurementsMouseControl.html"
+               target="_other">DistanceMeasurementsMouseControl</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/extras/PointerLens/PointerLens.js~PointerLens.html"
+               target="_other">PointerLens</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/viewer/scene/nodes/Node.js~Node.html"
+               target="_other">Node</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/viewer/scene/mesh/Mesh.js~Mesh.html"
+               target="_other">Mesh</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/viewer/scene/materials/PhongMaterial.js~PhongMaterial.html"
+               target="_other">PhongMaterial</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/viewer/scene/geometry/ReadableGeometry.js~ReadableGeometry.html"
+               target="_other">ReadableGeometry</a>
+        </li>
+        <li>
+            <a href="../../docs/function/index.html#static-function-buildBoxGeometry"
+               target="_other">buildBoxGeometry</a>
+        </li>
+    </ul>
+    <h3>Tutorials</h3>
+    <ul>
+        <li>
+            <a href="https://www.notion.so/xeokit/Accurate-Measurements-with-Snapping-5e6606afef20428f9b319ea0e82270f9"
+               target="_other">Accurate Measurements with Snapping</a>
+        </li>
+    </ul>
+    <h3>Assets</h3>
+    <ul>
+        <li>
+            <a href="http://openifcmodel.cs.auckland.ac.nz/Model/Details/274"
+               target="_other">Model source</a>
+        </li>
+    </ul>
+</div>
+</body>
+<script type="module">
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Import the modules we need for this example
+    //------------------------------------------------------------------------------------------------------------------
+
+    import {
+        Viewer,
+        Mesh,
+        Node,
+        PhongMaterial,
+        buildBoxGeometry,
+        ReadableGeometry,
+        ContextMenu,
+        PointerLens,
+        DistanceMeasurementsPlugin,
+        DistanceMeasurementsMouseControl,
+        DistanceMeasurementEditMouseControl
+    } from "../../dist/xeokit-sdk.es.js";
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a Viewer and arrange the camera
+    //------------------------------------------------------------------------------------------------------------------
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas"
+    });
+
+    viewer.cameraControl.panRightClick = false; // Prevents right-click-drag panning interfering with ContextMenus
+
+    viewer.scene.camera.eye = [12.10, 24.72, 31.26];
+    viewer.scene.camera.look = [1.22, 5.75, 0];
+    viewer.scene.camera.up = [-0.17, 0.85, -0.49];
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Build a simple scene graph representing a table with four legs
+    //------------------------------------------------------------------------------------------------------------------
+
+    const boxGeometry = new ReadableGeometry(viewer.scene, buildBoxGeometry({
+        xSize: 1,
+        ySize: 1,
+        zSize: 1
+    }));
+
+    // create 1st table, unrotated
+    new Node(viewer.scene, {
+        id: "table1",
+        isModel: true, // <--------------------- Node represents a model
+        rotation: [0, 0, 0],
+        position: [-10, 0, 0],
+        scale: [1, 1, 1],
+
+        children: [
+
+            new Mesh(viewer.scene, { // Red table leg
+                id: "redLeg1",
+                isObject: true, // <---------- Node represents an object
+                position: [-4, -6, -4],
+                scale: [1, 3, 1],
+                rotation: [0, 0, 0],
+                geometry: boxGeometry,
+                material: new PhongMaterial(viewer.scene, {
+                    diffuse: [1, 0.3, 0.3]
+                })
+            }),
+
+            new Mesh(viewer.scene, { // Green table leg
+                id: "greenLeg1",
+                isObject: true, // <---------- Node represents an object
+                position: [4, -6, -4],
+                scale: [1, 3, 1],
+                rotation: [0, 0, 0],
+                geometry: boxGeometry,
+                material: new PhongMaterial(viewer.scene, {
+                    diffuse: [0.3, 1.0, 0.3]
+                })
+            }),
+
+            new Mesh(viewer.scene, {// Blue table leg
+                id: "blueLeg1",
+                isObject: true, // <---------- Node represents an object
+                position: [4, -6, 4],
+                scale: [1, 3, 1],
+                rotation: [0, 0, 0],
+                geometry: boxGeometry,
+                material: new PhongMaterial(viewer.scene, {
+                    diffuse: [0.3, 0.3, 1.0]
+                })
+            }),
+
+            new Mesh(viewer.scene, {  // Yellow table leg
+                id: "yellowLeg1",
+                isObject: true, // <---------- Node represents an object
+                position: [-4, -6, 4],
+                scale: [1, 3, 1],
+                rotation: [0, 0, 0],
+                geometry: boxGeometry,
+                material: new PhongMaterial(viewer.scene, {
+                    diffuse: [1.0, 1.0, 0.0]
+                })
+            }),
+
+            new Mesh(viewer.scene, { // Purple table top
+                id: "tableTop1",
+                isObject: true, // <---------- Node represents an object
+                position: [0, -3, 0],
+                scale: [6, 0.5, 6],
+                rotation: [0, 0, 0],
+                geometry: boxGeometry,
+                material: new PhongMaterial(viewer.scene, {
+                    diffuse: [1.0, 0.3, 1.0]
+                })
+            })
+        ]
+    });
+
+    // create 2nd table, rotated
+    new Node(viewer.scene, {
+        id: "table2",
+        isModel: true, // <--------------------- Node represents a model
+        rotation: [0, 45, 0],
+        position: [10, 0, 0],
+        scale: [1, 1, 1],
+
+        children: [
+
+            new Mesh(viewer.scene, { // Red table leg
+                id: "redLeg2",
+                isObject: true, // <---------- Node represents an object
+                position: [-4, -6, -4],
+                scale: [1, 3, 1],
+                rotation: [0, 0, 0],
+                geometry: boxGeometry,
+                material: new PhongMaterial(viewer.scene, {
+                    diffuse: [1, 0.3, 0.3]
+                })
+            }),
+
+            new Mesh(viewer.scene, { // Green table leg
+                id: "greenLeg2",
+                isObject: true, // <---------- Node represents an object
+                position: [4, -6, -4],
+                scale: [1, 3, 1],
+                rotation: [0, 0, 0],
+                geometry: boxGeometry,
+                material: new PhongMaterial(viewer.scene, {
+                    diffuse: [0.3, 1.0, 0.3]
+                })
+            }),
+
+            new Mesh(viewer.scene, {// Blue table leg
+                id: "blueLeg2",
+                isObject: true, // <---------- Node represents an object
+                position: [4, -6, 4],
+                scale: [1, 3, 1],
+                rotation: [0, 0, 0],
+                geometry: boxGeometry,
+                material: new PhongMaterial(viewer.scene, {
+                    diffuse: [0.3, 0.3, 1.0]
+                })
+            }),
+
+            new Mesh(viewer.scene, {  // Yellow table leg
+                id: "yellowLeg2",
+                isObject: true, // <---------- Node represents an object
+                position: [-4, -6, 4],
+                scale: [1, 3, 1],
+                rotation: [0, 0, 0],
+                geometry: boxGeometry,
+                material: new PhongMaterial(viewer.scene, {
+                    diffuse: [1.0, 1.0, 0.0]
+                })
+            }),
+
+            new Mesh(viewer.scene, { // Purple table top
+                id: "tableTop2",
+                isObject: true, // <---------- Node represents an object
+                position: [0, -3, 0],
+                scale: [6, 0.5, 6],
+                rotation: [0, 0, 0],
+                geometry: boxGeometry,
+                material: new PhongMaterial(viewer.scene, {
+                    diffuse: [1.0, 0.3, 1.0]
+                })
+            })
+        ]
+    });
+
+
+    //------------------------------------------------------------------------------------------------------------------
+    // DistanceMeasurementsPlugin, DistanceMeasurementsMouseControl and PointerLens
+    //------------------------------------------------------------------------------------------------------------------
+
+    const distanceMeasurementsPlugin = new DistanceMeasurementsPlugin(viewer);
+
+    distanceMeasurementsPlugin.on("measurementStart", (distanceMeasurement) => {
+        console.log("measurementStart");
+        console.log("origin", distanceMeasurement.origin.entity);
+        console.log("target", distanceMeasurement.target.entity);
+
+        // At the start of the measurement, adjust the measurement axes
+
+        // Axes basis: unrotated table
+        if (distanceMeasurement.origin.entity.id.endsWith("1")) {
+            console.log("unrotated table => measurement axes are aligned with world axes");
+            distanceMeasurement.axesBasis = [
+                1, 0, 0, 0,
+                0, 1, 0, 0,
+                0, 0, 1, 0,
+                0, 0, 1, 1,
+            ];
+        }
+
+        // Axes basis: rotated table
+        if (distanceMeasurement.origin.entity.id.endsWith("2")) {
+            console.log("rotated table => measurement axes are rotated 45º with respect to world axes");
+            distanceMeasurement.axesBasis = [
+                0.707, 0, -0.707, 0,
+                0, 1, 0, 0,
+                0.707, 0, 0.707, 0,
+                0, 0, 1, 1,
+            ];
+        }
+    });
+
+    distanceMeasurementsPlugin.on("measurementEnd", (distanceMeasurement) => {
+        console.log("measurementEnd");
+        console.log("origin", distanceMeasurement.origin.entity);
+        console.log("target", distanceMeasurement.target.entity);
+    });
+
+    distanceMeasurementsPlugin.on("measurementCancel", (distanceMeasurement) => {
+        console.log("measurementCancel");
+        console.log("origin", distanceMeasurement.origin.entity);
+        console.log("target", distanceMeasurement.target.entity);
+    });
+
+    const distanceMeasurementsMouseControl = new DistanceMeasurementsMouseControl(distanceMeasurementsPlugin, {
+        pointerLens: new PointerLens(viewer),
+        snapping: false // Snapping not supported on Meshes, only on SceneModel
+    })
+
+    distanceMeasurementsMouseControl.snapping = true;
+
+    distanceMeasurementsMouseControl.activate();
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a context menu to delete and configure measurements
+    //------------------------------------------------------------------------------------------------------------------
+
+    let endMeasurementEdit = null;
+
+    const distanceMeasurementsContextMenu = new ContextMenu({
+        items: [
+            [
+                {
+                    title: "Clear",
+                    doAction: function (context) {
+                        context.distanceMeasurement.destroy();
+                    }
+                },
+                {
+                    getTitle: (context) => {
+                        return context.distanceMeasurement.axisVisible ? "Hide Axis" : "Show Axis";
+                    },
+                    doAction: function (context) {
+                        context.distanceMeasurement.axisVisible = !context.distanceMeasurement.axisVisible;
+                    }
+                },
+                {
+                    getTitle: (context) => {
+                        return context.distanceMeasurement.xLabelEnabled && context.distanceMeasurement.labelsVisible ? "Disable X Label" : "Enable X Label";
+                    },
+                    doAction: function (context) {
+                        context.distanceMeasurement.xLabelEnabled = !context.distanceMeasurement.xLabelEnabled;
+                    }
+                },
+                {
+                    getTitle: (context) => {
+                        return context.distanceMeasurement.yLabelEnabled && context.distanceMeasurement.labelsVisible ? "Disable Y Label" : "Enable Y Label";
+                    },
+                    doAction: function (context) {
+                        context.distanceMeasurement.yLabelEnabled = !context.distanceMeasurement.yLabelEnabled;
+                    }
+                },
+                {
+                    getTitle: (context) => {
+                        return context.distanceMeasurement.zLabelEnabled && context.distanceMeasurement.labelsVisible ? "Disable Z Label" : "Enable Z Label";
+                    },
+                    doAction: function (context) {
+                        context.distanceMeasurement.zLabelEnabled = !context.distanceMeasurement.zLabelEnabled;
+                    }
+                },
+                {
+                    getTitle: (context) => {
+                        return context.distanceMeasurement.lengthLabelEnabled && context.distanceMeasurement.labelsVisible ? "Disable Length Label" : "Enable Length Label";
+                    },
+                    doAction: function (context) {
+                        context.distanceMeasurement.lengthLabelEnabled = !context.distanceMeasurement.lengthLabelEnabled;
+                    }
+                },
+                {
+                    getTitle: (context) => {
+                        return context.distanceMeasurement.labelsVisible ? "Hide All Labels" : "Show All Labels";
+                    },
+                    doAction: function (context) {
+                        context.distanceMeasurement.labelsVisible = !context.distanceMeasurement.labelsVisible;
+                    }
+                },
+                {
+                    title: "Edit",
+                    doAction: function (context) {
+                        distanceMeasurementsMouseControl.deactivate();
+                        const measurement = context.distanceMeasurement;
+                        const edit = new DistanceMeasurementEditMouseControl(measurement, {
+                            pointerLens: new PointerLens(viewer),
+                            snapping: true
+                        });
+                        edit.on("edited", () => console.log("edited", measurement.id));
+                        endMeasurementEdit = () => {
+                            edit.deactivate();
+                            endMeasurementEdit = null;
+                        };
+                    }
+                }
+            ], [
+                {
+                    title: "Clear All",
+                    getEnabled: function (context) {
+                        return (Object.keys(context.distanceMeasurementsPlugin.measurements).length > 0);
+                    },
+                    doAction: function (context) {
+                        context.distanceMeasurementsPlugin.clear();
+                    }
+                },
+                {
+                    getTitle: () => {
+                        return "Cancel Measurement";
+                    },
+                    doAction: function () {
+                        distanceMeasurementsMouseControl.reset();
+                    }
+                }
+            ]
+        ]
+    });
+
+    distanceMeasurementsContextMenu.on("hidden", () => {
+        if (distanceMeasurementsContextMenu.context.distanceMeasurement) {
+            distanceMeasurementsContextMenu.context.distanceMeasurement.setHighlighted(false);
+        }
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a context menu to activate and deactivate the control
+    //------------------------------------------------------------------------------------------------------------------
+
+    const canvasContextMenu = new ContextMenu({
+        enabled: true,
+        context: {
+            viewer: viewer
+        },
+        items: [
+            [
+                {
+                    getTitle: (context) => {
+                        return distanceMeasurementsMouseControl.active ? "Deactivate Control" : "Activate Control";
+                    },
+                    doAction: function (context) {
+                        distanceMeasurementsMouseControl.active
+                            ? distanceMeasurementsMouseControl.deactivate()
+                            : distanceMeasurementsMouseControl.activate();
+                    }
+                },
+                {
+                    getTitle: () => {
+                        return "Cancel Measurement";
+                    },
+                    getEnabled: function () {
+                        return (!!distanceMeasurementsMouseControl.currentMeasurement);
+                    },
+                    doAction: function () {
+                        distanceMeasurementsMouseControl.reset();
+                    }
+                },
+                {
+                    getTitle: () => {
+                        return "End Editing";
+                    },
+                    getEnabled: function () {
+                        return !!endMeasurementEdit;
+                    },
+                    doAction: function () {
+                        endMeasurementEdit();
+                    }
+                }
+            ]
+        ]
+    });
+
+    viewer.scene.canvas.canvas.addEventListener('contextmenu', (event) => {
+        const canvasPos = getCanvasPosFromEvent(event);
+        console.log("canvas context menu")
+        canvasContextMenu.show(canvasPos[0], canvasPos[1]);
+        event.preventDefault();
+        event.stopPropagation();
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create an DistanceMeasurementsPlugin, activate its DistanceMeasuremntsControl
+    //------------------------------------------------------------------------------------------------------------------
+
+    distanceMeasurementsPlugin.on("mouseOver", (e) => {
+        if (endMeasurementEdit) {
+            return;
+        }
+        e.distanceMeasurement.setHighlighted(true);
+    });
+
+    distanceMeasurementsPlugin.on("mouseLeave", (e) => {
+        if (endMeasurementEdit) {
+            return;
+        }
+        if (distanceMeasurementsContextMenu.shown && distanceMeasurementsContextMenu.context.distanceMeasurement.id === e.distanceMeasurement.id) {
+            return;
+        }
+        e.distanceMeasurement.setHighlighted(false);
+    });
+
+    distanceMeasurementsPlugin.on("contextMenu", (e) => {
+        if (endMeasurementEdit) {
+            return;
+        }
+        distanceMeasurementsContextMenu.context = { // Must set context before showing menu
+            viewer: viewer,
+            distanceMeasurementsPlugin: distanceMeasurementsPlugin,
+            distanceMeasurement: e.distanceMeasurement
+        };
+        distanceMeasurementsContextMenu.show(e.event.clientX, e.event.clientY);
+        e.event.preventDefault();
+    });
+
+    const getCanvasPosFromEvent = function (event) {
+        const canvasPos = [];
+        if (!event) {
+            event = window.event;
+            canvasPos[0] = event.x;
+            canvasPos[1] = event.y;
+        } else {
+            let element = event.target;
+            let totalOffsetLeft = 0;
+            let totalOffsetTop = 0;
+            let totalScrollX = 0;
+            let totalScrollY = 0;
+            while (element.offsetParent) {
+                totalOffsetLeft += element.offsetLeft;
+                totalOffsetTop += element.offsetTop;
+                totalScrollX += element.scrollLeft;
+                totalScrollY += element.scrollTop;
+                element = element.offsetParent;
+            }
+            canvasPos[0] = event.pageX + totalScrollX - totalOffsetLeft;
+            canvasPos[1] = event.pageY + totalScrollY - totalOffsetTop;
+        }
+        return canvasPos;
+    };
+
+    window.viewer = viewer;
+
+</script>
+</html>

--- a/examples/measurement/index.html
+++ b/examples/measurement/index.html
@@ -261,6 +261,7 @@
             "# Creating distance measurements with mouse",
             ["distance_createWithMouse_snapping", "Click with mouse on model to create distance measurements, snapping enabled"],
             ["distance_createWithMouse_scenegraph", "Click with mouse on scene graph to create distance measurements, snapping disabled"],
+            ["distance_createWithMouse_scenegraph_OBB", "Click with mouse on scene graph to create OBB aligned measurements, snapping disabled"],
             ["distance_createWithMouse_snapping_offsetCanvas", "Click with mouse on model to create distance measurements, snapping enabled, offset canvas"],
             ["distance_createWithMouse_snapping_Lyon", "Click with mouse on model to create distance measurements, snapping enabled"],
             ["distance_createWithMouse_labelsNotOnWires", "Click with mouse on model to create distance measurements, snapping enabled, labels one below the other"],

--- a/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
+++ b/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
@@ -330,6 +330,12 @@ class DistanceMeasurement extends Component {
     }
 
     /**
+     * Sets the axes basis for the measurement.
+     * 
+     * The value is a 4x4 matrix where each column-vector defines an axis and must have unit length.
+     * 
+     * This is the ```identity``` matrix by default, meaning the measurement axes are the same as the world axes.
+     * 
      * @param {number[]} value 
      */
     set axesBasis(value) {
@@ -338,6 +344,15 @@ class DistanceMeasurement extends Component {
         this._needUpdate(0); // No lag
     }
 
+    /**
+     * Gets the axes basis for the measurement.
+     * 
+     * The value is a 4x4 matrix where each column-vector defines an axis and must have unit length.
+     * 
+     * This is the ```identity``` matrix by default, meaning the measurement axes are the same as the world axes.
+     * 
+     * @type {number[]}
+     */
     get axesBasis() {
         return this._axesBasis;
     }
@@ -381,21 +396,24 @@ class DistanceMeasurement extends Component {
                     tmpVec3
                 );
 
-                this.factors = math.transformVec3(this._axesBasis, delta);
+                /**
+                 * The length detected for each measurement axis.
+                 */
+                this._factors = math.transformVec3(this._axesBasis, delta);
 
                 this._wp[0] = this._originWorld[0];
                 this._wp[1] = this._originWorld[1];
                 this._wp[2] = this._originWorld[2];
                 this._wp[3] = 1.0;
 
-                this._wp[4] = this._originWorld[0] + this._axesBasis[0]*this.factors[0];
-                this._wp[5] = this._originWorld[1] + this._axesBasis[4]*this.factors[0];
-                this._wp[6] = this._originWorld[2] + this._axesBasis[8]*this.factors[0];
+                this._wp[4] = this._originWorld[0] + this._axesBasis[0]*this._factors[0];
+                this._wp[5] = this._originWorld[1] + this._axesBasis[4]*this._factors[0];
+                this._wp[6] = this._originWorld[2] + this._axesBasis[8]*this._factors[0];
                 this._wp[7] = 1.0;
 
-                this._wp[8] = this._originWorld[0] + this._axesBasis[0]*this.factors[0]+ this._axesBasis[1]*this.factors[1];
-                this._wp[9] = this._originWorld[1] + this._axesBasis[4]*this.factors[0]+ this._axesBasis[5]*this.factors[1];
-                this._wp[10] = this._originWorld[2] + this._axesBasis[8]*this.factors[0]+ this._axesBasis[9]*this.factors[1];;
+                this._wp[8] = this._originWorld[0] + this._axesBasis[0]*this._factors[0]+ this._axesBasis[1]*this._factors[1];
+                this._wp[9] = this._originWorld[1] + this._axesBasis[4]*this._factors[0]+ this._axesBasis[5]*this._factors[1];
+                this._wp[10] = this._originWorld[2] + this._axesBasis[8]*this._factors[0]+ this._axesBasis[9]*this._factors[1];;
                 this._wp[11] = 1.0;
 
                 this._wp[12] = this._targetWorld[0];
@@ -557,14 +575,14 @@ class DistanceMeasurement extends Component {
                 }
 
                 if (!this._xAxisLabelCulled) {
-                    this._xAxisLabel.setText(tilde + Math.abs(this.factors[0] * scale).toFixed(2) + unitAbbrev);
+                    this._xAxisLabel.setText(tilde + Math.abs(this._factors[0] * scale).toFixed(2) + unitAbbrev);
                     this._xAxisLabel.setCulled(!this.axisVisible);
                 } else {
                     this._xAxisLabel.setCulled(true);
                 }
 
                 if (!this._yAxisLabelCulled) {
-                    this._yAxisLabel.setText(tilde + Math.abs(this.factors[1] * scale).toFixed(2) + unitAbbrev);
+                    this._yAxisLabel.setText(tilde + Math.abs(this._factors[1] * scale).toFixed(2) + unitAbbrev);
                     this._yAxisLabel.setCulled(!this.axisVisible);
                 } else {
                     this._yAxisLabel.setCulled(true);
@@ -577,7 +595,7 @@ class DistanceMeasurement extends Component {
                     }
                     else {
                         this._zAxisLabel.setPrefix("Z");
-                        this._zAxisLabel.setText(tilde + Math.abs(this.factors[2] * scale).toFixed(2) + unitAbbrev);
+                        this._zAxisLabel.setText(tilde + Math.abs(this._factors[2] * scale).toFixed(2) + unitAbbrev);
                     }
                     this._zAxisLabel.setCulled(!this.axisVisible);
                 } else {

--- a/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
+++ b/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
@@ -6,6 +6,7 @@ import {Component} from "../../viewer/scene/Component.js";
 
 
 const distVec3 = math.vec3();
+const tmpVec3 = math.vec3();
 
 const lengthWire = (x1, y1, x2, y2) => {
     var a = x1 - x2;
@@ -316,6 +317,29 @@ class DistanceMeasurement extends Component {
         this.labelsVisible = cfg.labelsVisible;
         this.labelsOnWires = cfg.labelsOnWires;
         this.useRotationAdjustment = cfg.useRotationAdjustment;
+
+        /**
+         * @type {number[]}
+         */
+        this._axesBasis = [
+            1, 0, 0, 0,
+            0, 1, 0, 0,
+            0, 0, 1, 0,
+            0, 0, 0, 1,
+        ];
+    }
+
+    /**
+     * @param {number[]} value 
+     */
+    set axesBasis(value) {
+        this._axesBasis = value.slice();
+        this._wpDirty = true;
+        this._needUpdate(0); // No lag
+    }
+
+    get axesBasis() {
+        return this._axesBasis;
     }
 
     _update() {
@@ -351,19 +375,27 @@ class DistanceMeasurement extends Component {
                 this._wp[15] = 1.0;
             }
             else {
+                const delta = math.subVec3(
+                    this._targetWorld,
+                    this._originWorld,
+                    tmpVec3
+                );
+
+                this.factors = math.transformVec3(this._axesBasis, delta);
+
                 this._wp[0] = this._originWorld[0];
                 this._wp[1] = this._originWorld[1];
                 this._wp[2] = this._originWorld[2];
                 this._wp[3] = 1.0;
 
-                this._wp[4] = this._targetWorld[0];
-                this._wp[5] = this._originWorld[1];
-                this._wp[6] = this._originWorld[2];
+                this._wp[4] = this._originWorld[0] + this._axesBasis[0]*this.factors[0];
+                this._wp[5] = this._originWorld[1] + this._axesBasis[4]*this.factors[0];
+                this._wp[6] = this._originWorld[2] + this._axesBasis[8]*this.factors[0];
                 this._wp[7] = 1.0;
 
-                this._wp[8] = this._targetWorld[0];
-                this._wp[9] = this._targetWorld[1];
-                this._wp[10] = this._originWorld[2];
+                this._wp[8] = this._originWorld[0] + this._axesBasis[0]*this.factors[0]+ this._axesBasis[1]*this.factors[1];
+                this._wp[9] = this._originWorld[1] + this._axesBasis[4]*this.factors[0]+ this._axesBasis[5]*this.factors[1];
+                this._wp[10] = this._originWorld[2] + this._axesBasis[8]*this.factors[0]+ this._axesBasis[9]*this.factors[1];;
                 this._wp[11] = 1.0;
 
                 this._wp[12] = this._targetWorld[0];
@@ -525,14 +557,14 @@ class DistanceMeasurement extends Component {
                 }
 
                 if (!this._xAxisLabelCulled) {
-                    this._xAxisLabel.setText(tilde + Math.abs((this._targetWorld[0] - this._originWorld[0]) * scale).toFixed(2) + unitAbbrev);
+                    this._xAxisLabel.setText(tilde + Math.abs(this.factors[0] * scale).toFixed(2) + unitAbbrev);
                     this._xAxisLabel.setCulled(!this.axisVisible);
                 } else {
                     this._xAxisLabel.setCulled(true);
                 }
 
                 if (!this._yAxisLabelCulled) {
-                    this._yAxisLabel.setText(tilde + Math.abs((this._targetWorld[1] - this._originWorld[1]) * scale).toFixed(2) + unitAbbrev);
+                    this._yAxisLabel.setText(tilde + Math.abs(this.factors[1] * scale).toFixed(2) + unitAbbrev);
                     this._yAxisLabel.setCulled(!this.axisVisible);
                 } else {
                     this._yAxisLabel.setCulled(true);
@@ -545,7 +577,7 @@ class DistanceMeasurement extends Component {
                     }
                     else {
                         this._zAxisLabel.setPrefix("Z");
-                        this._zAxisLabel.setText(tilde + Math.abs((this._targetWorld[2] - this._originWorld[2]) * scale).toFixed(2) + unitAbbrev);
+                        this._zAxisLabel.setText(tilde + Math.abs(this.factors[2] * scale).toFixed(2) + unitAbbrev);
                     }
                     this._zAxisLabel.setCulled(!this.axisVisible);
                 } else {

--- a/types/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.d.ts
+++ b/types/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.d.ts
@@ -12,6 +12,10 @@ export declare class DistanceMeasurement extends Component {
    */
   plugin: DistanceMeasurementsPlugin;
 
+  set axesBasis(value: number[]);
+
+  get axesBasis(): number[];
+
   /**
    * Sets whether this DistanceMeasurement indicates that its measurement is approximate.
    *

--- a/types/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.d.ts
+++ b/types/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.d.ts
@@ -12,8 +12,22 @@ export declare class DistanceMeasurement extends Component {
    */
   plugin: DistanceMeasurementsPlugin;
 
+  /**
+   * Sets the axes basis for the measurement.
+   * 
+   * The value is a 4x4 matrix where each column-vector defines an axis and must have unit length.
+   * 
+   * This is the ```identity``` matrix by default, meaning the measurement axes are the same as the world axes.
+   */
   set axesBasis(value: number[]);
 
+  /**
+   * Gets the axes basis for the measurement.
+   * 
+   * The value is a 4x4 matrix where each column-vector defines an axis and must have unit length.
+   * 
+   * This is the ```identity``` matrix by default, meaning the measurement axes are the same as the world axes.
+   */
   get axesBasis(): number[];
 
   /**


### PR DESCRIPTION
## Description

This PR allows to externally set the axes of the measurement gizmo when defining a distance measurement.

At the moment, the intented usage is to set it externally:

```js
measurementPlugin.on("measurementCreated", (m) => {
    // e.g. obtain the basis based on the object OBB
    const axesBasis = lookUpObbAlignedBasis(m.origin.entity.id);
    // and use that in the measurement
    m.axesBasis = axesBasis;
});
```

This enables the measurements to be aligned to the measured objects.

## Before

The measurement wires are aligned to the world axes.

![image](https://github.com/user-attachments/assets/cb73807d-2282-4eb2-a3f7-2d18e8e2173d)

## After

The measurement wires are aligned to the object OBB.

![image](https://github.com/user-attachments/assets/b2294213-85b0-4e90-801f-6fdc851a9835)

## How it works

Given a concrete basis (by default it's the unit matrix) formed by the columns of the `axesBasis` matrix, in order to calculate the endpoints of the measurement wires (red, green, blue), the code will project the difference-vector in each of the basis' vectors, and use those projections to construct the endpoints.

It's not a breaking change: it will default to same behaviour as today in case the `axesBasis` attribute is not set for the measurement, which means it will stick to world-aligned measurement wires. This is done by setting the unit matrix as default, which will lead to consider the world X-Y-Z axes.