### PR TITLE
Add navigation examples

### DIFF
--- a/examples/measurement/index.html
+++ b/examples/measurement/index.html
@@ -265,7 +265,7 @@
             ["distance_createWithMouse_snapping_offsetCanvas", "Click with mouse on model to create distance measurements, snapping enabled, offset canvas"],
             ["distance_createWithMouse_snapping_Lyon", "Click with mouse on model to create distance measurements, snapping enabled"],
             ["distance_createWithMouse_labelsNotOnWires", "Click with mouse on model to create distance measurements, snapping enabled, labels one below the other"],
-
+            ["distance_createWithMouse_useRotationAdjustment", "Click with mouse on model to create distance measurements, snapping enabled, rotation adjusted, labels one below the other"],
             "# Creating distance measurements with mouse, snapping disabled",
             ["distance_createWithMouse_nosnapping", "Click with mouse on model to create distance measurements, snapping disabled"]
         ],
@@ -279,6 +279,7 @@
             "# Creating distance measurements programmatically",
             ["distance_modelWithMeasurements", "Creating distance measurements programmatically"],
             ["distance_modelWithMeasurements_hideAxisWires", "BIM model with distance measurements and axis-aligned wires hidden"],
+            ["distance_modelWithMeasurements_useRotationAdjustment", "BIM model with distance measurements and rotation adjustment"],
             ["distance_unitsAndScale", "BIM model with configured units (see source code)"]
         ],
 

--- a/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
+++ b/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
@@ -366,6 +366,16 @@ class DistanceMeasurement extends Component {
         const scene = this.plugin.viewer.scene;
 
         if (this._wpDirty) {
+            const delta = math.subVec3(
+                this._targetWorld,
+                this._originWorld,
+                tmpVec3
+            );
+
+            /**
+             * The length detected for each measurement axis.
+             */
+            this._factors = math.transformVec3(this._axesBasis, delta);
 
             this._measurementOrientation = determineMeasurementOrientation(this._originWorld, this._targetWorld, 0);
             if(this._measurementOrientation === 'Vertical' && this.useRotationAdjustment){
@@ -390,16 +400,6 @@ class DistanceMeasurement extends Component {
                 this._wp[15] = 1.0;
             }
             else {
-                const delta = math.subVec3(
-                    this._targetWorld,
-                    this._originWorld,
-                    tmpVec3
-                );
-
-                /**
-                 * The length detected for each measurement axis.
-                 */
-                this._factors = math.transformVec3(this._axesBasis, delta);
 
                 this._wp[0] = this._originWorld[0];
                 this._wp[1] = this._originWorld[1];


### PR DESCRIPTION
Fixed `this._factors` being `undefined` when adding vertical measurements.

Added missing navigation examples that show the usage of `useRotationAdjustment` in distance measurement plugin.