### PR TITLE
[FEATURE] Rotate around previous pivot when clicking on background

### DIFF
--- a/src/viewer/scene/CameraControl/lib/handlers/MousePickHandler.js
+++ b/src/viewer/scene/CameraControl/lib/handlers/MousePickHandler.js
@@ -16,6 +16,7 @@ class MousePickHandler {
         this._clicks = 0;
         this._timeout = null;
         this._lastPickedEntityId = null;
+        this._lastClickedWorldPos = null;
 
         let leftDown = false;
         let rightDown = false;
@@ -165,11 +166,16 @@ class MousePickHandler {
                     if (pickResult && pickResult.worldPos) {
                         pivotController.setPivotPos(pickResult.worldPos);
                         pivotController.startPivot();
+                        this._lastClickedWorldPos = pickResult.worldPos;
                     } else {
                         if (configs.smartPivot) {
                             pivotController.setCanvasPivotPos(states.pointerCanvasPos);
                         } else {
-                            pivotController.setPivotPos(scene.camera.look);
+                            if (this._lastClickedWorldPos) {
+                                pivotController.setPivotPos(this._lastClickedWorldPos);
+                            } else {
+                                pivotController.setPivotPos(scene.camera.look);
+                            }
                         }
                         pivotController.startPivot();
                     }


### PR DESCRIPTION
![2024-10-25_23h04_08](https://github.com/user-attachments/assets/b57b33e7-81f5-495b-8a0c-94604b03bac4)

The idea is to save latest pivot and use it if someone is rotating by clicking on a background. This option should be enabled if someone will do:
`viewer.cameraControl.smartPivot = false;`

Related to XCD-171