### PR TITLE
Export types for `DistanceMeasurementsTouchControl`

### DIFF
--- a/types/plugins/DistanceMeasurementsPlugin/index.d.ts
+++ b/types/plugins/DistanceMeasurementsPlugin/index.d.ts
@@ -1,5 +1,6 @@
 export * from "./DistanceMeasurement";
 export * from "./DistanceMeasurementsControl";
 export * from "./DistanceMeasurementsMouseControl";
+export * from "./DistanceMeasurementsTouchControl";
 export * from "./DistanceMeasurementsPlugin";
 


### PR DESCRIPTION
Otherwise, it's not possible to consume Touch-based measurements from Typescript apps using xeokit-sdk.