### PR TITLE
Wrong id passed to collapseNode method

### DIFF
--- a/src/plugins/TreeViewPlugin/TreeViewPlugin.js
+++ b/src/plugins/TreeViewPlugin/TreeViewPlugin.js
@@ -783,8 +783,8 @@ export class TreeViewPlugin extends Plugin {
     collapse() {
         for (let i = 0, len = this._rootNodes.length; i < len; i++) {
             const rootNode = this._rootNodes[i];
-            const objectId = rootNode.objectId;
-            this._collapseNode(objectId);
+            const nodeId = rootNode.nodeId;
+            this._collapseNode(nodeId);
         }
     }
 


### PR DESCRIPTION
Root node objectId was passed to _collapseNode instead of nodeId and the tree wasn't collapsing on collapse method call.