### PR TITLE
Add option for indeterminate checkbox in TreeViewPlugin

### DIFF
--- a/src/plugins/TreeViewPlugin/RenderService.js
+++ b/src/plugins/TreeViewPlugin/RenderService.js
@@ -135,11 +135,14 @@ export class RenderService {
     return element.checked;
   }
 
-  setCheckbox(nodeId, checked) {
+  setCheckbox(nodeId, checked, indeterminate = false) {
     const checkbox = document.getElementById(`checkbox-${nodeId}`);
     if (checkbox) {
       if (checked !== checkbox.checked) {
         checkbox.checked = checked;
+      }
+      if (indeterminate !== checkbox.indeterminate) {
+        checkbox.indeterminate = indeterminate;
       }
     }
   }

--- a/src/plugins/TreeViewPlugin/TreeViewPlugin.js
+++ b/src/plugins/TreeViewPlugin/TreeViewPlugin.js
@@ -453,8 +453,10 @@ export class TreeViewPlugin extends Plugin {
                 } else {
                     parent.numVisibleEntities--;
                 }
-
-                this._renderService.setCheckbox(parent.nodeId, (parent.numVisibleEntities > 0));
+                const indeterminate = this._showIndeterminate 
+                  && parent.numVisibleEntities > 0 
+                  && parent.numVisibleEntities < parent.numEntities;
+                this._renderService.setCheckbox(parent.nodeId, (parent.numVisibleEntities > 0), indeterminate);
 
                 parent = parent.parent;
             }
@@ -536,8 +538,10 @@ export class TreeViewPlugin extends Plugin {
                 } else {
                     parent.numVisibleEntities -= numUpdated;
                 }
-
-                this._renderService.setCheckbox(parent.nodeId, (parent.numVisibleEntities > 0));
+                const indeterminate = this._showIndeterminate 
+                  && parent.numVisibleEntities > 0 
+                  && parent.numVisibleEntities < parent.numEntities;
+                this._renderService.setCheckbox(parent.nodeId, (parent.numVisibleEntities > 0), indeterminate);
                 
                 parent = parent.parent;
             }

--- a/src/plugins/TreeViewPlugin/TreeViewPlugin.js
+++ b/src/plugins/TreeViewPlugin/TreeViewPlugin.js
@@ -361,6 +361,7 @@ export class TreeViewPlugin extends Plugin {
      * vertical World axis. For all hierarchy types, other node types will be ordered in the ascending alphanumeric order of their titles.
      * @param {Boolean} [cfg.pruneEmptyNodes=true] When true, will not contain nodes that don't have content in the {@link Scene}. These are nodes whose {@link MetaObject}s don't have {@link Entity}s.
      * @param {RenderService} [cfg.renderService] Optional {@link RenderService} to use. Defaults to the {@link TreeViewPlugin}'s default {@link RenderService}.
+     * @param {Boolean} [cfg.showIndeterminate=false] When true, will show indeterminate state for checkboxes when some but not all child nodes are checked
      */
     constructor(viewer, cfg = {}) {
 
@@ -412,6 +413,7 @@ export class TreeViewPlugin extends Plugin {
         this._pruneEmptyNodes = cfg.pruneEmptyNodes;
         this._showListItemElementId = null;
         this._renderService = cfg.renderService || new RenderService();
+        this._showIndeterminate = cfg.showIndeterminate ?? false;
 
         if (!this._renderService) {
             throw new Error('TreeViewPlugin: no render service set');

--- a/types/plugins/TreeViewPlugin/TreeViewPlugin.d.ts
+++ b/types/plugins/TreeViewPlugin/TreeViewPlugin.d.ts
@@ -19,6 +19,8 @@ export declare type TreeViewPluginConfiguration = {
   pruneEmptyNodes?: boolean;
   /** Optional {@link ITreeViewRenderService} to use. Defaults to the {@link TreeViewPlugin}'s default {@link RenderService}. */
   renderService?: ITreeViewRenderService;
+  /** When true, will show indeterminate state for checkboxes when some but not all child nodes are checked */
+  showIndeterminate?: boolean;
 };
 
 /**


### PR DESCRIPTION
Add option to TreeViewPlugin to indeterminate checkbox state for parent checkboxes when some but not all child checkboxes are checked. See https://creoox.atlassian.net/servicedesk/customer/portal/1/XCD-142 for more information.