### PR TITLE
[FEATURE] Better touch rotation for perspective projection

### DIFF
--- a/src/viewer/scene/CameraControl/lib/handlers/TouchPanRotateAndDollyHandler.js
+++ b/src/viewer/scene/CameraControl/lib/handlers/TouchPanRotateAndDollyHandler.js
@@ -198,20 +198,20 @@ class TouchPanRotateAndDollyHandler {
                     }
 
                 } else {
-                  //  if (!absorbTinyFirstDrag) {
+                    if (scene.camera.projection === "perspective") {
+                        const { fov, fovAxis } = scene.camera.perspective;
+                        const fovX = fovAxis === "x" || (fovAxis === "min" && canvasWidth < canvasHeight) ? fov : fov * (canvasWidth / canvasHeight);
+                        const fovY = fovAxis === "y" || (fovAxis === "min" && canvasHeight < canvasWidth) ? fov : fov * (canvasHeight / canvasWidth);
+
+                        const dx = xPanDelta / canvasWidth * fovX * configs.dragRotationRate / 360;
+                        const dy = yPanDelta / canvasHeight * fovY * configs.dragRotationRate / 360;
+
+                        updates.rotateDeltaY -= dx;
+                        updates.rotateDeltaX += dy;
+                    } else {
                         updates.rotateDeltaY -= (xPanDelta / canvasWidth) * (configs.dragRotationRate * 1.0); // Full horizontal rotation
                         updates.rotateDeltaX += (yPanDelta / canvasHeight) * (configs.dragRotationRate * 1.5); // Half vertical rotation
-                    // } else {
-                    //     firstDragDeltaY -= (xPanDelta / canvasWidth) * (configs.dragRotationRate * 1.0); // Full horizontal rotation
-                    //     firstDragDeltaX += (yPanDelta / canvasHeight) * (configs.dragRotationRate * 1.5); // Half vertical rotation
-                    //     if (Math.abs(firstDragDeltaX) > 5 || Math.abs(firstDragDeltaY) > 5) {
-                    //         updates.rotateDeltaX += firstDragDeltaX;
-                    //         updates.rotateDeltaY += firstDragDeltaY;
-                    //         firstDragDeltaX = 0;
-                    //         firstDragDeltaY = 0;
-                    //         absorbTinyFirstDrag = false;
-                    //     }
-                    // }
+                    }
                 }
 
             } else if (numTouches === 2) {


### PR DESCRIPTION
Touch rotation is currently bound to [magic numbers](https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/scene/CameraControl/lib/handlers/TouchPanRotateAndDollyHandler.js#L202-L203) *(1 for full horizontal rotation and 1.5 for half vertical rotation)*.

This PR change the way `rotateDeltaY` and `rotateDeltaX` are computed. The new computation is based on the `x` and `y` axis `fov` and the canvas aspect ratio. Doing so, the touch rotation in perspective projection behaves more like what is it done on other viewers like Autodesk, Catenda and Dalux (it is possible to test with free demo data on the last one).

**The rotation behavior is described as follows:**

https://github.com/user-attachments/assets/7efd5568-91c3-444f-ba06-13eb6fb51121

(video recorded using the mouse but the code is for touch handler ONLY)

When you touch a specific area on the model and then rotate, the finger stays above the previously touched area. The touched area follows the finger (minus some perspective distortion on the canvas edges).

To prevent breaking changes and still get the expected behaviour, the `configs.dragRotationRate` must be set to `-360`, the opposite as the default value `360`. I did not change this default value of `360` and it is handled in the new code, when divided by `360` when computing `dx` and `dy`.

**NB**: touch rotation is changed in this PR for **perspective projection ONLY**. For the other projections, the behavior is kept the same as before.