### PR TITLE
Fix model not scaling when loading using XKTLoaderPlugin

### DIFF
--- a/src/viewer/scene/model/SceneModel.js
+++ b/src/viewer/scene/model/SceneModel.js
@@ -1606,6 +1606,8 @@ export class SceneModel extends Component {
             math.quaternionToRotationMat4(this._quaternion, this._worldRotationMatrix);
             math.conjugateQuaternion(this._quaternion, this._conjugateQuaternion);
             math.quaternionToRotationMat4(this._conjugateQuaternion, this._worldRotationMatrixConjugate);
+            math.scaleMat4v(this._scale, this._worldRotationMatrix);
+            math.scaleMat4v(this._scale, this._worldRotationMatrixConjugate);
             this._matrix.set(this._worldRotationMatrix);
             math.translateMat4v(this._position, this._matrix);
             this._matrixDirty = false;


### PR DESCRIPTION
This PR fixes the inability to scale when loading a model using XKTLoaderPlugin.

Ticket reference: XCD-169 

Closes #1687 