### PR TITLE
Return created SceneModelEntity in SceneModel.createEntity method

### DIFF
--- a/src/viewer/scene/model/SceneModel.js
+++ b/src/viewer/scene/model/SceneModel.js
@@ -3492,7 +3492,7 @@ export class SceneModel extends Component {
             flags = flags | ENTITY_FLAGS.SELECTED;
         }
         cfg.flags = flags;
-        this._createEntity(cfg);
+        return this._createEntity(cfg);
     }
 
     _createEntity(cfg) {
@@ -3523,6 +3523,7 @@ export class SceneModel extends Component {
         this._entities[cfg.id] = entity;
         this._entitiesToFinalize.push(entity);
         this.numEntities++;
+        return entity;
     }
 
     /**


### PR DESCRIPTION
For one of the features that I am working on, we need user to be able to set some properties on the SceneModelEntity, but when I create an entity using SceneModel.createEntity, it does not return the create SceneModelEntity.

I have introduced this change so that user can control the parameters of the created SceneModelEntity.