### PR TITLE
#1704 Optimize Annotations' position update

### DIFF
--- a/src/plugins/AnnotationsPlugin/Annotation.js
+++ b/src/plugins/AnnotationsPlugin/Annotation.js
@@ -215,16 +215,14 @@ class Annotation extends Marker {
         const boundary = this.scene.canvas.boundary;
         const left = boundary[0] + this.canvasPos[0];
         const top  = boundary[1] + this.canvasPos[1];
-        const markerRect = this._marker.getBoundingClientRect();
-        const markerWidth = markerRect.width;
+        const markerWidth = this._marker.getBoundingClientRect().width;
         const markerDir = (this._markerAlign === "right") ? -1 : ((this._markerAlign === "center") ? 0 : 1);
         const markerCenter = left + markerDir * (markerWidth / 2 - 12);
         this._marker.style.left = px(markerCenter - markerWidth / 2);
         this._marker.style.top  = px(top - 12);
         this._marker.style["z-index"] = 90005 + Math.floor(this._viewPos[2]) + 1;
 
-        const labelRect = this._label.getBoundingClientRect();
-        const labelWidth = labelRect.width;
+        const labelWidth = this._label.getBoundingClientRect().width;
         const labelDir = Math.sign(this._labelPosition);
         this._label.style.left = px(markerCenter + labelDir * (markerWidth / 2 + Math.abs(this._labelPosition) + labelWidth / 2) - labelWidth / 2);
         this._label.style.top  = px(top - 17);


### PR DESCRIPTION
~I have mixed feelings about this change.
We might want to look for a performance improvement that doesn't require setting an extra flag and potentially (though unlikely) sacrificing some positioning precision.
That might involve a different method of rendering a marker though.
Hopefully a huge number of Annotations, which makes this performance improvement necessary, is not a very common case.~
Previous approach, required an explicit user call to take advantage of the optimization.
I've changed the approach to instead automatically rely on cached widths values (which are expensive to obtain), and postpone the expensive calculations by some timeout.
This way the calculations don't interfere with e.g. interactive camera manipulation, and are delayed to after the camera manipulation stops.
Even though cached values might not represent actual widths while the calculation is delayed, that shouldn't be a practical problem.