### PR TITLE
Fix rootnames showing as 'na' in TreeViewPlugin

### DIFF
--- a/src/viewer/metadata/MetaModel.js
+++ b/src/viewer/metadata/MetaModel.js
@@ -304,8 +304,8 @@ class MetaModel {
 
         for (let modelId in metaScene.metaModels) {
             const metaModel = metaScene.metaModels[modelId];
-            for (let i = 0, len = metaModel.metaObjects.length; i < len; i++) {
-                const metaObject = metaModel.metaObjects[i];
+            for (let objectId in metaModel.metaObjects) {
+                const metaObject = metaModel.metaObjects[objectId];
                 metaObject.metaModels.push(metaModel);
             }
         }


### PR DESCRIPTION
With the latest version of xeokit sdk, TreeViewPlugin shows "na" as the rootnames.

Ticket reference: XCD-168