### PR TITLE
Add separator as an independent li tag.

### DIFF
--- a/examples/buildings/dotbim_BlenderHouse.html
+++ b/examples/buildings/dotbim_BlenderHouse.html
@@ -139,26 +139,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -174,6 +173,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
     </style>
 

--- a/examples/buildings/dotbim_House.html
+++ b/examples/buildings/dotbim_House.html
@@ -139,26 +139,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -174,6 +173,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
     </style>
 

--- a/examples/buildings/dotbim_MulticolorHouse.html
+++ b/examples/buildings/dotbim_MulticolorHouse.html
@@ -139,26 +139,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -174,6 +173,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
     </style>
 

--- a/examples/buildings/dotbim_SmallHouse.html
+++ b/examples/buildings/dotbim_SmallHouse.html
@@ -139,26 +139,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -174,6 +173,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
     </style>
 

--- a/examples/buildings/dotbim_Teapots.html
+++ b/examples/buildings/dotbim_Teapots.html
@@ -139,26 +139,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -174,6 +173,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
     </style>
 

--- a/examples/buildings/dotbim_TestFaceColors.html
+++ b/examples/buildings/dotbim_TestFaceColors.html
@@ -143,26 +143,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -178,6 +177,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
     </style>
 

--- a/examples/buildings/dotbim_TestStructure.html
+++ b/examples/buildings/dotbim_TestStructure.html
@@ -139,26 +139,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -174,6 +173,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
     </style>
 

