### PR TITLE
Use documentElement instead of body for client{X,Y}=>canvasPos transformation

### DIFF
--- a/examples/scenegraph/overlay.js
+++ b/examples/scenegraph/overlay.js
@@ -103,7 +103,7 @@ export const setupOverlayAlignmentControl = function(viewer, overlay) {
     const copyCanvasPos = (event, vec2) => {
         vec2[0] = event.clientX;
         vec2[1] = event.clientY;
-        transformToNode(canvas.ownerDocument.body, canvas, vec2);
+        transformToNode(canvas.ownerDocument.documentElement, canvas, vec2);
         return vec2;
     };
 

--- a/src/plugins/ZonesPlugin/ZonesPlugin.js
+++ b/src/plugins/ZonesPlugin/ZonesPlugin.js
@@ -343,7 +343,7 @@ const mousePointSelector = function(viewer, ray2WorldPos) {
         const copyCanvasPos = (event, vec2) => {
             vec2[0] = event.clientX;
             vec2[1] = event.clientY;
-            transformToNode(canvas.ownerDocument.body, canvas, vec2);
+            transformToNode(canvas.ownerDocument.documentElement, canvas, vec2);
             return vec2;
         };
 
@@ -418,7 +418,7 @@ const touchPointSelector = function(viewer, pointerCircle, ray2WorldPos) {
         const copyCanvasPos = (event, vec2) => {
             vec2[0] = event.clientX;
             vec2[1] = event.clientY;
-            transformToNode(canvas.ownerDocument.body, canvas, vec2);
+            transformToNode(canvas.ownerDocument.documentElement, canvas, vec2);
             return vec2;
         };
 
@@ -1735,7 +1735,7 @@ export class ZoneTranslateControl extends Component {
         const copyCanvasPos = (event, vec2) => {
             vec2[0] = event.clientX;
             vec2[1] = event.clientY;
-            transformToNode(canvas.ownerDocument.body, canvas, vec2);
+            transformToNode(canvas.ownerDocument.documentElement, canvas, vec2);
             return vec2;
         };
 

--- a/src/plugins/lib/ui/index.js
+++ b/src/plugins/lib/ui/index.js
@@ -117,7 +117,7 @@ export function activateDraggableDot(dot, cfg) {
 
     const onChange = event => {
         const canvasPos = math.vec2([ event.clientX, event.clientY ]);
-        transformToNode(canvas.ownerDocument.body, canvas, canvasPos);
+        transformToNode(canvas.ownerDocument.documentElement, canvas, canvasPos);
         onMove(canvasPos, pickWorldPos(canvasPos));
     };
 


### PR DESCRIPTION
Use `canvas.ownerDocument.documentElement` instead of `canvas.ownerDocument.body` for `client{X,Y}`=>`canvasPos` transformation.

The `body.getBoundingClientRect()` might not always have 0 for `.left` and `.top`, which would give incorrect transformation from the `client{X,Y}` space to the canvas space.
The `canvas.ownerDocument.documentElement` is guaranteed to have 0 `.left` and `.top`.