### PR TITLE
Update ObjectsMemento::StoreyViewsPlugin to restore only visibility

### DIFF
--- a/src/plugins/StoreyViewsPlugin/StoreyViewsPlugin.js
+++ b/src/plugins/StoreyViewsPlugin/StoreyViewsPlugin.js
@@ -541,7 +541,11 @@ class StoreyViewsPlugin extends Plugin {
             height = Math.round(width * aspect);
         }
 
-        this._objectsMemento.saveObjects(scene);
+        const mask = {
+            visible: true,
+        }
+
+        this._objectsMemento.saveObjects(scene, mask);
         this._cameraMemento.saveCamera(scene);
 
         this.showStoreyObjects(storeyId, utils.apply(options, {
@@ -556,7 +560,7 @@ class StoreyViewsPlugin extends Plugin {
             format: format,
         });
 
-        this._objectsMemento.restoreObjects(scene);
+        this._objectsMemento.restoreObjects(scene, mask);
         this._cameraMemento.restoreCamera(scene);
 
         return new StoreyMap(storeyId, src, format, width, height, padding);


### PR DESCRIPTION
When invoking createStoreyMap function from StoreyViewsPlugin when there are more than one models on the screen, the object memento eventually eventually end up recolorizing all of the objects.

In our case, we had an ifc and a point cloud model on the screen, with createStoreyMaps being called for the ifc model only.

The point cloud model had _colorize set to default value of [255, 255, 255] and when objects memento restore the model's state, it ends colorizing the point cloud to true.

In this fix, I have updated ObjectsMemento to only restore visibility of the objects on the scene as StoreyViewsPlugin does not update any other property of the objects.