--- a/examples/buildings/xkt_manifest_Clinic.html
+++ b/examples/buildings/xkt_manifest_Clinic.html
@@ -138,26 +138,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -173,6 +172,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
         .buttons {

--- a/examples/buildings/xkt_manifest_KarhumakiBridge.html
+++ b/examples/buildings/xkt_manifest_KarhumakiBridge.html
@@ -138,26 +138,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -173,6 +172,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
         .buttons {

--- a/examples/buildings/xkt_manifest_KarhumakiBridge_hotlink.html
+++ b/examples/buildings/xkt_manifest_KarhumakiBridge_hotlink.html
@@ -138,26 +138,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -173,6 +172,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
         .buttons {

--- a/examples/buildings/xkt_manifest_KarhumakiBridge_inline.html
+++ b/examples/buildings/xkt_manifest_KarhumakiBridge_inline.html
@@ -138,26 +138,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -173,6 +172,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
         .buttons {

--- a/examples/buildings/xkt_manifest_KarhumakiBridge_inline_urls.html
+++ b/examples/buildings/xkt_manifest_KarhumakiBridge_inline_urls.html
@@ -138,26 +138,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -173,6 +172,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
         .buttons {

--- a/examples/buildings/xkt_manifest_WestRiverSideHospital.html
+++ b/examples/buildings/xkt_manifest_WestRiverSideHospital.html
@@ -138,26 +138,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -173,6 +172,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
         .buttons {

--- a/examples/buildings/xkt_vbo_federated_Clinic.html
+++ b/examples/buildings/xkt_vbo_federated_Clinic.html
@@ -138,26 +138,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -173,6 +172,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
         .buttons {

--- a/examples/cad/3DXML_Widget.html
+++ b/examples/cad/3DXML_Widget.html
@@ -139,26 +139,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
-            font-weight: bold;
+            font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -174,6 +173,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>

--- a/examples/measurement/angle_createWithMouse_nosnapping.html
+++ b/examples/measurement/angle_createWithMouse_nosnapping.html
@@ -40,26 +40,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -75,6 +74,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>

--- a/examples/measurement/angle_createWithMouse_snapping.html
+++ b/examples/measurement/angle_createWithMouse_snapping.html
@@ -40,26 +40,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -75,6 +74,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>

--- a/examples/measurement/angle_createWithMouse_snapping_canvasToPagePos.html
+++ b/examples/measurement/angle_createWithMouse_snapping_canvasToPagePos.html
@@ -40,26 +40,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -75,6 +74,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>

--- a/examples/measurement/angle_createWithMouse_snapping_offsetCanvas.html
+++ b/examples/measurement/angle_createWithMouse_snapping_offsetCanvas.html
@@ -40,26 +40,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -75,6 +74,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>

--- a/examples/measurement/angle_modelWithMeasurements.html
+++ b/examples/measurement/angle_modelWithMeasurements.html
@@ -40,26 +40,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -75,6 +74,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>

--- a/examples/measurement/distance_createWithMouse_labelsNotOnWires.html
+++ b/examples/measurement/distance_createWithMouse_labelsNotOnWires.html
@@ -40,26 +40,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -75,6 +74,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>

--- a/examples/measurement/distance_createWithMouse_nosnapping.html
+++ b/examples/measurement/distance_createWithMouse_nosnapping.html
@@ -40,26 +40,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -75,6 +74,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
     </style>
 </head>

--- a/examples/measurement/distance_createWithMouse_scenegraph.html
+++ b/examples/measurement/distance_createWithMouse_scenegraph.html
@@ -40,26 +40,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -75,6 +74,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>

--- a/examples/measurement/distance_createWithMouse_scenegraph_OBB.html
+++ b/examples/measurement/distance_createWithMouse_scenegraph_OBB.html
@@ -40,26 +40,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -75,6 +74,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>

--- a/examples/measurement/distance_createWithMouse_snapping.html
+++ b/examples/measurement/distance_createWithMouse_snapping.html
@@ -40,26 +40,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -75,6 +74,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>
@@ -135,7 +152,7 @@
     //------------------------------------------------------------------------------------------------------------------
 
     import {Viewer, XKTLoaderPlugin, ContextMenu, PointerLens, DistanceMeasurementsPlugin, DistanceMeasurementsMouseControl, DistanceMeasurementEditMouseControl} from "../../dist/xeokit-sdk.es.js";
-
+    
     //------------------------------------------------------------------------------------------------------------------
     // Create a Viewer and arrange the camera
     //------------------------------------------------------------------------------------------------------------------

--- a/examples/measurement/distance_createWithMouse_snapping_OpenProject_Hospital.html
+++ b/examples/measurement/distance_createWithMouse_snapping_OpenProject_Hospital.html
@@ -40,27 +40,25 @@
             padding: 0;
         }
 
-
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -76,6 +74,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>

--- a/examples/measurement/distance_createWithMouse_snapping_canvasToPagePos.html
+++ b/examples/measurement/distance_createWithMouse_snapping_canvasToPagePos.html
@@ -40,26 +40,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -75,6 +74,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>

--- a/examples/measurement/distance_createWithMouse_snapping_dtx_batching.html
+++ b/examples/measurement/distance_createWithMouse_snapping_dtx_batching.html
@@ -40,26 +40,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -75,6 +74,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>

--- a/examples/measurement/distance_createWithMouse_snapping_dtx_instancing.html
+++ b/examples/measurement/distance_createWithMouse_snapping_dtx_instancing.html
@@ -40,26 +40,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -75,6 +74,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>

--- a/examples/measurement/distance_createWithMouse_snapping_offsetCanvas.html
+++ b/examples/measurement/distance_createWithMouse_snapping_offsetCanvas.html
@@ -40,26 +40,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -75,6 +74,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>

--- a/examples/measurement/distance_createWithMouse_snapping_vbo_batching.html
+++ b/examples/measurement/distance_createWithMouse_snapping_vbo_batching.html
@@ -40,26 +40,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -75,6 +74,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>

--- a/examples/measurement/distance_createWithMouse_snapping_vbo_instancing.html
+++ b/examples/measurement/distance_createWithMouse_snapping_vbo_instancing.html
@@ -40,26 +40,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -75,6 +74,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>

--- a/examples/measurement/distance_createWithMouse_useRotationAdjustment.html
+++ b/examples/measurement/distance_createWithMouse_useRotationAdjustment.html
@@ -40,26 +40,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -75,6 +74,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
     </style>
 </head>

--- a/examples/measurement/distance_createWithTouch_snapping.html
+++ b/examples/measurement/distance_createWithTouch_snapping.html
@@ -40,26 +40,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -75,6 +74,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>

--- a/examples/measurement/distance_modelWithMeasurements.html
+++ b/examples/measurement/distance_modelWithMeasurements.html
@@ -40,26 +40,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -75,6 +74,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>

--- a/examples/measurement/distance_modelWithMeasurements_useRotationAdjustment.html
+++ b/examples/measurement/distance_modelWithMeasurements_useRotationAdjustment.html
@@ -40,26 +40,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -75,6 +74,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
     </style>
 </head>

--- a/examples/navigation/ContextMenu_Canvas_TreeViewPlugin_Custom.html
+++ b/examples/navigation/ContextMenu_Canvas_TreeViewPlugin_Custom.html
@@ -126,26 +126,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -161,6 +160,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>

--- a/examples/navigation/ContextMenu_dynamicItemTitles.html
+++ b/examples/navigation/ContextMenu_dynamicItemTitles.html
@@ -33,26 +33,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -68,6 +67,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>

--- a/examples/navigation/ContextMenu_dynamicItemVisibilities.html
+++ b/examples/navigation/ContextMenu_dynamicItemVisibilities.html
@@ -33,26 +33,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -68,6 +67,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>

--- a/examples/navigation/ContextMenu_subMenus.html
+++ b/examples/navigation/ContextMenu_subMenus.html
@@ -33,26 +33,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
             font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -68,6 +67,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>

--- a/examples/navigation/TreeViewPlugin_Containment_3DXML.html
+++ b/examples/navigation/TreeViewPlugin_Containment_3DXML.html
@@ -139,26 +139,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
-            font-weight: bold;
+            font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -174,6 +173,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>

--- a/examples/navigation/TreeViewPlugin_Containment_Federated.html
+++ b/examples/navigation/TreeViewPlugin_Containment_Federated.html
@@ -139,26 +139,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
-            font-weight: bold;
+            font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -174,6 +173,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>

--- a/examples/navigation/TreeViewPlugin_Types_Federated.html
+++ b/examples/navigation/TreeViewPlugin_Types_Federated.html
@@ -139,26 +139,25 @@
             padding: 0;
         }
 
-        .xeokit-context-menu ul li {
+        .xeokit-context-menu-item {
             list-style-type: none;
             padding-left: 10px;
             padding-right: 20px;
             padding-top: 4px;
             padding-bottom: 4px;
             color: black;
-            border-bottom: 1px solid gray;
             background: rgba(255, 255, 255, 0.46);
             cursor: pointer;
             width: calc(100% - 30px);
         }
 
-        .xeokit-context-menu ul li:hover {
+        .xeokit-context-menu-item:hover {
             background: black;
             color: white;
-            font-weight: bold;
+            font-weight: normal;
         }
 
-        .xeokit-context-menu ul li span {
+        .xeokit-context-menu-item span {
             display: inline-block;
         }
 
@@ -174,6 +173,24 @@
             cursor: default;
             background: #eeeeee;
             font-weight: normal;
+        }
+
+        .xeokit-context-menu-item-seperator {
+            background: rgba(0, 0, 0, 1);
+            height: 1px;
+            width: 100%;
+        }
+
+        .xeokit-context-menu-item-visible {
+            visibility: visible;
+            height: auto;
+            padding: null;
+        }
+
+        .xeokit-context-menu-item-hidden {
+            visibility: hidden;
+            height: 0;
+            padding: 0;
         }
 
     </style>

--- a/src/extras/ContextMenu/ContextMenu.js
+++ b/src/extras/ContextMenu/ContextMenu.js
@@ -1,4 +1,4 @@
-import {Map} from "../../viewer/scene/utils/Map.js";
+import { Map } from "../../viewer/scene/utils/Map.js";
 
 const idMap = new Map();
 
@@ -636,21 +636,27 @@ class ContextMenu {
                         if (itemSubMenu) {
 
                             html.push(
-                                '<li id="' + item.id + '" class="xeokit-context-menu-item" style="' +
-                                ((groupIdx === groupLen - 1) || ((j < lenj - 1)) ? 'border-bottom: 0' : 'border-bottom: 1px solid black') +
-                                '">' +
+                                '<li id="' + item.id + '" class="xeokit-context-menu-item">' +
                                 actionTitle +
                                 ' [MORE]' +
                                 '</li>');
+                            if (!((groupIdx === groupLen - 1) || (j < lenj - 1))) {
+                                html.push(
+                                    '<li id="' + item.id + '" class="xeokit-context-menu-item-seperator"></li>'
+                                );
+                            }
 
                         } else {
 
                             html.push(
-                                '<li id="' + item.id + '" class="xeokit-context-menu-item" style="' +
-                                ((groupIdx === groupLen - 1) || ((j < lenj - 1)) ? 'border-bottom: 0' : 'border-bottom: 1px solid black') +
-                                '">' +
+                                '<li id="' + item.id + '" class="xeokit-context-menu-item">' +
                                 actionTitle +
                                 '</li>');
+                            if (!((groupIdx === groupLen - 1) || (j < lenj - 1))) {
+                                html.push(
+                                    '<li id="' + item.id + '" class="xeokit-context-menu-item-seperator"></li>'
+                                );
+                            }
                         }
                     }
                 }
@@ -848,14 +854,13 @@ class ContextMenu {
             const shown = getShown(this._context);
             item.shown = shown;
             if (!shown) {
-                itemElement.style.visibility = "hidden";
-                itemElement.style.height = "0";
-                itemElement.style.padding = "0";
+                itemElement.classList.remove("xeokit-context-menu-item-visible");
+                itemElement.classList.add("xeokit-context-menu-item-hidden");
                 continue;
             } else {
-                itemElement.style.visibility = "visible";
-                itemElement.style.height = "auto";
-                itemElement.style.padding = null;
+                itemElement.classList.remove("ceokit-context-menu-item-hidden");
+                itemElement.classList.add("xeokit-context-menu-item-visible");
+
             }
             const enabled = getEnabled(this._context);
             item.enabled = enabled;
@@ -925,4 +930,4 @@ class ContextMenu {
     }
 }
 
-export {ContextMenu};
+export { ContextMenu };


### PR DESCRIPTION
Previously in the context menu, the separator between menu items was achieve by adding inline style of `border-bottom: 1px solid black;`.

Xeovision team needed the separator to be an independent li tag and that makes sense as well. Also, they were struggling with inline css styling that was added to menu items.

I have given the separator an independent li tag.

I have introduced 3 new classes:
1.`xeokit-context-menu-item-seperator` that is assigned to seperators in the menu
2. `xeokit-context-menu-item-visible` for items that are visible.
3. `xeokit-context-menu-item-hidden` for items that are hiddden.

@xeolabs @MichalDybizbanskiCreoox , this change will cause one problem for the users who are currently using context menus that is their hidden menu items will become visible because ContextMenu does not hide or show menu items, instead it toggles between the visible and hidden classes.

They will have to implement the visible and hidden classes like this:
`.xeokit-context-menu-item-visible {
    visibility: visible;
    height: auto;
    padding: null;
}

.xeokit-context-menu-item-hidden {
    visibility: hidden;
    height: 0;
    padding: 0;
}`

Reference ticket: XEOK-92