### PR TITLE
XEOK-114 Fix wrong aabb value after rotating a model

### DIFF
--- a/src/viewer/scene/model/SceneModelMesh.js
+++ b/src/viewer/scene/model/SceneModelMesh.js
@@ -375,6 +375,15 @@ export class SceneModelMesh {
      */
     set aabb(aabb) { // Called by SceneModel
         this._aabbLocal = aabb;
+        if (this.origin) {
+            const origin = this.origin;
+            this._aabbLocal[0] += origin[0];
+            this._aabbLocal[1] += origin[1];
+            this._aabbLocal[2] += origin[2];
+            this._aabbLocal[3] += origin[0];
+            this._aabbLocal[4] += origin[1];
+            this._aabbLocal[5] += origin[2];
+        }
     }
 
     /**
@@ -390,15 +399,6 @@ export class SceneModelMesh {
             } else {
                 math.transformOBB3(this.model.worldMatrix, tempOBB3, tempOBB3b);
                 math.OBB3ToAABB3(tempOBB3b, this._aabbWorld);
-            }
-            if (this.origin) {
-                const origin = this.origin;
-                this._aabbWorld[0] += origin[0];
-                this._aabbWorld[1] += origin[1];
-                this._aabbWorld[2] += origin[2];
-                this._aabbWorld[3] += origin[0];
-                this._aabbWorld[4] += origin[1];
-                this._aabbWorld[5] += origin[2];
             }
             this._aabbWorldDirty = false;
         }


### PR DESCRIPTION
This PR fixes https://github.com/xeokit/xeokit-sdk/issues/1316
It changes the value previously returned by the `SceneModelMesh::aabb` getter to a correct one.
Hopefully no calling code compensates for its previous incorrectness, which now would result in a wrong computation.