### PR TITLE
[FIX] Fixing the glbTreeViewPlugin.html behaviour by using autoMetaModel

### DIFF
--- a/examples/lidar/glb_TreeViewPlugin.html
+++ b/examples/lidar/glb_TreeViewPlugin.html
@@ -129,13 +129,6 @@
     <img class="info-icon" src="../../assets/images/gltf_logo.png"/>
     <h1>GLTFLoaderPlugin & TreeViewPlugin</h1>
     <h2>Making a LiDAR scan appear in the TreeViewPlugin</h2>
-    <p>The GLTFLoader's <b>elementId</b> parameter causes
-        the entire model to be loaded into a single Entity that gets this ID.</p>
-       <p>In conjunction with that parameter, we can also
-        use the GLTFLoaderPlugin's <b>metaModelJSON</b> parameter to create a MetaModel with a MetaObject that corresponds
-           to that Entity.</p>
-    <p>The TreeViewPlugin is then able to have a node that represents the LiDAR model and controls the
-        visibility of that Entity.</p>
     <h3>Stats</h3>
     <ul>
         <li>
@@ -224,11 +217,6 @@
 
     //----------------------------------------------------------------------------------------------------------------------
     // Load a model and fit it to view
-    //
-    // - Specify an `elementId` parameter, which causes the entire model to be loaded into a single Entity that gets this ID.
-    // - Specify a `metaModelJSON` parameter, which creates a MetaModel with two MetaObjects, one of which corresponds
-    //   to our Entity. Then the TreeViewPlugin is able to have a node that can represent the model and control the
-    //   visibility of the Entity.
     //----------------------------------------------------------------------------------------------------------------------
 
     const gltfLoader = new GLTFLoaderPlugin(viewer);

--- a/examples/lidar/glb_TreeViewPlugin.html
+++ b/examples/lidar/glb_TreeViewPlugin.html
@@ -236,25 +236,7 @@
     const sceneModel = gltfLoader.load({ // Creates a SceneModel with ID "myScanModel"
         id: "myScanModel",
         src: "../../assets/models/gltf/GLBSample/public-use-sample-apartment.glb",
-
-        entityId: "3toKckUfH2jBmd$7uhJHa4",  // Creates an Entity with this ID
-
-        metaModelJSON: { // Creates a MetaModel with ID "myScanModel"
-            "metaObjects": [
-                {
-                    "id": "3toKckUfH2jBmd$7uhJHa6", // Creates a MetaObject with this ID
-                    "name": "My Project",
-                    "type": "Default",
-                    "parent": null
-                },
-                {
-                    "id": "3toKckUfH2jBmd$7uhJHa4", // Creates a MetaObject with this ID (same ID as our Entity)
-                    "name": "My Scan",
-                    "type": "Default",
-                    "parent": "3toKckUfH2jBmd$7uhJHa6"
-                }
-            ]
-        }
+        autoMetaModel:true
     });
 
     const t0 = performance.now();


### PR DESCRIPTION
Hello,

this PR solves the problem with this particular example described in XCD-159 by using autoMetaModel: true instead of creating your own meta model manually.

It only solves this particular example file. It doesn't fix the fact, that there is some regression made somewhere in between 26.07.2024 and 31.07.2024 commits. Question if it should be also fixed separately.