### PR TITLE
Removed implementation of visible and hidden classes

### DIFF
--- a/examples/buildings/dotbim_BlenderHouse.html
+++ b/examples/buildings/dotbim_BlenderHouse.html
@@ -175,23 +175,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
     </style>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>

--- a/examples/buildings/dotbim_House.html
+++ b/examples/buildings/dotbim_House.html
@@ -175,23 +175,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
     </style>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>

--- a/examples/buildings/dotbim_MulticolorHouse.html
+++ b/examples/buildings/dotbim_MulticolorHouse.html
@@ -175,23 +175,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
     </style>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>

--- a/examples/buildings/dotbim_SmallHouse.html
+++ b/examples/buildings/dotbim_SmallHouse.html
@@ -175,23 +175,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
     </style>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>

--- a/examples/buildings/dotbim_Teapots.html
+++ b/examples/buildings/dotbim_Teapots.html
@@ -175,23 +175,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
     </style>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>

--- a/examples/buildings/dotbim_TestFaceColors.html
+++ b/examples/buildings/dotbim_TestFaceColors.html
@@ -179,23 +179,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
     </style>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>

--- a/examples/buildings/dotbim_TestStructure.html
+++ b/examples/buildings/dotbim_TestStructure.html
@@ -175,23 +175,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
     </style>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>

