### PR TITLE
XEOK-115 Fix object.numPrimitives and numTriangles are NaN #1671

### DIFF
--- a/src/viewer/scene/model/SceneModel.js
+++ b/src/viewer/scene/model/SceneModel.js
@@ -3129,6 +3129,7 @@ export class SceneModel extends Component {
             cfg.meshMatrix = cfg.transform.worldMatrix;
         }
         mesh.portionId = mesh.layer.createPortion(mesh, cfg);
+        mesh.numPrimitives = cfg.numPrimitives;
         this._meshes[cfg.id] = mesh;
         this._unusedMeshes[cfg.id] = mesh;
         this._meshList.push(mesh);


### PR DESCRIPTION
Originally reported at https://github.com/xeokit/xeokit-sdk/issues/1671