### PR TITLE
Fix: update VBOBatchingTrianglesBuffer constructor 

### DIFF
--- a/src/viewer/scene/model/vbo/batching/triangles/VBOBatchingTrianglesBuffer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/VBOBatchingTrianglesBuffer.js
@@ -7,9 +7,9 @@ const configs = new Configs();
  */
 export class VBOBatchingTrianglesBuffer {
 
-    constructor() {
-        this.maxVerts = configs.maxGeometryBatchSize;
-        this.maxIndices = configs.maxGeometryBatchSize * 3; // Rough rule-of-thumb
+    constructor(maxBatchSize = configs.maxGeometryBatchSize) {
+        this.maxVerts = maxBatchSize;
+        this.maxIndices = maxBatchSize * 3; // Rough rule-of-thumb
         this.positions = [];
         this.colors = [];
         this.uv = [];


### PR DESCRIPTION
fix: expose maxGeometryBatchSize as parameter in the `VBOBatchingTrianglesBuffer` constructor.
`VBOBatchingTrianglesBuffer` is instantiated [here](https://github.com/xeokit/xeokit-sdk/blob/2e1c208ec047bd7cb8120deb35bb2b526afea43c/src/viewer/scene/model/vbo/batching/triangles/VBOBatchingTrianglesLayer.js#L72) passing the `maxGeometryBatchSize` taken from the provided `cfg` object. But before this fix`VBOBatchingTrianglesBuffer` was ignoring it.