### PR TITLE
XCD-196 Render Zones ordered by camera distance

### DIFF
--- a/src/plugins/ZonesPlugin/ZonesPlugin.js
+++ b/src/plugins/ZonesPlugin/ZonesPlugin.js
@@ -482,8 +482,21 @@ class Zone extends Component {
         }
 
 
-        const positions = [].concat(...pos);
+        const min = idx => Math.min(...pos.map(p => p[idx]));
+        const max = idx => Math.max(...pos.map(p => p[idx]));
+
+        const xmin = min(0);
+        const ymin = min(1);
+        const zmin = min(2);
+        const xmax = max(0);
+        const ymax = max(1);
+        const zmax = max(2);
+
+        this._center = math.vec3([ (xmin + xmax) / 2, (ymin + ymax) / 2, (zmin + zmax) / 2 ]);
+
+        const positions = [].concat(...pos.map(p => math.subVec3(p, this._center, p)));
         this._zoneMesh = new Mesh(scene, {
+            origin: this._center,
             edges: this._edges,
             geometry: new ReadableGeometry(
                 scene,
@@ -524,19 +537,6 @@ class Zone extends Component {
         }
 
         this._metrics = null;
-
-
-        const min = idx => Math.min(...pos.map(p => p[idx]));
-        const max = idx => Math.max(...pos.map(p => p[idx]));
-
-        const xmin = min(0);
-        const ymin = min(1);
-        const zmin = min(2);
-        const xmax = max(0);
-        const ymax = max(1);
-        const zmax = max(2);
-
-        this._center = math.vec3([ (xmin + xmax) / 2, (ymin + ymax) / 2, (zmin + zmax) / 2 ]);
     }
 
     get baseArea() {

--- a/src/viewer/scene/webgl/Renderer.js
+++ b/src/viewer/scene/webgl/Renderer.js
@@ -11,6 +11,8 @@ import {SAODepthLimitedBlurRenderer} from "./sao/SAODepthLimitedBlurRenderer.js"
 import {RenderBufferManager} from "./RenderBufferManager.js";
 import {getExtension} from "./getExtension.js";
 
+const vec3_0 = math.vec3([0,0,0]);
+
 /**
  * @private
  */
@@ -713,9 +715,11 @@ const Renderer = function (scene, options) {
             // Transparent color fill
 
             if (normalFillTransparentBinLen > 0) {
+                const eye = frameCtx.pickOrigin || scene.camera.eye;
+                const byDist = normalFillTransparentBin.map(d => ({ drawable: d, distSq: math.distVec3(d.origin || vec3_0, eye) }));
+                byDist.sort((a, b) => b.distSq - a.distSq);
                 for (i = 0; i < normalFillTransparentBinLen; i++) {
-                    drawable = normalFillTransparentBin[i];
-                    drawable.drawColorTransparent(frameCtx);
+                    byDist[i].drawable.drawColorTransparent(frameCtx);
                 }
             }
 


### PR DESCRIPTION
This PR introduces sorting normalFillTransparentBin drawables by their distance from the eye before draw calls, to improve the zones appearance.