### PR TITLE
Fix when manifestSrc contains a Shared Access Key

### DIFF
--- a/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
+++ b/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
@@ -427,7 +427,7 @@ parsers[ParserV11.version] = ParserV11;
  *
  * ````javascript
  * const sceneModel = xktLoader.load({
- *   manifestSrc: "https://xeokit.github.io/xeokit-sdk/assets/models/models/xkt/Schependomlaan.xkt",
+ *   src: "https://xeokit.github.io/xeokit-sdk/assets/models/models/xkt/Schependomlaan.xkt",
  *   id: "myModel",
  * });
  * ````
@@ -1165,6 +1165,10 @@ class XKTLoaderPlugin extends Plugin {
 }
 
 function getBaseDirectory(filePath) {
+    if (filePath.indexOf('?') > -1) {
+        filePath = filePath.split('?')[0];
+    }
+
     const pathArray = filePath.split('/');
     pathArray.pop(); // Remove the file name or the last segment of the path
     return pathArray.join('/') + '/';


### PR DESCRIPTION
Ran into a problem today, the manifestSrc url contains a Shared Access Key (files are not public avialable) and the key contained a /.

Example: `https://domain.com/manifest.json?sp=r&sig=/eDdWelJCWXFUnBrPdkyuvGW5b4VIvhfhHSg844pGsQ%3D`

In this case the signature contains a /, this causes the function `getBaseDirectory` to get the wrong base path.

Solution: strip the querystring from the filePath
