### PR TITLE
fix: use css class to mark submenu

### DIFF
--- a/src/extras/ContextMenu/ContextMenu.js
+++ b/src/extras/ContextMenu/ContextMenu.js
@@ -636,9 +636,8 @@ class ContextMenu {
                         if (itemSubMenu) {
 
                             html.push(
-                                '<li id="' + item.id + '" class="xeokit-context-menu-item">' +
+                                '<li id="' + item.id + '" class="xeokit-context-menu-item xeokit-context-menu-submenu">' +
                                 actionTitle +
-                                ' [MORE]' +
                                 '</li>');
                             if (!((groupIdx === groupLen - 1) || (j < lenj - 1))) {
                                 html.push(


### PR DESCRIPTION
Marking sub menu items with class gives a possibility to add custom styles for menu items with sub menus
 
<img width="904" alt="image" src="https://github.com/user-attachments/assets/94e2851f-7b84-48d1-aefd-80377c02c690">
