### PR TITLE
Fix rotation transformation in getEachVertex.

### DIFF
--- a/src/viewer/scene/math/rtcCoords.js
+++ b/src/viewer/scene/math/rtcCoords.js
@@ -130,9 +130,9 @@ function rtcToWorldPos(rtcCenter, rtcPos, worldPos) {
  * @param rtcPlanePos
  * @returns {*}
  */
-function getPlaneRTCPos(dist, dir, rtcOrigin, rtcPlanePos, rotationMatrixConjugate) {
-    const rtcCenter = (rotationMatrixConjugate
-                       ? (tempVec4.set(rtcOrigin, 0), tempVec4[3] = 1, math.mulMat4v4(rotationMatrixConjugate, tempVec4, tempVec4))
+function getPlaneRTCPos(dist, dir, rtcOrigin, rtcPlanePos, rotationMatrix) {
+    const rtcCenter = (rotationMatrix
+                       ? (tempVec4.set(rtcOrigin, 0), tempVec4[3] = 1, math.mulMat4v4(rotationMatrix, tempVec4, tempVec4))
                        : rtcOrigin);
     const rtcCenterToPlaneDist = math.dotVec3(dir, rtcCenter) + dist;
     const dirNormalized = math.normalizeVec3(dir, tempVec3a);

--- a/src/viewer/scene/model/SceneModel.js
+++ b/src/viewer/scene/model/SceneModel.js
@@ -1605,7 +1605,7 @@ export class SceneModel extends Component {
         if (this._matrixDirty) {
             math.quaternionToRotationMat4(this._quaternion, this._worldRotationMatrix);
             math.conjugateQuaternion(this._quaternion, this._conjugateQuaternion);
-            math.quaternionToRotationMat4(this._quaternion, this._worldRotationMatrixConjugate);
+            math.quaternionToRotationMat4(this._conjugateQuaternion, this._worldRotationMatrixConjugate);
             this._matrix.set(this._worldRotationMatrix);
             math.translateMat4v(this._position, this._matrix);
             this._matrixDirty = false;

--- a/src/viewer/scene/model/dtx/lines/renderers/DTXLinesColorRenderer.js
+++ b/src/viewer/scene/model/dtx/lines/renderers/DTXLinesColorRenderer.js
@@ -81,7 +81,7 @@ export class DTXLinesColorRenderer {
             rtcViewMatrix = viewMatrix;
         }
 
-        gl.uniformMatrix4fv(this._uSceneModelMatrix, false, rotationMatrixConjugate);
+        gl.uniformMatrix4fv(this._uSceneModelMatrix, false, rotationMatrix);
         gl.uniformMatrix4fv(this._uViewMatrix, false, rtcViewMatrix);
         gl.uniformMatrix4fv(this._uProjMatrix, false, camera.projMatrix);
         gl.uniform1i(this._uRenderPass, renderPass);
@@ -106,7 +106,7 @@ export class DTXLinesColorRenderer {
                         if (active) {
                             const sectionPlane = sectionPlanes[sectionPlaneIndex];
                             if (origin) {
-                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrixConjugate);
+                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrix);
                                 gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
                             } else {
                                 gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);

--- a/src/viewer/scene/model/dtx/triangles/DTXTrianglesLayer.js
+++ b/src/viewer/scene/model/dtx/triangles/DTXTrianglesLayer.js
@@ -1122,8 +1122,8 @@ export class DTXTrianglesLayer {
                 worldPos[2] = positions[i + 2];
                 worldPos[3] = 1.0;
                 math.decompressPosition(worldPos, positionsDecodeMatrix);
-                math.transformPoint4(this.model.worldMatrix, worldPos);
-                math.transformPoint4(this.model.worldMatrix, worldPos);
+                math.transformPoint4(this.model.worldMatrix, worldPos, worldPos);
+                math.transformPoint4(this.model.worldMatrix, worldPos, worldPos);
                 worldPos[0] += offsetX;
                 worldPos[1] += offsetY;
                 worldPos[2] += offsetZ;

--- a/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesColorRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesColorRenderer.js
@@ -93,7 +93,7 @@ export class DTXTrianglesColorRenderer {
             rtcCameraEye = camera.eye;
         }
 
-        gl.uniformMatrix4fv(this._uSceneModelMatrix, false, rotationMatrixConjugate);
+        gl.uniformMatrix4fv(this._uSceneModelMatrix, false, rotationMatrix);
         gl.uniformMatrix4fv(this._uViewMatrix, false, rtcViewMatrix);
         gl.uniformMatrix4fv(this._uProjMatrix, false, camera.projMatrix);
         gl.uniform3fv(this._uCameraEyeRtc, rtcCameraEye);
@@ -119,7 +119,7 @@ export class DTXTrianglesColorRenderer {
                         if (active) {
                             const sectionPlane = sectionPlanes[sectionPlaneIndex];
                             if (origin) {
-                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrixConjugate);
+                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrix);
                                 gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
                             } else {
                                 gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);

--- a/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesDepthRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesDepthRenderer.js
@@ -88,7 +88,7 @@ export class DTXTrianglesDepthRenderer {
             rtcCameraEye = camera.eye;
         }
 
-        gl.uniformMatrix4fv(this._uSceneModelMatrix, false, rotationMatrixConjugate);
+        gl.uniformMatrix4fv(this._uSceneModelMatrix, false, rotationMatrix);
         gl.uniformMatrix4fv(this._uViewMatrix, false, rtcViewMatrix);
         gl.uniformMatrix4fv(this._uProjMatrix, false, camera.projMatrix);
         gl.uniform3fv(this._uCameraEyeRtc, rtcCameraEye);
@@ -114,7 +114,7 @@ export class DTXTrianglesDepthRenderer {
                         if (active) {
                             const sectionPlane = sectionPlanes[sectionPlaneIndex];
                             if (origin) {
-                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrixConjugate);
+                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrix);
                                 gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
                             } else {
                                 gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);

--- a/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesEdgesColorRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesEdgesColorRenderer.js
@@ -81,7 +81,7 @@ export class DTXTrianglesEdgesColorRenderer {
         }
 
         gl.uniform1i(this._uRenderPass, renderPass);
-        gl.uniformMatrix4fv(this._uSceneModelMatrix, false, rotationMatrixConjugate);
+        gl.uniformMatrix4fv(this._uSceneModelMatrix, false, rotationMatrix);
         gl.uniformMatrix4fv(this._uViewMatrix, false, rtcViewMatrix);
         gl.uniformMatrix4fv(this._uProjMatrix, false, camera.projMatrix);
 
@@ -100,7 +100,7 @@ export class DTXTrianglesEdgesColorRenderer {
                         if (active) {
                             const sectionPlane = sectionPlanes[sectionPlaneIndex];
                             if (origin) {
-                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrixConjugate);
+                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrix);
                                 gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
                             } else {
                                 gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);

--- a/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesEdgesRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesEdgesRenderer.js
@@ -86,7 +86,7 @@ export class DTXTrianglesEdgesRenderer {
         }
 
         gl.uniform1i(this._uRenderPass, renderPass);
-        gl.uniformMatrix4fv(this._uSceneModelMatrix, false, rotationMatrixConjugate);
+        gl.uniformMatrix4fv(this._uSceneModelMatrix, false, rotationMatrix);
         gl.uniformMatrix4fv(this._uViewMatrix, false, rtcViewMatrix);
         gl.uniformMatrix4fv(this._uProjMatrix, false, camera.projMatrix);
 
@@ -127,7 +127,7 @@ export class DTXTrianglesEdgesRenderer {
                         if (active) {
                             const sectionPlane = sectionPlanes[sectionPlaneIndex];
                             if (origin) {
-                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrixConjugate);
+                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrix);
                                 gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
                             } else {
                                 gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);

--- a/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesNormalsRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesNormalsRenderer.js
@@ -84,7 +84,7 @@ export class DTXTrianglesNormalsRenderer {
 
         gl.uniform1i(this._uRenderPass, renderPass);
 
-        gl.uniformMatrix4fv(this._uWorldMatrix, false, rotationMatrixConjugate);
+        gl.uniformMatrix4fv(this._uWorldMatrix, false, rotationMatrix);
         gl.uniformMatrix4fv(this._uViewMatrix, false, rtcViewMatrix);
         gl.uniformMatrix4fv(this._uProjMatrix, false, camera.projMatrix);
 
@@ -106,7 +106,7 @@ export class DTXTrianglesNormalsRenderer {
                         if (active) {
                             const sectionPlane = sectionPlanes[sectionPlaneIndex];
                             if (origin) {
-                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrixConjugate);
+                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrix);
                                 gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
                             } else {
                                 gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);

--- a/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesOcclusionRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesOcclusionRenderer.js
@@ -96,7 +96,7 @@ export class DTXTrianglesOcclusionRenderer {
 
         gl.uniform3fv(this._uCameraEyeRtc, rtcCameraEye);
         gl.uniform1i(this._uRenderPass, renderPass);
-        gl.uniformMatrix4fv(this._uWorldMatrix, false, rotationMatrixConjugate);
+        gl.uniformMatrix4fv(this._uWorldMatrix, false, rotationMatrix);
         gl.uniformMatrix4fv(this._uViewMatrix, false, rtcViewMatrix);
 
         gl.uniformMatrix4fv(this._uProjMatrix, false, camera.projMatrix);
@@ -121,7 +121,7 @@ export class DTXTrianglesOcclusionRenderer {
                         if (active) {
                             const sectionPlane = sectionPlanes[sectionPlaneIndex];
                             if (origin) {
-                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrixConjugate);
+                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrix);
                                 gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
                             } else {
                                 gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);

--- a/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesPickDepthRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesPickDepthRenderer.js
@@ -102,7 +102,7 @@ export class DTXTrianglesPickDepthRenderer {
         gl.uniform2f(this._uDrawingBufferSize, gl.drawingBufferWidth, gl.drawingBufferHeight);
         gl.uniform1f(this._uPickZNear, frameCtx.pickZNear);
         gl.uniform1f(this._uPickZFar, frameCtx.pickZFar);
-        gl.uniformMatrix4fv(this._uSceneModelMatrix, false, rotationMatrixConjugate);
+        gl.uniformMatrix4fv(this._uSceneModelMatrix, false, rotationMatrix);
         gl.uniformMatrix4fv(this._uViewMatrix, false, rtcViewMatrix);
         gl.uniformMatrix4fv(this._uProjMatrix, false, projMatrix);
         if (scene.logarithmicDepthBufferEnabled) {
@@ -125,7 +125,7 @@ export class DTXTrianglesPickDepthRenderer {
                         if (active) {
                             const sectionPlane = sectionPlanes[sectionPlaneIndex];
                             if (origin) {
-                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrixConjugate);
+                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrix);
                                 gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
                             } else {
                                 gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);

--- a/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesPickMeshRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesPickMeshRenderer.js
@@ -88,7 +88,7 @@ export class DTXTrianglesPickMeshRenderer {
         }
         gl.uniform2fv(this._uPickClipPos, frameCtx.pickClipPos);
         gl.uniform2f(this._uDrawingBufferSize, gl.drawingBufferWidth, gl.drawingBufferHeight);
-        gl.uniformMatrix4fv(this._uSceneModelMatrix, false, rotationMatrixConjugate);
+        gl.uniformMatrix4fv(this._uSceneModelMatrix, false, rotationMatrix);
         gl.uniformMatrix4fv(this._uViewMatrix, false, rtcViewMatrix);
         gl.uniformMatrix4fv(this._uProjMatrix, false, projMatrix);
         gl.uniform3fv(this._uCameraEyeRtc, rtcCameraEye);
@@ -112,7 +112,7 @@ export class DTXTrianglesPickMeshRenderer {
                         if (active) {
                             const sectionPlane = sectionPlanes[sectionPlaneIndex];
                             if (origin) {
-                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrixConjugate);
+                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrix);
                                 gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
                             } else {
                                 gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);

--- a/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesPickNormalsFlatRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesPickNormalsFlatRenderer.js
@@ -99,7 +99,7 @@ export class DTXTrianglesPickNormalsFlatRenderer {
         }
         gl.uniform2fv(this._uPickClipPos, frameCtx.pickClipPos);
         gl.uniform2f(this._uDrawingBufferSize, gl.drawingBufferWidth, gl.drawingBufferHeight);
-        gl.uniformMatrix4fv(this._uSceneModelMatrix, false, rotationMatrixConjugate);
+        gl.uniformMatrix4fv(this._uSceneModelMatrix, false, rotationMatrix);
         gl.uniformMatrix4fv(this._uViewMatrix, false, rtcViewMatrix);
         gl.uniformMatrix4fv(this._uProjMatrix, false, projMatrix);
         gl.uniform3fv(this._uCameraEyeRtc, rtcCameraEye);
@@ -123,7 +123,7 @@ export class DTXTrianglesPickNormalsFlatRenderer {
                         if (active) {
                             const sectionPlane = sectionPlanes[sectionPlaneIndex];
                             if (origin) {
-                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrixConjugate);
+                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrix);
                                 gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
                             } else {
                                 gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);

--- a/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesPickNormalsRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesPickNormalsRenderer.js
@@ -32,7 +32,7 @@ export class DTXTrianglesPickNormalsRenderer {
         const state = dataTextureLayer._state;
         const textureState = state.textureState;
         const origin = dataTextureLayer._state.origin;
-        const {rotationMatrixConjugate} = model;
+        const {rotationMatrix} = model;
 
         const viewMatrix = frameCtx.pickViewMatrix || camera.viewMatrix;
         const projMatrix = frameCtx.pickProjMatrix || camera.projMatrix;
@@ -94,7 +94,7 @@ export class DTXTrianglesPickNormalsRenderer {
                         if (active) {
                             const sectionPlane = sectionPlanes[sectionPlaneIndex];
                             if (origin) {
-                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrixConjugate);
+                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrix);
                                 gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
                             } else {
                                 gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);

--- a/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesSilhouetteRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesSilhouetteRenderer.js
@@ -94,7 +94,7 @@ export class DTXTrianglesSilhouetteRenderer {
 
         gl.uniform3fv(this._uCameraEyeRtc, rtcCameraEye);
         gl.uniform1i(this._uRenderPass, renderPass);
-        gl.uniformMatrix4fv(this._uWorldMatrix, false, rotationMatrixConjugate);
+        gl.uniformMatrix4fv(this._uWorldMatrix, false, rotationMatrix);
         gl.uniformMatrix4fv(this._uViewMatrix, false, rtcViewMatrix);
         gl.uniformMatrix4fv(this._uProjMatrix, false, camera.projMatrix);
 
@@ -138,7 +138,7 @@ export class DTXTrianglesSilhouetteRenderer {
                         if (active) {
                             const sectionPlane = sectionPlanes[sectionPlaneIndex];
                             if (origin) {
-                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrixConjugate);
+                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrix);
                                 gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
                             } else {
                                 gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);

--- a/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesSnapInitRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesSnapInitRenderer.js
@@ -110,7 +110,7 @@ export class DTXTrianglesSnapInitRenderer {
         gl.uniform3fv(this._uCoordinateScaler, coordinateScaler);
         gl.uniform1i(this._uRenderPass, renderPass);
         gl.uniform1i(this._uPickInvisible, frameCtx.pickInvisible);
-        gl.uniformMatrix4fv(this._uSceneWorldModelMatrix, false, rotationMatrixConjugate);
+        gl.uniformMatrix4fv(this._uSceneWorldModelMatrix, false, rotationMatrix);
         gl.uniformMatrix4fv(this._uViewMatrix, false, rtcViewMatrix);
         gl.uniformMatrix4fv(this._uProjMatrix, false, camera.projMatrix);
         if (SNAPPING_LOG_DEPTH_BUF_ENABLED) {
@@ -132,7 +132,7 @@ export class DTXTrianglesSnapInitRenderer {
                         if (active) {
                             const sectionPlane = sectionPlanes[sectionPlaneIndex];
                             if (origin) {
-                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrixConjugate);
+                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrix);
                                 gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
                             } else {
                                 gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);

--- a/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesSnapRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesSnapRenderer.js
@@ -115,7 +115,7 @@ export class DTXTrianglesSnapRenderer {
         gl.uniform3fv(this._uCoordinateScaler, coordinateScaler);
         gl.uniform1i(this._uRenderPass, renderPass);
         gl.uniform1i(this._uPickInvisible, frameCtx.pickInvisible);
-        gl.uniformMatrix4fv(this._uSceneModelMatrix, false, rotationMatrixConjugate);
+        gl.uniformMatrix4fv(this._uSceneModelMatrix, false, rotationMatrix);
         gl.uniformMatrix4fv(this._uViewMatrix, false, rtcViewMatrix);
         gl.uniformMatrix4fv(this._uProjMatrix, false, camera.projMatrix);
         if (SNAPPING_LOG_DEPTH_BUF_ENABLED) {
@@ -137,7 +137,7 @@ export class DTXTrianglesSnapRenderer {
                         if (active) {
                             const sectionPlane = sectionPlanes[sectionPlaneIndex];
                             if (origin) {
-                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrixConjugate);
+                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, rotationMatrix);
                                 gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
                             } else {
                                 gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);

--- a/src/viewer/scene/model/vbo/VBORenderer.js
+++ b/src/viewer/scene/model/vbo/VBORenderer.js
@@ -132,7 +132,7 @@ export class VBORenderer {
                             const sectionPlane = sectionPlanes[sectionPlaneIndex];
                             const origin = layer._state.origin;
                             if (origin) {
-                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, model.rotationMatrixConjugate);
+                                const rtcSectionPlanePos = getPlaneRTCPos(sectionPlane.dist, sectionPlane.dir, origin, tempVec3a, model.rotationMatrix);
                                 gl.uniform3fv(sectionPlaneUniforms.pos, rtcSectionPlanePos);
                             } else {
                                 gl.uniform3fv(sectionPlaneUniforms.pos, sectionPlane.pos);
@@ -462,7 +462,7 @@ export class VBORenderer {
         let offset = 0;
         const mat4Size = 4 * 4;
 
-        this._matricesUniformBlockBufferData.set(rotationMatrixConjugate, 0);
+        this._matricesUniformBlockBufferData.set(rotationMatrix, 0);
 
         const gotOrigin = (origin[0] !== 0 || origin[1] !== 0 || origin[2] !== 0);
         const gotPosition = (position[0] !== 0 || position[1] !== 0 || position[2] !== 0);

--- a/src/viewer/scene/model/vbo/batching/lines/renderers/VBOBatchingLineSnapInitRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/lines/renderers/VBOBatchingLineSnapInitRenderer.js
@@ -101,7 +101,7 @@ export class VBOBatchingLineSnapInitRenderer extends VBORenderer {
         let offset = 0;
         const mat4Size = 4 * 4;
 
-        this._matricesUniformBlockBufferData.set(rotationMatrixConjugate, 0);
+        this._matricesUniformBlockBufferData.set(rotationMatrix, 0);
         this._matricesUniformBlockBufferData.set(rtcViewMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(camera.projMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(state.positionsDecodeMatrix, offset += mat4Size);

--- a/src/viewer/scene/model/vbo/batching/lines/renderers/VBOBatchingLinesSnapInitRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/lines/renderers/VBOBatchingLinesSnapInitRenderer.js
@@ -100,7 +100,7 @@ export class VBOBatchingLinesSnapInitRenderer extends VBORenderer {
         let offset = 0;
         const mat4Size = 4 * 4;
 
-        this._matricesUniformBlockBufferData.set(rotationMatrixConjugate, 0);
+        this._matricesUniformBlockBufferData.set(rotationMatrix, 0);
         this._matricesUniformBlockBufferData.set(rtcViewMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(camera.projMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(state.positionsDecodeMatrix, offset += mat4Size);

--- a/src/viewer/scene/model/vbo/batching/lines/renderers/VBOBatchingLinesSnapRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/lines/renderers/VBOBatchingLinesSnapRenderer.js
@@ -104,7 +104,7 @@ export class VBOBatchingLinesSnapRenderer extends VBORenderer{
         let offset = 0;
         const mat4Size = 4 * 4;
 
-        this._matricesUniformBlockBufferData.set(rotationMatrixConjugate, 0);
+        this._matricesUniformBlockBufferData.set(rotationMatrix, 0);
         this._matricesUniformBlockBufferData.set(rtcViewMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(camera.projMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(state.positionsDecodeMatrix, offset += mat4Size);

--- a/src/viewer/scene/model/vbo/batching/points/renderers/VBOBatchingPointsSnapInitRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/points/renderers/VBOBatchingPointsSnapInitRenderer.js
@@ -100,7 +100,7 @@ export class VBOBatchingPointsSnapInitRenderer extends VBORenderer {
         let offset = 0;
         const mat4Size = 4 * 4;
 
-        this._matricesUniformBlockBufferData.set(rotationMatrixConjugate, 0);
+        this._matricesUniformBlockBufferData.set(rotationMatrix, 0);
         this._matricesUniformBlockBufferData.set(rtcViewMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(camera.projMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(state.positionsDecodeMatrix, offset += mat4Size);

--- a/src/viewer/scene/model/vbo/batching/points/renderers/VBOBatchingPointsSnapRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/points/renderers/VBOBatchingPointsSnapRenderer.js
@@ -104,7 +104,7 @@ export class VBOBatchingPointsSnapRenderer extends VBORenderer{
         let offset = 0;
         const mat4Size = 4 * 4;
 
-        this._matricesUniformBlockBufferData.set(rotationMatrixConjugate, 0);
+        this._matricesUniformBlockBufferData.set(rotationMatrix, 0);
         this._matricesUniformBlockBufferData.set(rtcViewMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(camera.projMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(state.positionsDecodeMatrix, offset += mat4Size);

--- a/src/viewer/scene/model/vbo/batching/triangles/VBOBatchingTrianglesLayer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/VBOBatchingTrianglesLayer.js
@@ -816,12 +816,15 @@ export class VBOBatchingTrianglesLayer {
             return;
         }
         const positions = portion.quantizedPositions;
-        const origin = state.origin;
-        const offsetX = origin[0] ;
-        const offsetY = origin[1] ;
-        const offsetZ = origin[2] ;
-        const worldPos = tempVec4a;
         const sceneModelMatrix = this.model.matrix;
+        const origin = math.vec4();
+        origin.set(state.origin, 0);
+        origin[3] = 1;
+        math.mulMat4v4(sceneModelMatrix, origin, origin);
+        const offsetX = origin[0];
+        const offsetY = origin[1];
+        const offsetZ = origin[2];
+        const worldPos = tempVec4a;
         const positionsDecodeMatrix = state.positionsDecodeMatrix;
         for (let i = 0, len = positions.length; i < len; i += 3) {
             worldPos[0] = positions[i];
@@ -829,7 +832,8 @@ export class VBOBatchingTrianglesLayer {
             worldPos[2] = positions[i + 2];
             worldPos[3] = 1.0;
             math.decompressPosition(worldPos, positionsDecodeMatrix);
-            math.transformPoint4(sceneModelMatrix, worldPos);
+            worldPos[3] = 1;
+            math.mulMat4v4(sceneModelMatrix, worldPos, worldPos);
             worldPos[0] += offsetX;
             worldPos[1] += offsetY;
             worldPos[2] += offsetZ;

--- a/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesSnapInitRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesSnapInitRenderer.js
@@ -100,7 +100,7 @@ export class TrianglesSnapInitRenderer extends VBORenderer {
         let offset = 0;
         const mat4Size = 4 * 4;
 
-        this._matricesUniformBlockBufferData.set(rotationMatrixConjugate, 0);
+        this._matricesUniformBlockBufferData.set(rotationMatrix, 0);
         this._matricesUniformBlockBufferData.set(rtcViewMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(camera.projMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(state.positionsDecodeMatrix, offset += mat4Size);

--- a/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesSnapRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesSnapRenderer.js
@@ -103,7 +103,7 @@ export class TrianglesSnapRenderer extends VBORenderer{
         let offset = 0;
         const mat4Size = 4 * 4;
 
-        this._matricesUniformBlockBufferData.set(rotationMatrixConjugate, 0);
+        this._matricesUniformBlockBufferData.set(rotationMatrix, 0);
         this._matricesUniformBlockBufferData.set(rtcViewMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(camera.projMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(state.positionsDecodeMatrix, offset += mat4Size);

--- a/src/viewer/scene/model/vbo/instancing/lines/renderers/VBOInstancingLinesSnapInitRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/lines/renderers/VBOInstancingLinesSnapInitRenderer.js
@@ -96,7 +96,7 @@ export class VBOInstancingLinesSnapInitRenderer extends VBORenderer {
         let offset = 0;
         const mat4Size = 4 * 4;
 
-        this._matricesUniformBlockBufferData.set(rotationMatrixConjugate, 0);
+        this._matricesUniformBlockBufferData.set(rotationMatrix, 0);
         this._matricesUniformBlockBufferData.set(rtcViewMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(camera.projMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(state.positionsDecodeMatrix, offset += mat4Size);

--- a/src/viewer/scene/model/vbo/instancing/lines/renderers/VBOInstancingLinesSnapRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/lines/renderers/VBOInstancingLinesSnapRenderer.js
@@ -96,7 +96,7 @@ export class VBOInstancingLinesSnapRenderer extends VBORenderer {
         let offset = 0;
         const mat4Size = 4 * 4;
 
-        this._matricesUniformBlockBufferData.set(rotationMatrixConjugate, 0);
+        this._matricesUniformBlockBufferData.set(rotationMatrix, 0);
         this._matricesUniformBlockBufferData.set(rtcViewMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(camera.projMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(state.positionsDecodeMatrix, offset += mat4Size);

--- a/src/viewer/scene/model/vbo/instancing/points/renderers/VBOInstancingPointsSnapInitRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/points/renderers/VBOInstancingPointsSnapInitRenderer.js
@@ -96,7 +96,7 @@ export class VBOInstancingPointsSnapInitRenderer extends VBORenderer {
         let offset = 0;
         const mat4Size = 4 * 4;
 
-        this._matricesUniformBlockBufferData.set(rotationMatrixConjugate, 0);
+        this._matricesUniformBlockBufferData.set(rotationMatrix, 0);
         this._matricesUniformBlockBufferData.set(rtcViewMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(camera.projMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(state.positionsDecodeMatrix, offset += mat4Size);

--- a/src/viewer/scene/model/vbo/instancing/points/renderers/VBOInstancingPointsSnapRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/points/renderers/VBOInstancingPointsSnapRenderer.js
@@ -96,7 +96,7 @@ export class VBOInstancingPointsSnapRenderer extends VBORenderer {
         let offset = 0;
         const mat4Size = 4 * 4;
 
-        this._matricesUniformBlockBufferData.set(rotationMatrixConjugate, 0);
+        this._matricesUniformBlockBufferData.set(rotationMatrix, 0);
         this._matricesUniformBlockBufferData.set(rtcViewMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(camera.projMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(state.positionsDecodeMatrix, offset += mat4Size);

--- a/src/viewer/scene/model/vbo/instancing/triangles/VBOInstancingTrianglesLayer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/VBOInstancingTrianglesLayer.js
@@ -708,21 +708,25 @@ export class VBOInstancingTrianglesLayer {
             return;
         }
         const positions = geometry.positionsCompressed;
-        const origin = state.origin;
+        const sceneModelMatrix = this.model.matrix;
+        const origin = math.vec4();
+        origin.set(state.origin, 0);
+        origin[3] = 1;
+        math.mulMat4v4(sceneModelMatrix, origin, origin);
         const offsetX = origin[0];
         const offsetY = origin[1];
         const offsetZ = origin[2];
         const worldPos = tempVec4a;
         const portionMatrix = portion.matrix;
-        const sceneModelMatrix = this.model.matrix;
         const positionsDecodeMatrix = state.positionsDecodeMatrix;
         for (let i = 0, len = positions.length; i < len; i += 3) {
             worldPos[0] = positions[i];
             worldPos[1] = positions[i + 1];
             worldPos[2] = positions[i + 2];
             math.decompressPosition(worldPos, positionsDecodeMatrix);
-            math.transformPoint3(portionMatrix, worldPos);
-            math.transformPoint3(sceneModelMatrix, worldPos);
+            math.transformPoint3(portionMatrix, worldPos, worldPos);
+            worldPos[3] = 1;
+            math.mulMat4v4(sceneModelMatrix, worldPos, worldPos);
             worldPos[0] += offsetX;
             worldPos[1] += offsetY;
             worldPos[2] += offsetZ;

--- a/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesSnapInitRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesSnapInitRenderer.js
@@ -102,7 +102,7 @@ export class TrianglesSnapInitRenderer extends VBORenderer {
         let offset = 0;
         const mat4Size = 4 * 4;
 
-        this._matricesUniformBlockBufferData.set(rotationMatrixConjugate, 0);
+        this._matricesUniformBlockBufferData.set(rotationMatrix, 0);
         this._matricesUniformBlockBufferData.set(rtcViewMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(camera.projMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(state.positionsDecodeMatrix, offset += mat4Size);

--- a/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesSnapRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesSnapRenderer.js
@@ -103,7 +103,7 @@ export class TrianglesSnapRenderer extends VBORenderer {
         let offset = 0;
         const mat4Size = 4 * 4;
 
-        this._matricesUniformBlockBufferData.set(rotationMatrixConjugate, 0);
+        this._matricesUniformBlockBufferData.set(rotationMatrix, 0);
         this._matricesUniformBlockBufferData.set(rtcViewMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(camera.projMatrix, offset += mat4Size);
         this._matricesUniformBlockBufferData.set(state.positionsDecodeMatrix, offset += mat4Size);


### PR DESCRIPTION
This PR is meant to address two topics:
1. Incorrect transformation of rotated vertices in `getEachVertex` method.
2. Incorrect calculation of `rotationMatrixConjugate` in sceneModel. Previously, the `rotationMatrixConjugate` and `rotationMatrix`, both contained the same values, so I have fixed that and replaced `rotationMatrixConjugate` with `rotationMatrix` through the SDK. @MichalDybizbanskiCreoox these changes also effects your previous fix for section planes in a sense that it uses `rotationMatrix` now.

I have tested these fixes and replacements on my end but if you guys have special cases in mind, then it would be best test this PR against those scenarios before merging with main.