### PR TITLE
Update indeterminate state in TreeViewPlugin

### DIFF
--- a/src/plugins/TreeViewPlugin/RenderService.js
+++ b/src/plugins/TreeViewPlugin/RenderService.js
@@ -143,6 +143,9 @@ export class RenderService {
       }
       if (indeterminate !== checkbox.indeterminate) {
         checkbox.indeterminate = indeterminate;
+        if (indeterminate) {
+          checkbox.checked = false;
+        }
       }
     }
   }


### PR DESCRIPTION
This PR updates the checkbox indeterminate state that was introduced in #1642 to also clear the `checked` property from checkbox. Previously, the checkbox could enter a state where it had both the `checked` and `indeterminate` properties set to `true`.

See https://creoox.atlassian.net/servicedesk/customer/portal/1/XCD-142 for more information.