### PR TITLE
XCD-144 Fix shaking measurement

### DIFF
--- a/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
+++ b/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
@@ -1078,7 +1078,7 @@ class DistanceMeasurement extends Component {
         value = value !== undefined ? Boolean(value) : this.plugin.defaultLengthLabelEnabled;
         this._lengthLabelEnabled = value;
         var labelsVisible = this._visible && this._labelsVisible;
-        this._lengthLabel.setVisible(labelsVisible && !this._lengthAxisLabelCulled && this._clickable && this._axisEnabled && this._lengthLabelEnabled);
+        this._lengthLabel.setVisible(labelsVisible && this._clickable && this._axisEnabled && this._lengthLabelEnabled);
         this._cpDirty = true;
         this._needUpdate();
     }

--- a/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
+++ b/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurement.js
@@ -727,7 +727,7 @@ class DistanceMeasurement extends Component {
         this._yAxisWire.setVisible(yAxisVisible);
         this._zAxisWire.setVisible(zAxisVisible);
 
-        this._xAxisLabel.setVisible(xAxisVisible && !this._xAxisLabelCulled && this._EnabledVisible);
+        this._xAxisLabel.setVisible(xAxisVisible && !this._xAxisLabelCulled && this._xLabelEnabled);
         this._yAxisLabel.setVisible(yAxisVisible && !this._yAxisLabelCulled && this._yLabelEnabled);
         this._zAxisLabel.setVisible(zAxisVisible && !this._zAxisLabelCulled && this._zLabelEnabled);
 

--- a/src/plugins/lib/html/Dot.js
+++ b/src/plugins/lib/html/Dot.js
@@ -184,7 +184,7 @@ class Dot {
     }
 
     _updateVisibility() {
-        this._dot.style.visibility = this._visible && !this._culled ? "visible" : "hidden";
+        this._dot.style.visibility = this._dotClickable.style.visibility = this._visible && !this._culled ? "visible" : "hidden";
     }
 
     setVisible(visible) {

--- a/src/plugins/lib/html/Dot.js
+++ b/src/plugins/lib/html/Dot.js
@@ -163,12 +163,12 @@ class Dot {
         this._x = x;
         this._y = y;
         var dotStyle = this._dot.style;
-        dotStyle["left"] = (Math.round(x) - 4) + 'px';
-        dotStyle["top"] = (Math.round(y) - 4) + 'px';
+        dotStyle["left"] = (Math.round(x) - 6) + 'px';
+        dotStyle["top"] = (Math.round(y) - 6) + 'px';
 
         var dotClickableStyle = this._dotClickable.style;
-        dotClickableStyle["left"] = (Math.round(x) - 9) + 'px';
-        dotClickableStyle["top"] = (Math.round(y) - 9) + 'px';
+        dotClickableStyle["left"] = (Math.round(x) - 14) + 'px';
+        dotClickableStyle["top"] = (Math.round(y) - 14) + 'px';
     }
 
     setFillColor(color) {

--- a/src/plugins/lib/html/Dot.js
+++ b/src/plugins/lib/html/Dot.js
@@ -183,12 +183,16 @@ class Dot {
         this._dot.style.opacity = opacity;
     }
 
+    _updateVisibility() {
+        this._dot.style.visibility = this._visible && !this._culled ? "visible" : "hidden";
+    }
+
     setVisible(visible) {
         if (this._visible === visible) {
             return;
         }
         this._visible = !!visible;
-        this._dot.style.visibility = this._visible && !this._culled ? "visible" : "hidden";
+        this._updateVisibility();
     }
 
     setCulled(culled) {
@@ -196,7 +200,7 @@ class Dot {
             return;
         }
         this._culled = !!culled;
-        this._dot.style.visibility = this._visible && !this._culled ? "visible" : "hidden";
+        this._updateVisibility();
     }
 
     setClickable(clickable) {

--- a/src/plugins/lib/html/Label.js
+++ b/src/plugins/lib/html/Label.js
@@ -167,12 +167,16 @@ class Label {
         this._label.style.opacity = opacity;
     }
 
+    _updateVisibility() {
+        this._label.style.visibility = this._visible && !this._culled ? "visible" : "hidden";
+    }
+
     setVisible(visible) {
         if (this._visible === visible) {
             return;
         }
         this._visible = !!visible;
-        this._label.style.visibility = this._visible && !this._culled ? "visible" : "hidden";
+        this._updateVisibility();
     }
 
     setCulled(culled) {
@@ -180,7 +184,7 @@ class Label {
             return;
         }
         this._culled = !!culled;
-        this._label.style.visibility = this._visible && !this._culled ? "visible" : "hidden";
+        this._updateVisibility();
     }
 
     setHighlighted(highlighted) {

--- a/src/plugins/lib/html/Wire.js
+++ b/src/plugins/lib/html/Wire.js
@@ -208,12 +208,16 @@ class Wire {
         this._wire.style.opacity = opacity;
     }
 
+    _updateVisibility() {
+        this._wire.style.visibility = this._visible && !this._culled ? "visible" : "hidden";
+    }
+
     setVisible(visible) {
         if (this._visible === visible) {
             return;
         }
         this._visible = !!visible;
-        this._wire.style.visibility = this._visible && !this._culled ? "visible" : "hidden";
+        this._updateVisibility();
     }
 
     setCulled(culled) {
@@ -221,7 +225,7 @@ class Wire {
             return;
         }
         this._culled = !!culled;
-        this._wire.style.visibility = this._visible && !this._culled ? "visible" : "hidden";
+        this._updateVisibility();
     }
 
     setClickable(clickable) {

--- a/src/plugins/lib/html/Wire.js
+++ b/src/plugins/lib/html/Wire.js
@@ -209,7 +209,7 @@ class Wire {
     }
 
     _updateVisibility() {
-        this._wire.style.visibility = this._visible && !this._culled ? "visible" : "hidden";
+        this._wire.style.visibility = this._wireClickable.style.visibility = this._visible && !this._culled ? "visible" : "hidden";
     }
 
     setVisible(visible) {

--- a/src/plugins/lib/html/Wire.js
+++ b/src/plugins/lib/html/Wire.js
@@ -174,21 +174,21 @@ class Wire {
         wireStyle["width"] = Math.round(length) + 'px';
         wireStyle["left"] = Math.round(this._x1) + 'px';
         wireStyle["top"] = Math.round(this._y1) + 'px';
-        wireStyle['-webkit-transform'] = 'rotate(' + angle + 'deg)';
-        wireStyle['-moz-transform'] = 'rotate(' + angle + 'deg)';
-        wireStyle['-ms-transform'] = 'rotate(' + angle + 'deg)';
-        wireStyle['-o-transform'] = 'rotate(' + angle + 'deg)';
-        wireStyle['transform'] = 'rotate(' + angle + 'deg)';
+        wireStyle['-webkit-transform'] =
+            wireStyle['-moz-transform'] =
+            wireStyle['-ms-transform'] =
+            wireStyle['-o-transform'] =
+            wireStyle['transform'] = 'rotate(' + angle + 'deg) translate(-' + this._thickness + 'px, -' + this._thickness + 'px)';
 
         var wireClickableStyle = this._wireClickable.style;
         wireClickableStyle["width"] = Math.round(length) + 'px';
         wireClickableStyle["left"] = Math.round(this._x1) + 'px';
         wireClickableStyle["top"] = Math.round(this._y1) + 'px';
-        wireClickableStyle['-webkit-transform'] = 'rotate(' + angle + 'deg)';
-        wireClickableStyle['-moz-transform'] = 'rotate(' + angle + 'deg)';
-        wireClickableStyle['-ms-transform'] = 'rotate(' + angle + 'deg)';
-        wireClickableStyle['-o-transform'] = 'rotate(' + angle + 'deg)';
-        wireClickableStyle['transform'] = 'rotate(' + angle + 'deg)';
+        wireClickableStyle['-webkit-transform'] =
+            wireClickableStyle['-moz-transform'] =
+            wireClickableStyle['-ms-transform'] =
+            wireClickableStyle['-o-transform'] =
+            wireClickableStyle['transform'] = 'rotate(' + angle + 'deg) translate(-' + this._thicknessClickable + 'px, -' + this._thicknessClickable + 'px)';
     }
 
     setStartAndEnd(x1, y1, x2, y2) {

--- a/src/plugins/lib/ui/index.js
+++ b/src/plugins/lib/ui/index.js
@@ -140,6 +140,8 @@ export class Dot3D extends Marker {
 
         super(scene, markerCfg);
 
+        this.__visible = true;  // "__" to not interfere with Marker::_visible
+
         const handler = (cfgEvent, componentEvent) => {
             return event => {
                 if (cfgEvent) {
@@ -182,6 +184,9 @@ export class Dot3D extends Marker {
         };
 
         const updateDotPos = () => {
+            if (! this.__visible) {
+                return;
+            }
             const p0 = tmpVec4c;
             toClipSpace(this.worldPos, p0);
             math.mulVec3Scalar(p0, 1.0 / p0[3]);
@@ -209,6 +214,8 @@ export class Dot3D extends Marker {
         const onProjMatrix = camera.on("projMatrix", updateDotPos);
         const onCanvasBnd  = scene.canvas.on("boundary", updateDotPos);
         const planesUpdate = scene.on("sectionPlaneUpdated", updateDotPos);
+
+        this._updatePosition = updateDotPos;
 
         this._cleanup = () => {
             camera.off(onViewMatrix);
@@ -240,7 +247,11 @@ export class Dot3D extends Marker {
     }
 
     setVisible(value) {
-        this._dot.setVisible(value);
+        if (this.__visible != value) {
+            this.__visible = value;
+            this._updatePosition();
+            this._dot.setVisible(value);
+        }
     }
 
     destroy() {
@@ -260,6 +271,7 @@ export class Label3D {
         this._end   = math.vec3();
         this._yOff  = 0;
         this._betweenWires = false;
+        this.__visible = true;
 
         const setPosOnWire = (p0, p1, yOff) => {
             p0[0] += p1[0];
@@ -269,6 +281,9 @@ export class Label3D {
         };
 
         this._updatePositions = () => {
+            if (! this.__visible) {
+                return;
+            }
             if (this._betweenWires) {
                 const visibleA = clipSegment(scene, parentElement, this._start, this._mid, tmpVec2a, tmpVec2b);
                 const visibleB = clipSegment(scene, parentElement, this._end,   this._mid, tmpVec2c, tmpVec2d);
@@ -346,7 +361,11 @@ export class Label3D {
     }
 
     setVisible(value) {
-        this._label.setVisible(value);
+        if (this.__visible != value) {
+            this.__visible = value;
+            this._updatePositions();
+            this._label.setVisible(value);
+        }
     }
 
     destroy() {
@@ -362,8 +381,12 @@ export class Wire3D {
         this._wire  = new Wire(parentElement, cfg);
         this._start = math.vec3();
         this._end   = math.vec3();
+        this.__visible = true;
 
         this._updatePositions = () => {
+            if (! this.__visible) {
+                return;
+            }
             const visible = clipSegment(scene, parentElement, this._start, this._end, tmpVec2a, tmpVec2b);
             this._wire.setCulled(! visible);
             if (visible) {
@@ -408,7 +431,11 @@ export class Wire3D {
     }
 
     setVisible(value) {
-        this._wire.setVisible(value);
+        if (this.__visible != value) {
+            this.__visible = value;
+            this._updatePositions();
+            this._wire.setVisible(value);
+        }
     }
 
     destroy() {


### PR DESCRIPTION
Not sure what was the original intention to hide measurement controls when camera was too close to them, but it causes glitches as described at https://creoox.atlassian.net/browse/XCD-175?focusedCommentId=13492
Removing this special logic seems to fix the reported issue.