### PR TITLE
[FIX] Fix IfcBuildingStorey elevation sort

### DIFF
--- a/src/plugins/StoreyViewsPlugin/StoreyViewsPlugin.js
+++ b/src/plugins/StoreyViewsPlugin/StoreyViewsPlugin.js
@@ -845,8 +845,8 @@ class StoreyViewsPlugin extends Plugin {
 
             if (storey1MetaObject && (storey1MetaObject.attributes && storey1MetaObject.attributes.elevation !== undefined) &&
                 storey2MetaObject && (storey2MetaObject.attributes && storey2MetaObject.attributes.elevation !== undefined)) {
-                const elevation1 = storey1MetaObject.attributes.elevation;
-                const elevation2 = storey2MetaObject.attributes.elevation;
+                const elevation1 = Number.parseFloat(storey1MetaObject.attributes.elevation);
+                const elevation2 = Number.parseFloat(storey2MetaObject.attributes.elevation);
                 if (elevation1 > elevation2) {
                     return -1;
                 }

--- a/src/plugins/TreeViewPlugin/TreeViewPlugin.js
+++ b/src/plugins/TreeViewPlugin/TreeViewPlugin.js
@@ -1235,8 +1235,8 @@ export class TreeViewPlugin extends Plugin {
 
             if (storey1MetaObject && (storey1MetaObject.attributes && storey1MetaObject.attributes.elevation !== undefined) &&
                 storey2MetaObject && (storey2MetaObject.attributes && storey2MetaObject.attributes.elevation !== undefined)) {
-                const elevation1 = storey1MetaObject.attributes.elevation;
-                const elevation2 = storey2MetaObject.attributes.elevation;
+                const elevation1 = Number.parseFloat(storey1MetaObject.attributes.elevation);
+                const elevation2 = Number.parseFloat(storey2MetaObject.attributes.elevation);
                 if (elevation1 > elevation2) {
                     return -1;
                 }


### PR DESCRIPTION
`StoreyViewsPlugin` sorts its `Storey` objects on the `elevation` attribute that belongs to each `Storey`'s `IfcBuildingStorey`.

`TreeViewPlugin` likewise sorts nodes that represent `IfcBuildingStoreys`.

The attribute can be either a string or a number.

This PR ensures that these two plugins always parse the attribute correctly into a float.