--- a/examples/buildings/xkt_manifest_Clinic.html
+++ b/examples/buildings/xkt_manifest_Clinic.html
@@ -174,23 +174,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
         .buttons {
             display: flex;

--- a/examples/buildings/xkt_manifest_KarhumakiBridge.html
+++ b/examples/buildings/xkt_manifest_KarhumakiBridge.html
@@ -174,23 +174,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
         .buttons {
             display: flex;

--- a/examples/buildings/xkt_manifest_KarhumakiBridge_hotlink.html
+++ b/examples/buildings/xkt_manifest_KarhumakiBridge_hotlink.html
@@ -174,23 +174,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
         .buttons {
             display: flex;

--- a/examples/buildings/xkt_manifest_KarhumakiBridge_inline.html
+++ b/examples/buildings/xkt_manifest_KarhumakiBridge_inline.html
@@ -174,23 +174,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
         .buttons {
             display: flex;

--- a/examples/buildings/xkt_manifest_KarhumakiBridge_inline_urls.html
+++ b/examples/buildings/xkt_manifest_KarhumakiBridge_inline_urls.html
@@ -174,23 +174,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
         .buttons {
             display: flex;

--- a/examples/buildings/xkt_manifest_WestRiverSideHospital.html
+++ b/examples/buildings/xkt_manifest_WestRiverSideHospital.html
@@ -174,23 +174,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
         .buttons {
             display: flex;

--- a/examples/buildings/xkt_vbo_federated_Clinic.html
+++ b/examples/buildings/xkt_vbo_federated_Clinic.html
@@ -174,23 +174,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
         .buttons {
             display: flex;

--- a/examples/cad/3DXML_Widget.html
+++ b/examples/cad/3DXML_Widget.html
@@ -175,23 +175,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/examples/measurement/angle_createWithMouse_nosnapping.html
+++ b/examples/measurement/angle_createWithMouse_nosnapping.html
@@ -76,23 +76,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/examples/measurement/angle_createWithMouse_snapping.html
+++ b/examples/measurement/angle_createWithMouse_snapping.html
@@ -76,23 +76,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/examples/measurement/angle_createWithMouse_snapping_canvasToPagePos.html
+++ b/examples/measurement/angle_createWithMouse_snapping_canvasToPagePos.html
@@ -76,23 +76,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/examples/measurement/angle_createWithMouse_snapping_offsetCanvas.html
+++ b/examples/measurement/angle_createWithMouse_snapping_offsetCanvas.html
@@ -76,23 +76,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/examples/measurement/angle_modelWithMeasurements.html
+++ b/examples/measurement/angle_modelWithMeasurements.html
@@ -76,23 +76,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/examples/measurement/distance_createWithMouse_labelsNotOnWires.html
+++ b/examples/measurement/distance_createWithMouse_labelsNotOnWires.html
@@ -76,23 +76,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/examples/measurement/distance_createWithMouse_nosnapping.html
+++ b/examples/measurement/distance_createWithMouse_nosnapping.html
@@ -76,23 +76,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
     </style>
 </head>
 

--- a/examples/measurement/distance_createWithMouse_scenegraph.html
+++ b/examples/measurement/distance_createWithMouse_scenegraph.html
@@ -76,23 +76,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/examples/measurement/distance_createWithMouse_scenegraph_OBB.html
+++ b/examples/measurement/distance_createWithMouse_scenegraph_OBB.html
@@ -76,23 +76,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/examples/measurement/distance_createWithMouse_snapping.html
+++ b/examples/measurement/distance_createWithMouse_snapping.html
@@ -76,23 +76,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/examples/measurement/distance_createWithMouse_snapping_OpenProject_Hospital.html
+++ b/examples/measurement/distance_createWithMouse_snapping_OpenProject_Hospital.html
@@ -76,23 +76,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/examples/measurement/distance_createWithMouse_snapping_canvasToPagePos.html
+++ b/examples/measurement/distance_createWithMouse_snapping_canvasToPagePos.html
@@ -76,23 +76,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/examples/measurement/distance_createWithMouse_snapping_dtx_batching.html
+++ b/examples/measurement/distance_createWithMouse_snapping_dtx_batching.html
@@ -76,23 +76,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/examples/measurement/distance_createWithMouse_snapping_dtx_instancing.html
+++ b/examples/measurement/distance_createWithMouse_snapping_dtx_instancing.html
@@ -76,23 +76,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/examples/measurement/distance_createWithMouse_snapping_offsetCanvas.html
+++ b/examples/measurement/distance_createWithMouse_snapping_offsetCanvas.html
@@ -76,23 +76,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/examples/measurement/distance_createWithMouse_snapping_vbo_batching.html
+++ b/examples/measurement/distance_createWithMouse_snapping_vbo_batching.html
@@ -76,23 +76,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/examples/measurement/distance_createWithMouse_snapping_vbo_instancing.html
+++ b/examples/measurement/distance_createWithMouse_snapping_vbo_instancing.html
@@ -76,23 +76,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/examples/measurement/distance_createWithMouse_useRotationAdjustment.html
+++ b/examples/measurement/distance_createWithMouse_useRotationAdjustment.html
@@ -76,23 +76,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
     </style>
 </head>
 

--- a/examples/measurement/distance_createWithTouch_snapping.html
+++ b/examples/measurement/distance_createWithTouch_snapping.html
@@ -76,23 +76,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/examples/measurement/distance_modelWithMeasurements.html
+++ b/examples/measurement/distance_modelWithMeasurements.html
@@ -76,23 +76,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/examples/measurement/distance_modelWithMeasurements_useRotationAdjustment.html
+++ b/examples/measurement/distance_modelWithMeasurements_useRotationAdjustment.html
@@ -76,23 +76,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
     </style>
 </head>
 

--- a/examples/navigation/ContextMenu_Canvas_TreeViewPlugin_Custom.html
+++ b/examples/navigation/ContextMenu_Canvas_TreeViewPlugin_Custom.html
@@ -162,23 +162,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/examples/navigation/ContextMenu_dynamicItemTitles.html
+++ b/examples/navigation/ContextMenu_dynamicItemTitles.html
@@ -69,23 +69,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/examples/navigation/ContextMenu_dynamicItemVisibilities.html
+++ b/examples/navigation/ContextMenu_dynamicItemVisibilities.html
@@ -69,23 +69,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/examples/navigation/ContextMenu_subMenus.html
+++ b/examples/navigation/ContextMenu_subMenus.html
@@ -69,23 +69,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/examples/navigation/TreeViewPlugin_Containment_3DXML.html
+++ b/examples/navigation/TreeViewPlugin_Containment_3DXML.html
@@ -175,23 +175,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/examples/navigation/TreeViewPlugin_Containment_Federated.html
+++ b/examples/navigation/TreeViewPlugin_Containment_Federated.html
@@ -175,23 +175,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/examples/navigation/TreeViewPlugin_Types_Federated.html
+++ b/examples/navigation/TreeViewPlugin_Types_Federated.html
@@ -175,23 +175,13 @@
             font-weight: normal;
         }
 
-        .xeokit-context-menu-item-seperator {
+        .xeokit-context-menu-item-separator {
             background: rgba(0, 0, 0, 1);
             height: 1px;
             width: 100%;
         }
 
-        .xeokit-context-menu-item-visible {
-            visibility: visible;
-            height: auto;
-            padding: null;
-        }
-
-        .xeokit-context-menu-item-hidden {
-            visibility: hidden;
-            height: 0;
-            padding: 0;
-        }
+        
 
     </style>
 </head>

--- a/src/extras/ContextMenu/ContextMenu.js
+++ b/src/extras/ContextMenu/ContextMenu.js
@@ -642,7 +642,7 @@ class ContextMenu {
                                 '</li>');
                             if (!((groupIdx === groupLen - 1) || (j < lenj - 1))) {
                                 html.push(
-                                    '<li id="' + item.id + '" class="xeokit-context-menu-item-seperator"></li>'
+                                    '<li id="' + item.id + '" class="xeokit-context-menu-item-separator"></li>'
                                 );
                             }
 
@@ -654,7 +654,7 @@ class ContextMenu {
                                 '</li>');
                             if (!((groupIdx === groupLen - 1) || (j < lenj - 1))) {
                                 html.push(
-                                    '<li id="' + item.id + '" class="xeokit-context-menu-item-seperator"></li>'
+                                    '<li id="' + item.id + '" class="xeokit-context-menu-item-separator"></li>'
                                 );
                             }
                         }
@@ -854,12 +854,10 @@ class ContextMenu {
             const shown = getShown(this._context);
             item.shown = shown;
             if (!shown) {
-                itemElement.classList.remove("xeokit-context-menu-item-visible");
-                itemElement.classList.add("xeokit-context-menu-item-hidden");
+                itemElement.style.display = "none";
                 continue;
             } else {
-                itemElement.classList.remove("ceokit-context-menu-item-hidden");
-                itemElement.classList.add("xeokit-context-menu-item-visible");
+                itemElement.style.display = "";
 
             }
             const enabled = getEnabled(this._context);


### PR DESCRIPTION
Fixed the class name used for separator in context menu item from `.xeokit-context-menu-item-seperator` to `.xeokit-context-menu-item-separator`.

Removed classes that were previously added for hidden and visible menu elements.