### PR TITLE
[IMPROVEMENT]: Simpler and more robust obtention of mouse canvas coordinates

### DIFF
--- a/src/viewer/scene/input/Input.js
+++ b/src/viewer/scene/input/Input.js
@@ -1300,15 +1300,11 @@ class Input extends Component {
             this.mouseCanvasPos[1] = event.y;
         } else {
             let element = event.target;
-            let totalOffsetLeft = 0;
-            let totalOffsetTop = 0;
-            while (element.offsetParent) {
-                totalOffsetLeft += element.offsetLeft;
-                totalOffsetTop += element.offsetTop;
-                element = element.offsetParent;
-            }
-            this.mouseCanvasPos[0] = event.pageX - totalOffsetLeft;
-            this.mouseCanvasPos[1] = event.pageY - totalOffsetTop;
+
+            const rect = element.getBoundingClientRect();
+
+            this.mouseCanvasPos[0] = event.clientX - rect.left;
+            this.mouseCanvasPos[1] = event.clientY - rect.top;
         }
     }
 


### PR DESCRIPTION
## Description

The code in `Input.js::_getMouseCanvasPos()` has been refactored to use a combination of `pageX` / `pageY` attributes together with `getBoundingClientRect`.

This PR unifies the calculation of mouse coordinates relative to the canvas by making sure the input variables to the calculation are all based in the viewport:

- according to MDN, [`mouseEvent.clientX`](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/clientX) and [`mouseEvent.clientY`](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/clientY) return the mouse coordinates in the viewport coordinate system

- also, the [`Element.getBoundingClientRect`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect) function returns the bbox of a given element (in this case the canvas) in the viewport coordinate system

This allows for a very simple way to obtain the mouse coordinates relative to the canvas.

This change is tested to work really well in the following scenarios (some of them not supported by current code in `Input.js`):

- the main canvas is inside a cascade of different div elements each defining `top`/`left` CSS properties and having a combination of `position: fixed` and `position: absolute`.

- the main canvas is placed inside a div and the body has scroll enabled

@xeolabs if you have some specific check in mind I can do before merging this just let me know 😃 

But I think the code looks super simple now and it's robust thanks to `ev.clientX` / `ev.clientY` / `getBoundingClientRect` to be based all in viewport coordinates 😊.