### PR TITLE
Fix ShowNode method in TreeViewPlugin does not collapse the tree

### DIFF
--- a/src/plugins/TreeViewPlugin/TreeViewPlugin.js
+++ b/src/plugins/TreeViewPlugin/TreeViewPlugin.js
@@ -701,6 +701,8 @@ export class TreeViewPlugin extends Plugin {
             return; // Node may not exist for the given object if (this._pruneEmptyNodes == true)
         }
 
+        this.collapse();
+
         const nodeId = node.nodeId;
 
         const switchElement = this._renderService.getSwitchElement(nodeId);


### PR DESCRIPTION
The TreeViewPlugin's documentation says that if you call `ShowNode` method with an object, it will first collapse the tree, then expand and scroll the node into view. However, the collapsing was not implement. 

Collapsing of TreeViewNode was added in this PR.

Reference Ticket number: XEOK-101