### PR TITLE
XCD-176 IPad Cut Mode

### DIFF
--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -411,14 +411,34 @@ class Control {
                 isObject: false
             }), NO_STATE_INHERIT);
 
+            const bigArrowHead = new Mesh(rootNode, {
+                geometry: shapes.arrowHeadBig,
+                material: material,
+                matrix: arrowMatrix,
+                pickable: false,
+                collidable: true,
+                clippable: false,
+                visible: false,
+                isObject: false
+            });
+
+            meshesToAdd.push(bigArrowHead);
+
             return {
                 arrowHandleId: arrowHandle.id,
                 shaftHandleId: shaftHandle.id,
+                bigArrowHead: bigArrowHead,
                 set visible(v) {
                     arrow.visible = arrowHandle.visible = shaft.visible = shaftHandle.visible = v;
+                    if (! v) {
+                        bigArrowHead.visible = v;
+                    }
                 },
                 set culled(c) {
                     arrow.culled = arrowHandle.culled = shaft.culled = shaftHandle.culled = c;
+                    if (! c) {
+                        bigArrowHead.culled = c;
+                    }
                 }
             };
         };
@@ -619,51 +639,6 @@ class Control {
                 visible: false,
                 scale: [1, 1, 1],
                 rotation: [0, 0, 45],
-                isObject: false
-            }), NO_STATE_INHERIT),
-
-            xAxisArrow: rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.arrowHeadBig,
-                material: materials.red,
-                matrix: (function () {
-                    const translate = math.translateMat4c(0, radius + .1, 0, math.identityMat4());
-                    const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [0, 0, 1], math.identityMat4());
-                    return math.mulMat4(rotate, translate, math.identityMat4());
-                })(),
-                pickable: false,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT),
-
-            yAxisArrow: rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.arrowHeadBig,
-                material: materials.green,
-                matrix: (function () {
-                    const translate = math.translateMat4c(0, radius + .1, 0, math.identityMat4());
-                    const rotate = math.rotationMat4v(180 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
-                    return math.mulMat4(rotate, translate, math.identityMat4());
-                })(),
-                pickable: false,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT),
-
-            zAxisArrow: rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.arrowHeadBig,
-                material: materials.blue,
-                matrix: (function () {
-                    const translate = math.translateMat4c(0, radius + .1, 0, math.identityMat4());
-                    const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
-                    return math.mulMat4(rotate, translate, math.identityMat4());
-                })(),
-                pickable: false,
-                collidable: true,
-                clippable: false,
-                visible: false,
                 isObject: false
             }), NO_STATE_INHERIT)
         };
@@ -889,32 +864,20 @@ class Control {
                 switch (meshId) {
 
                     case this._displayMeshes.xAxis.arrowHandleId:
-                        affordanceMesh = this._affordanceMeshes.xAxisArrow;
-                        nextDragAction = DRAG_ACTIONS.xTranslate;
-                        break;
-
                     case this._displayMeshes.xAxis.shaftHandleId:
-                        affordanceMesh = this._affordanceMeshes.xAxisArrow;
+                        affordanceMesh = this._displayMeshes.xAxis.bigArrowHead;
                         nextDragAction = DRAG_ACTIONS.xTranslate;
                         break;
 
                     case this._displayMeshes.yAxis.arrowHandleId:
-                        affordanceMesh = this._affordanceMeshes.yAxisArrow;
-                        nextDragAction = DRAG_ACTIONS.yTranslate;
-                        break;
-
                     case this._displayMeshes.yAxis.shaftHandleId:
-                        affordanceMesh = this._affordanceMeshes.yAxisArrow;
+                        affordanceMesh = this._displayMeshes.yAxis.bigArrowHead;
                         nextDragAction = DRAG_ACTIONS.yTranslate;
                         break;
 
                     case this._displayMeshes.zAxis.arrowHandleId:
-                        affordanceMesh = this._affordanceMeshes.zAxisArrow;
-                        nextDragAction = DRAG_ACTIONS.zTranslate;
-                        break;
-
                     case this._displayMeshes.zAxis.shaftHandleId:
-                        affordanceMesh = this._affordanceMeshes.zAxisArrow;
+                        affordanceMesh = this._displayMeshes.zAxis.bigArrowHead;
                         nextDragAction = DRAG_ACTIONS.zTranslate;
                         break;
 

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -276,6 +276,64 @@ class Control {
             })
         };
 
+        const addCurve = (material, matrix, matrix1, matrix2) => {
+            const curve = rootNode.addChild(new Mesh(rootNode, {
+                geometry: shapes.curve,
+                material: material,
+                matrix: matrix,
+                pickable: false,
+                collidable: true,
+                clippable: false,
+                backfaces: true,
+                visible: false,
+                isObject: false
+            }), NO_STATE_INHERIT);
+
+            const handle = rootNode.addChild(new Mesh(rootNode, {
+                geometry: shapes.curveHandle,
+                material: materials.pickable,
+                matrix: matrix,
+                pickable: true,
+                collidable: true,
+                clippable: false,
+                backfaces: true,
+                visible: false,
+                isObject: false
+            }), NO_STATE_INHERIT);
+
+            const arrow1 = rootNode.addChild(new Mesh(rootNode, {
+                geometry: shapes.arrowHead,
+                material: material,
+                matrix: matrix1,
+                pickable: true,
+                collidable: true,
+                clippable: false,
+                visible: false,
+                isObject: false
+            }), NO_STATE_INHERIT);
+
+            const arrow2 = rootNode.addChild(new Mesh(rootNode, {
+                geometry: shapes.arrowHead,
+                material: material,
+                matrix: matrix2,
+                pickable: true,
+                collidable: true,
+                clippable: false,
+                visible: false,
+                isObject: false
+            }), NO_STATE_INHERIT);
+
+            return {
+                handleId: handle.id,
+                set visible(v) {
+                    curve.visible = handle.visible = arrow1.visible = arrow2.visible = v;
+                },
+                set culled(c) {
+                    curve.culled = handle.culled = arrow1.culled = arrow2.culled = c;
+                }
+            };
+        };
+
         this._displayMeshes = {
 
             plane: rootNode.addChild(new Mesh(rootNode, {
@@ -348,253 +406,70 @@ class Control {
             //
             //----------------------------------------------------------------------------------------------------------
 
-            xCurveHandle: (function() {
-
-                const material = materials.red;
-
-                const matrix = (function () {
+            xCurve: addCurve(
+                materials.red,
+                (function () {
                     const rotate2 = math.rotationMat4v(90 * math.DEGTORAD, [0, 1, 0], math.identityMat4());
                     const rotate1 = math.rotationMat4v(270 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
                     return math.mulMat4(rotate1, rotate2, math.identityMat4());
-                })();
-
-                const mat1 = (function () {
+                })(),
+                (function () {
                     const translate = math.translateMat4c(0., -0.07, -0.8, math.identityMat4());
                     const scale = math.scaleMat4v([0.6, 0.6, 0.6], math.identityMat4());
                     const rotate = math.rotationMat4v(0 * math.DEGTORAD, [0, 0, 1], math.identityMat4());
                     return math.mulMat4(math.mulMat4(translate, scale, math.identityMat4()), rotate, math.identityMat4());
-                })();
-
-                const mat2 = (function () {
+                })(),
+                (function () {
                     const translate = math.translateMat4c(0.0, -0.8, -0.07, math.identityMat4());
                     const scale = math.scaleMat4v([0.6, 0.6, 0.6], math.identityMat4());
                     const rotate = math.rotationMat4v(90 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
                     return math.mulMat4(math.mulMat4(translate, scale, math.identityMat4()), rotate, math.identityMat4());
-                })();
-
-            const curve = rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.curve,
-                material: material,
-                matrix: matrix,
-                pickable: false,
-                collidable: true,
-                clippable: false,
-                backfaces: true,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT);
-
-            const handle = rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.curveHandle,
-                material: materials.pickable,
-                matrix: matrix,
-                pickable: true,
-                collidable: true,
-                clippable: false,
-                backfaces: true,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT);
-
-            const arrow1 = rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.arrowHead,
-                material: material,
-                matrix: mat1,
-                pickable: true,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT);
-
-            const arrow2 = rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.arrowHead,
-                material: material,
-                matrix: mat2,
-                pickable: true,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT);
-
-                return {
-                    id: handle.id,
-                    set visible(v) {
-                        curve.visible = handle.visible = arrow1.visible = arrow2.visible = v;
-                    },
-                    set culled(c) {
-                        curve.culled = handle.culled = arrow1.culled = arrow2.culle = c;
-                    }
-                };
-            })(),
+                })()),
 
             //----------------------------------------------------------------------------------------------------------
             //
             //----------------------------------------------------------------------------------------------------------
 
-            yCurveHandle: (function() {
-
-                const material = materials.green;
-
-                const matrix = (function() {
+            yCurve: addCurve(
+                materials.green,
+                (function() {
                     const q = math.identityQuaternion();
                     math.eulerToQuaternion([-90, 0, 0], "XYZ", q);
                     const m = math.mat4();
                     math.quaternionToMat4(q, m);
                     return m;
-                })();
-
-                const mat1 = (function () {
+                })(),
+                (function () {
                     const translate = math.translateMat4c(0.07, 0, -0.8, math.identityMat4());
                     const scale = math.scaleMat4v([0.6, 0.6, 0.6], math.identityMat4());
                     const rotate = math.rotationMat4v(90 * math.DEGTORAD, [0, 0, 1], math.identityMat4());
                     return math.mulMat4(math.mulMat4(translate, scale, math.identityMat4()), rotate, math.identityMat4());
-                })();
-
-                const mat2 = (function () {
+                })(),
+                (function () {
                     const translate = math.translateMat4c(0.8, 0.0, -0.07, math.identityMat4());
                     const scale = math.scaleMat4v([0.6, 0.6, 0.6], math.identityMat4());
                     const rotate = math.rotationMat4v(90 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
                     return math.mulMat4(math.mulMat4(translate, scale, math.identityMat4()), rotate, math.identityMat4());
-                })();
-
-            const curve = rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.curve,
-                material: material,
-                matrix: matrix,
-                pickable: false,
-                collidable: true,
-                clippable: false,
-                backfaces: true,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT);
-
-            const handle = rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.curveHandle,
-                material: materials.pickable,
-                matrix: matrix,
-                pickable: true,
-                collidable: true,
-                clippable: false,
-                backfaces: true,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT);
-
-            const arrow1 = rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.arrowHead,
-                material: material,
-                matrix: mat1,
-                pickable: true,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT);
-
-            const arrow2 = rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.arrowHead,
-                material: material,
-                matrix: mat2,
-                pickable: true,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT);
-
-                return {
-                    id: handle.id,
-                    set visible(v) {
-                        curve.visible = handle.visible = arrow1.visible = arrow2.visible = v;
-                    },
-                    set culled(c) {
-                        curve.culled = handle.culled = arrow1.culled = arrow2.culle = c;
-                    }
-                };
-            })(),
+                })()),
 
             //----------------------------------------------------------------------------------------------------------
             //
             //----------------------------------------------------------------------------------------------------------
 
-            zCurveHandle: (function() {
-
-                const material = materials.blue;
-
-                const matrix = math.rotationMat4v(180 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
-
-                const mat1 = (function () {
+            zCurve: addCurve(
+                materials.blue,
+                math.rotationMat4v(180 * math.DEGTORAD, [1, 0, 0], math.identityMat4()),
+                (function () {
                     const translate = math.translateMat4c(.8, -0.07, 0, math.identityMat4());
                     const scale = math.scaleMat4v([0.6, 0.6, 0.6], math.identityMat4());
                     return math.mulMat4(translate, scale, math.identityMat4());
-                })();
-
-                const mat2 = (function () {
+                })(),
+                (function () {
                     const translate = math.translateMat4c(.05, -0.8, 0, math.identityMat4());
                     const scale = math.scaleMat4v([0.6, 0.6, 0.6], math.identityMat4());
                     const rotate = math.rotationMat4v(90 * math.DEGTORAD, [0, 0, 1], math.identityMat4());
                     return math.mulMat4(math.mulMat4(translate, scale, math.identityMat4()), rotate, math.identityMat4());
-                })();
-
-            const curve = rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.curve,
-                material: material,
-                matrix: matrix,
-                pickable: false,
-                collidable: true,
-                clippable: false,
-                backfaces: true,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT);
-
-            const handle = rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.curveHandle,
-                material: materials.pickable,
-                matrix: matrix,
-                pickable: true,
-                collidable: true,
-                clippable: false,
-                backfaces: true,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT);
-
-            const arrow1 = rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.arrowHead,
-                material: material,
-                matrix: mat1,
-                pickable: true,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT);
-
-            const arrow2 = rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.arrowHead,
-                material: material,
-                matrix: mat2,
-                pickable: true,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT);
-
-                return {
-                    id: handle.id,
-                    set visible(v) {
-                        curve.visible = handle.visible = arrow1.visible = arrow2.visible = v;
-                    },
-                    set culled(c) {
-                        curve.culled = handle.culled = arrow1.culled = arrow2.culle = c;
-                    }
-                };
-            })(),
+                })()),
 
             //----------------------------------------------------------------------------------------------------------
             //
@@ -1170,17 +1045,17 @@ class Control {
                         nextDragAction = DRAG_ACTIONS.zTranslate;
                         break;
 
-                    case this._displayMeshes.xCurveHandle.id:
+                    case this._displayMeshes.xCurve.handleId:
                         affordanceMesh = this._affordanceMeshes.xHoop;
                         nextDragAction = DRAG_ACTIONS.xRotate;
                         break;
 
-                    case this._displayMeshes.yCurveHandle.id:
+                    case this._displayMeshes.yCurve.handleId:
                         affordanceMesh = this._affordanceMeshes.yHoop;
                         nextDragAction = DRAG_ACTIONS.yRotate;
                         break;
 
-                    case this._displayMeshes.zCurveHandle.id:
+                    case this._displayMeshes.zCurve.handleId:
                         affordanceMesh = this._affordanceMeshes.zHoop;
                         nextDragAction = DRAG_ACTIONS.zRotate;
                         break;

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -43,7 +43,6 @@ class Control {
 
         this._rootNode = null; // Root of Node graph that represents this control in the 3D scene
         this._displayMeshes = null; // Meshes that are always visible
-        this._affordanceMeshes = null; // Meshes displayed momentarily for affordance
 
         this._ignoreNextSectionPlaneDirUpdate = false;
 
@@ -130,13 +129,6 @@ class Control {
                 this._displayMeshes[id].visible = visible;
             }
         }
-        if (!visible) {
-            for (id in this._affordanceMeshes) {
-                if (this._affordanceMeshes.hasOwnProperty(id)) {
-                    this._affordanceMeshes[id].visible = visible;
-                }
-            }
-        }
     }
 
     /**
@@ -158,13 +150,6 @@ class Control {
         for (id in this._displayMeshes) {
             if (this._displayMeshes.hasOwnProperty(id)) {
                 this._displayMeshes[id].culled = culled;
-            }
-        }
-        if (!culled) {
-            for (id in this._affordanceMeshes) {
-                if (this._affordanceMeshes.hasOwnProperty(id)) {
-                    this._affordanceMeshes[id].culled = culled;
-                }
             }
         }
     }
@@ -609,39 +594,6 @@ class Control {
         };
 
         meshesToAdd.forEach(m => rootNode.addChild(m, NO_STATE_INHERIT));
-
-        this._affordanceMeshes = {
-
-            planeFrame: rootNode.addChild(new Mesh(rootNode, {
-                geometry: new ReadableGeometry(rootNode, buildTorusGeometry({
-                    center: [0, 0, 0],
-                    radius: 2,
-                    tube: tubeRadius,
-                    radialSegments: 4,
-                    tubeSegments: 4,
-                    arc: Math.PI * 2.0
-                })),
-                material: new PhongMaterial(rootNode, {
-                    ambient: [1, 1, 1],
-                    diffuse: [0, 0, 0],
-                    emissive: [1, 1, 0]
-                }),
-                highlighted: true,
-                highlightMaterial: new EmphasisMaterial(rootNode, {
-                    edges: false,
-                    filled: true,
-                    fillColor: [1, 1, 0],
-                    fillAlpha: 1.0
-                }),
-                pickable: false,
-                collidable: false,
-                clippable: false,
-                visible: false,
-                scale: [1, 1, 1],
-                rotation: [0, 0, 45],
-                isObject: false
-            }), NO_STATE_INHERIT)
-        };
     }
 
     _bindEvents() {
@@ -1032,7 +984,6 @@ class Control {
         this._setSectionPlane(null);
         this._rootNode.destroy();
         this._displayMeshes = {};
-        this._affordanceMeshes = {};
     }
 }
 

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -676,11 +676,10 @@ class Control {
         })();
 
         {
-            let down = false;
             let lastAffordanceMesh = null;
 
             this._onCameraControlHover = this._viewer.cameraControl.on("hoverEnter", (hit) => {
-                if (this._visible && (! down)) {
+                if (this._visible && (! dragAction)) {
                     if (lastAffordanceMesh) {
                         lastAffordanceMesh.visible = false;
                     }
@@ -711,31 +710,28 @@ class Control {
                 e.preventDefault();
                 if (this._visible && (e.which === 1) && nextDragAction) { // Left button
                     this._viewer.cameraControl.pointerEnabled = false;
-                    down = true;
                     dragAction = nextDragAction;
                     lastCanvasPos.set(getClickCoordsWithinElement(e));
                 }
             });
 
             canvas.addEventListener("mousemove", this._canvasMouseMoveListener = (e) => {
-                if (this._visible && down) {
+                if (this._visible && dragAction) {
                     const canvasPos = getClickCoordsWithinElement(e);
-                    if (dragAction) {
-                        const [ isTranslate, axis ] = dragAction;
-                        if (isTranslate) {
-                            dragTranslateSectionPlane(axis, lastCanvasPos, canvasPos);
-                        } else {
-                            dragRotateSectionPlane(axis, lastCanvasPos, canvasPos);
-                        }
+                    const [ isTranslate, axis ] = dragAction;
+                    if (isTranslate) {
+                        dragTranslateSectionPlane(axis, lastCanvasPos, canvasPos);
+                    } else {
+                        dragRotateSectionPlane(axis, lastCanvasPos, canvasPos);
                     }
                     lastCanvasPos.set(canvasPos);
                 }
             });
 
             canvas.addEventListener("mouseup", this._canvasMouseUpListener = (e) => {
-                if (this._visible && down) {
+                if (this._visible && dragAction) {
                     this._viewer.cameraControl.pointerEnabled = true;
-                    down = false;
+                    dragAction = null;
                 }
             });
         }

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -638,6 +638,29 @@ class Control {
                     currentDrag.cleanup();
                 }
             });
+
+
+            addCanvasEventListener("touchstart", event => {
+                event.preventDefault();
+                if (event.touches.length === 1)
+                {
+                    const touchStartId = event.touches[0].identifier;
+                    startDrag(event, event => [...event.changedTouches].find(e => e.identifier === touchStartId));
+                }
+            });
+
+            addCanvasEventListener("touchmove", event => {
+                event.preventDefault();
+                currentDrag && currentDrag.onChange(event);
+            });
+
+            addCanvasEventListener("touchend",  event => {
+                event.preventDefault();
+                if (currentDrag) {
+                    currentDrag.onChange(event);
+                    currentDrag.cleanup();
+                }
+            });
         }
 
         this._unbindSectionPlane = () => { };

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -47,11 +47,9 @@ class Control {
 
         // Builds the Entities that represent this Control.
         const NO_STATE_INHERIT = false;
-        const radius = 1.0;
-        const handleTubeRadius = 0.06;
-        const hoopRadius = radius - 0.2;
+        const arrowLength = 1.0;
+        const handleRadius = 0.09;
         const tubeRadius = 0.01;
-        const arrowRadius = 0.07;
 
         const rootNode = new Node(scene, { // Root of Node graph that represents this control in the 3D scene
             position: [0, 0, 0],
@@ -59,10 +57,10 @@ class Control {
             isObject: false
         });
 
-        const arrowGeometry = (radiusBottom, height, radialSegments) => new ReadableGeometry(rootNode, buildCylinderGeometry({
+        const arrowGeometry = (radiusBottom, height) => new ReadableGeometry(rootNode, buildCylinderGeometry({
             radiusTop: 0.001,
             radiusBottom: radiusBottom,
-            radialSegments: radialSegments,
+            radialSegments: 32,
             heightSegments: 1,
             height: height,
             openEnded: false
@@ -78,7 +76,7 @@ class Control {
         }));
 
         const torusGeometry = (tube, arcFraction, tubeSegments) => new ReadableGeometry(rootNode, buildTorusGeometry({
-            radius: hoopRadius,
+            radius: arrowLength - 0.2,
             tube: tube,
             radialSegments: 64,
             tubeSegments: tubeSegments,
@@ -87,16 +85,16 @@ class Control {
 
         const shapes = {// Reusable geometries
 
-            arrowHead: arrowGeometry(arrowRadius, 0.2, 32),
-            arrowHeadBig: arrowGeometry(0.09, 0.25, 32),
-            arrowHeadHandle: tubeGeometry(0.09, 0.37, 8),
+            curve:       torusGeometry(tubeRadius,   0.25, 14),
+            curveHandle: torusGeometry(handleRadius, 0.25, 14),
+            hoop:        torusGeometry(tubeRadius,   1,     8),
 
-            curve:       torusGeometry(tubeRadius, 0.25, 14),
-            curveHandle: torusGeometry(handleTubeRadius, 0.25, 14),
-            hoop:        torusGeometry(tubeRadius, 1, 8),
+            arrowHead:       arrowGeometry(0.07, 0.2),
+            arrowHeadBig:    arrowGeometry(0.09, 0.25),
+            arrowHeadHandle: tubeGeometry(handleRadius, 0.37, 8),
 
-            axis: tubeGeometry(tubeRadius, radius, 20),
-            axisHandle: tubeGeometry(0.08, radius, 20)
+            axis:       tubeGeometry(tubeRadius,   arrowLength, 20),
+            axisHandle: tubeGeometry(handleRadius, arrowLength, 20)
         };
 
         const colorMaterial = (rgb) => new PhongMaterial(rootNode, {
@@ -202,8 +200,8 @@ class Control {
             const axisRotation = math.quaternionToRotationMat4(math.vec3PairToQuaternion([ 0, 1, 0 ], axisDirection), math.identityMat4());
 
             const translatedAxisMatrix = (yOffset) => math.mulMat4(axisRotation, math.translateMat4c(0, yOffset, 0, math.identityMat4()), math.identityMat4());
-            const arrowMatrix = translatedAxisMatrix(radius + .1);
-            const shaftMatrix = translatedAxisMatrix(radius / 2);
+            const arrowMatrix = translatedAxisMatrix(arrowLength + .1);
+            const shaftMatrix = translatedAxisMatrix(arrowLength / 2);
 
             const arrow = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.arrowHead,

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -263,8 +263,8 @@ class Control {
                 isObject: false
             }), NO_STATE_INHERIT);
 
-            handlers[arrowHandle.id] = handlers[shaftHandle.id] = [ bigArrowHead, [ true, rgb ] ];
-            handlers[rotateHandle.id] = [ hoop, [ false, rgb ] ];
+            handlers[arrowHandle.id] = handlers[shaftHandle.id] = [ bigArrowHead, (lastCanvasPos, canvasPos) => dragTranslateSectionPlane(rgb, lastCanvasPos, canvasPos) ];
+            handlers[rotateHandle.id] = [ hoop, (lastCanvasPos, canvasPos) => dragRotateSectionPlane(rgb, lastCanvasPos, canvasPos) ];
 
             return {
                 set visible(v) {
@@ -581,12 +581,7 @@ class Control {
             addCanvasEventListener("mousemove", (e) => {
                 if (this._visible && dragAction) {
                     getClickCoordsWithinElement(e, canvasPos);
-                    const [ isTranslate, axis ] = dragAction;
-                    if (isTranslate) {
-                        dragTranslateSectionPlane(axis, lastCanvasPos, canvasPos);
-                    } else {
-                        dragRotateSectionPlane(axis, lastCanvasPos, canvasPos);
-                    }
+                    dragAction(lastCanvasPos, canvasPos);
                     lastCanvasPos.set(canvasPos);
                 }
             });

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -263,12 +263,20 @@ class Control {
 
         const meshesToAdd = [ ];
 
-        const addCurve = (material, highlightMaterial, direction, matrix1, matrix2) => {
+        const addCurve = (material, highlightMaterial, direction) => {
             const rotateToHorizontal = math.rotationMat4v(270 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
             const rotation = math.quaternionToRotationMat4(math.vec3PairToQuaternion([ 0, 1, 0 ], direction), math.identityMat4());
             const matrix = math.mulMat4(rotation, rotateToHorizontal, math.identityMat4());
 
             const scale = math.scaleMat4v([0.6, 0.6, 0.6], math.identityMat4());
+
+            const scaledArrowMatrix = (t, matR) => {
+                const matT = math.translateMat4v(t, math.identityMat4());
+                const ret = math.identityMat4();
+                math.mulMat4(matT, matR, ret);
+                math.mulMat4(matrix, ret, ret);
+                return math.mulMat4(ret, scale, math.identityMat4());
+            };
 
             const curve = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.curve,
@@ -297,7 +305,7 @@ class Control {
             const arrow1 = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.arrowHead,
                 material: material,
-                matrix: math.mulMat4(matrix1, scale, math.identityMat4()),
+                matrix: scaledArrowMatrix([ .8, .07, 0 ], math.rotationMat4v(180 * math.DEGTORAD, [0, 0, 1], math.identityMat4())),
                 pickable: true,
                 collidable: true,
                 clippable: false,
@@ -308,7 +316,7 @@ class Control {
             const arrow2 = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.arrowHead,
                 material: material,
-                matrix: math.mulMat4(matrix2, scale, math.identityMat4()),
+                matrix: scaledArrowMatrix([ .07, .8, 0 ], math.rotationMat4v(90 * math.DEGTORAD, [0, 0, 1], math.identityMat4())),
                 pickable: true,
                 collidable: true,
                 clippable: false,
@@ -506,57 +514,9 @@ class Control {
             //
             //----------------------------------------------------------------------------------------------------------
 
-            xCurve: addCurve(
-                materials.red,
-                materials.highlightRed,
-                [1,0,0],
-                (function () {
-                    const translate = math.translateMat4c(0., -0.07, -0.8, math.identityMat4());
-                    const rotate = math.rotationMat4v(0 * math.DEGTORAD, [0, 0, 1], math.identityMat4());
-                    return math.mulMat4(translate, rotate, math.identityMat4());
-                })(),
-                (function () {
-                    const translate = math.translateMat4c(0.0, -0.8, -0.07, math.identityMat4());
-                    const rotate = math.rotationMat4v(90 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
-                    return math.mulMat4(translate, rotate, math.identityMat4());
-                })()),
-
-            //----------------------------------------------------------------------------------------------------------
-            //
-            //----------------------------------------------------------------------------------------------------------
-
-            yCurve: addCurve(
-                materials.green,
-                materials.highlightGreen,
-                [0,1,0],
-                (function () {
-                    const translate = math.translateMat4c(0.07, 0, -0.8, math.identityMat4());
-                    const rotate = math.rotationMat4v(90 * math.DEGTORAD, [0, 0, 1], math.identityMat4());
-                    return math.mulMat4(translate, rotate, math.identityMat4());
-                })(),
-                (function () {
-                    const translate = math.translateMat4c(0.8, 0.0, -0.07, math.identityMat4());
-                    const rotate = math.rotationMat4v(90 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
-                    return math.mulMat4(translate, rotate, math.identityMat4());
-                })()),
-
-            //----------------------------------------------------------------------------------------------------------
-            //
-            //----------------------------------------------------------------------------------------------------------
-
-            zCurve: addCurve(
-                materials.blue,
-                materials.highlightBlue,
-                [0,0,-1],
-                (function () {
-                    const translate = math.translateMat4c(.8, -0.07, 0, math.identityMat4());
-                    return translate;
-                })(),
-                (function () {
-                    const translate = math.translateMat4c(.05, -0.8, 0, math.identityMat4());
-                    const rotate = math.rotationMat4v(90 * math.DEGTORAD, [0, 0, 1], math.identityMat4());
-                    return math.mulMat4(translate, rotate, math.identityMat4());
-                })()),
+            xCurve: addCurve(materials.red,   materials.highlightRed,   [ 1, 0, 0 ]),
+            yCurve: addCurve(materials.green, materials.highlightGreen, [ 0, 1, 0 ]),
+            zCurve: addCurve(materials.blue,  materials.highlightBlue,  [ 0, 0, -1 ]),
 
             //----------------------------------------------------------------------------------------------------------
             //

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -348,188 +348,253 @@ class Control {
             //
             //----------------------------------------------------------------------------------------------------------
 
-            xCurve: rootNode.addChild(new Mesh(rootNode, { // Red hoop about Y-axis
-                geometry: shapes.curve,
-                material: materials.red,
-                matrix: (function () {
+            xCurveHandle: (function() {
+
+                const material = materials.red;
+
+                const matrix = (function () {
                     const rotate2 = math.rotationMat4v(90 * math.DEGTORAD, [0, 1, 0], math.identityMat4());
                     const rotate1 = math.rotationMat4v(270 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
                     return math.mulMat4(rotate1, rotate2, math.identityMat4());
-                })(),
-                pickable: false,
-                collidable: true,
-                clippable: false,
-                backfaces: true,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT),
+                })();
 
-            xCurveHandle: rootNode.addChild(new Mesh(rootNode, { // Red hoop about Y-axis
-                geometry: shapes.curveHandle,
-                material: materials.pickable,
-                matrix: (function () {
-                    const rotate2 = math.rotationMat4v(90 * math.DEGTORAD, [0, 1, 0], math.identityMat4());
-                    const rotate1 = math.rotationMat4v(270 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
-                    return math.mulMat4(rotate1, rotate2, math.identityMat4());
-                })(),
-                pickable: true,
-                collidable: true,
-                clippable: false,
-                backfaces: true,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT),
-
-            xCurveArrow1: rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.arrowHead,
-                material: materials.red,
-                matrix: (function () {
+                const mat1 = (function () {
                     const translate = math.translateMat4c(0., -0.07, -0.8, math.identityMat4());
                     const scale = math.scaleMat4v([0.6, 0.6, 0.6], math.identityMat4());
                     const rotate = math.rotationMat4v(0 * math.DEGTORAD, [0, 0, 1], math.identityMat4());
                     return math.mulMat4(math.mulMat4(translate, scale, math.identityMat4()), rotate, math.identityMat4());
-                })(),
-                pickable: true,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT),
+                })();
 
-            xCurveArrow2: rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.arrowHead,
-                material: materials.red,
-                matrix: (function () {
+                const mat2 = (function () {
                     const translate = math.translateMat4c(0.0, -0.8, -0.07, math.identityMat4());
                     const scale = math.scaleMat4v([0.6, 0.6, 0.6], math.identityMat4());
                     const rotate = math.rotationMat4v(90 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
                     return math.mulMat4(math.mulMat4(translate, scale, math.identityMat4()), rotate, math.identityMat4());
-                })(),
-                pickable: true,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT),
+                })();
 
-            //----------------------------------------------------------------------------------------------------------
-            //
-            //----------------------------------------------------------------------------------------------------------
-
-            yCurve: rootNode.addChild(new Mesh(rootNode, {
+            const curve = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.curve,
-                material: materials.green,
-                rotation: [-90, 0, 0],
+                material: material,
+                matrix: matrix,
                 pickable: false,
                 collidable: true,
                 clippable: false,
                 backfaces: true,
                 visible: false,
                 isObject: false
-            }), NO_STATE_INHERIT),
+            }), NO_STATE_INHERIT);
 
-            yCurveHandle: rootNode.addChild(new Mesh(rootNode, {
+            const handle = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.curveHandle,
                 material: materials.pickable,
-                rotation: [-90, 0, 0],
+                matrix: matrix,
                 pickable: true,
                 collidable: true,
                 clippable: false,
                 backfaces: true,
                 visible: false,
                 isObject: false
-            }), NO_STATE_INHERIT),
+            }), NO_STATE_INHERIT);
 
-            yCurveArrow1: rootNode.addChild(new Mesh(rootNode, {
+            const arrow1 = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.arrowHead,
-                material: materials.green,
-                matrix: (function () {
+                material: material,
+                matrix: mat1,
+                pickable: true,
+                collidable: true,
+                clippable: false,
+                visible: false,
+                isObject: false
+            }), NO_STATE_INHERIT);
+
+            const arrow2 = rootNode.addChild(new Mesh(rootNode, {
+                geometry: shapes.arrowHead,
+                material: material,
+                matrix: mat2,
+                pickable: true,
+                collidable: true,
+                clippable: false,
+                visible: false,
+                isObject: false
+            }), NO_STATE_INHERIT);
+
+                return {
+                    id: handle.id,
+                    set visible(v) {
+                        curve.visible = handle.visible = arrow1.visible = arrow2.visible = v;
+                    },
+                    set culled(c) {
+                        curve.culled = handle.culled = arrow1.culled = arrow2.culle = c;
+                    }
+                };
+            })(),
+
+            //----------------------------------------------------------------------------------------------------------
+            //
+            //----------------------------------------------------------------------------------------------------------
+
+            yCurveHandle: (function() {
+
+                const material = materials.green;
+
+                const matrix = (function() {
+                    const q = math.identityQuaternion();
+                    math.eulerToQuaternion([-90, 0, 0], "XYZ", q);
+                    const m = math.mat4();
+                    math.quaternionToMat4(q, m);
+                    return m;
+                })();
+
+                const mat1 = (function () {
                     const translate = math.translateMat4c(0.07, 0, -0.8, math.identityMat4());
                     const scale = math.scaleMat4v([0.6, 0.6, 0.6], math.identityMat4());
                     const rotate = math.rotationMat4v(90 * math.DEGTORAD, [0, 0, 1], math.identityMat4());
                     return math.mulMat4(math.mulMat4(translate, scale, math.identityMat4()), rotate, math.identityMat4());
-                })(),
-                pickable: true,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT),
+                })();
 
-            yCurveArrow2: rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.arrowHead,
-                material: materials.green,
-                matrix: (function () {
+                const mat2 = (function () {
                     const translate = math.translateMat4c(0.8, 0.0, -0.07, math.identityMat4());
                     const scale = math.scaleMat4v([0.6, 0.6, 0.6], math.identityMat4());
                     const rotate = math.rotationMat4v(90 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
                     return math.mulMat4(math.mulMat4(translate, scale, math.identityMat4()), rotate, math.identityMat4());
-                })(),
-                pickable: true,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT),
+                })();
 
-            //----------------------------------------------------------------------------------------------------------
-            //
-            //----------------------------------------------------------------------------------------------------------
-
-            zCurve: rootNode.addChild(new Mesh(rootNode, { // Blue hoop about Z-axis
+            const curve = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.curve,
-                material: materials.blue,
-                matrix: math.rotationMat4v(180 * math.DEGTORAD, [1, 0, 0], math.identityMat4()),
+                material: material,
+                matrix: matrix,
                 pickable: false,
                 collidable: true,
                 clippable: false,
                 backfaces: true,
                 visible: false,
                 isObject: false
-            }), NO_STATE_INHERIT),
+            }), NO_STATE_INHERIT);
 
-            zCurveHandle: rootNode.addChild(new Mesh(rootNode, {
+            const handle = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.curveHandle,
                 material: materials.pickable,
-                matrix: math.rotationMat4v(180 * math.DEGTORAD, [1, 0, 0], math.identityMat4()),
+                matrix: matrix,
                 pickable: true,
                 collidable: true,
                 clippable: false,
                 backfaces: true,
                 visible: false,
                 isObject: false
-            }), NO_STATE_INHERIT),
+            }), NO_STATE_INHERIT);
 
-            zCurveCurveArrow1: rootNode.addChild(new Mesh(rootNode, {
+            const arrow1 = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.arrowHead,
-                material: materials.blue,
-                matrix: (function () {
-                    const translate = math.translateMat4c(.8, -0.07, 0, math.identityMat4());
-                    const scale = math.scaleMat4v([0.6, 0.6, 0.6], math.identityMat4());
-                    return math.mulMat4(translate, scale, math.identityMat4());
-                })(),
+                material: material,
+                matrix: mat1,
                 pickable: true,
                 collidable: true,
                 clippable: false,
                 visible: false,
                 isObject: false
-            }), NO_STATE_INHERIT),
+            }), NO_STATE_INHERIT);
 
-            zCurveArrow2: rootNode.addChild(new Mesh(rootNode, {
+            const arrow2 = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.arrowHead,
-                material: materials.blue,
-                matrix: (function () {
+                material: material,
+                matrix: mat2,
+                pickable: true,
+                collidable: true,
+                clippable: false,
+                visible: false,
+                isObject: false
+            }), NO_STATE_INHERIT);
+
+                return {
+                    id: handle.id,
+                    set visible(v) {
+                        curve.visible = handle.visible = arrow1.visible = arrow2.visible = v;
+                    },
+                    set culled(c) {
+                        curve.culled = handle.culled = arrow1.culled = arrow2.culle = c;
+                    }
+                };
+            })(),
+
+            //----------------------------------------------------------------------------------------------------------
+            //
+            //----------------------------------------------------------------------------------------------------------
+
+            zCurveHandle: (function() {
+
+                const material = materials.blue;
+
+                const matrix = math.rotationMat4v(180 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
+
+                const mat1 = (function () {
+                    const translate = math.translateMat4c(.8, -0.07, 0, math.identityMat4());
+                    const scale = math.scaleMat4v([0.6, 0.6, 0.6], math.identityMat4());
+                    return math.mulMat4(translate, scale, math.identityMat4());
+                })();
+
+                const mat2 = (function () {
                     const translate = math.translateMat4c(.05, -0.8, 0, math.identityMat4());
                     const scale = math.scaleMat4v([0.6, 0.6, 0.6], math.identityMat4());
                     const rotate = math.rotationMat4v(90 * math.DEGTORAD, [0, 0, 1], math.identityMat4());
                     return math.mulMat4(math.mulMat4(translate, scale, math.identityMat4()), rotate, math.identityMat4());
-                })(),
+                })();
+
+            const curve = rootNode.addChild(new Mesh(rootNode, {
+                geometry: shapes.curve,
+                material: material,
+                matrix: matrix,
+                pickable: false,
+                collidable: true,
+                clippable: false,
+                backfaces: true,
+                visible: false,
+                isObject: false
+            }), NO_STATE_INHERIT);
+
+            const handle = rootNode.addChild(new Mesh(rootNode, {
+                geometry: shapes.curveHandle,
+                material: materials.pickable,
+                matrix: matrix,
+                pickable: true,
+                collidable: true,
+                clippable: false,
+                backfaces: true,
+                visible: false,
+                isObject: false
+            }), NO_STATE_INHERIT);
+
+            const arrow1 = rootNode.addChild(new Mesh(rootNode, {
+                geometry: shapes.arrowHead,
+                material: material,
+                matrix: mat1,
                 pickable: true,
                 collidable: true,
                 clippable: false,
                 visible: false,
                 isObject: false
-            }), NO_STATE_INHERIT),
+            }), NO_STATE_INHERIT);
+
+            const arrow2 = rootNode.addChild(new Mesh(rootNode, {
+                geometry: shapes.arrowHead,
+                material: material,
+                matrix: mat2,
+                pickable: true,
+                collidable: true,
+                clippable: false,
+                visible: false,
+                isObject: false
+            }), NO_STATE_INHERIT);
+
+                return {
+                    id: handle.id,
+                    set visible(v) {
+                        curve.visible = handle.visible = arrow1.visible = arrow2.visible = v;
+                    },
+                    set culled(c) {
+                        curve.culled = handle.culled = arrow1.culled = arrow2.culle = c;
+                    }
+                };
+            })(),
 
             //----------------------------------------------------------------------------------------------------------
             //

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -41,7 +41,6 @@ class Control {
         this._origin = math.vec3();
         this._rtcPos = math.vec3();
 
-        this._baseDir = math.vec3(); // Saves direction of clip plane when we start dragging an arrow or ring.
         this._rootNode = null; // Root of Node graph that represents this control in the 3D scene
         this._displayMeshes = null; // Meshes that are always visible
         this._affordanceMeshes = null; // Meshes displayed momentarily for affordance
@@ -105,7 +104,6 @@ class Control {
 
     /** @private */
     _setDir(xyz) {
-        this._baseDir.set(xyz);
         this._rootNode.quaternion = math.vec3PairToQuaternion(zeroVec, xyz, quat);
     }
 

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -343,8 +343,8 @@ class Control {
             };
         };
 
-        const addAxis = (material, rotationQuat) => {
-            const rotation = math.quaternionToRotationMat4(rotationQuat, math.identityMat4());
+        const addAxis = (material, direction) => {
+            const rotation = math.quaternionToRotationMat4(math.vec3PairToQuaternion([ 0, 1, 0 ], direction), math.identityMat4());
 
             const arrowT = math.translateMat4c(0, radius + .1, 0, math.identityMat4());
             const arrowMatrix = math.mulMat4(rotation, arrowT, math.identityMat4());
@@ -588,9 +588,9 @@ class Control {
             //
             //----------------------------------------------------------------------------------------------------------
 
-            xAxis: addAxis(materials.red,   math.angleAxisToQuaternion([ 0, 0, 1, -90 * math.DEGTORAD ])),
-            yAxis: addAxis(materials.green, math.angleAxisToQuaternion([ 1, 0, 0, 180 * math.DEGTORAD ])),
-            zAxis: addAxis(materials.blue,  math.angleAxisToQuaternion([ 1, 0, 0, -90 * math.DEGTORAD ]))
+            xAxis: addAxis(materials.red,   [ 1, 0, 0 ]),
+            yAxis: addAxis(materials.green, [ 0, -1, 0 ]),
+            zAxis: addAxis(materials.blue,  [ 0, 0, -1 ])
         };
 
         meshesToAdd.forEach(m => rootNode.addChild(m, NO_STATE_INHERIT));

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -491,186 +491,225 @@ class Control {
             //
             //----------------------------------------------------------------------------------------------------------
 
-            xAxisArrow: rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.arrowHead,
-                material: materials.red,
-                matrix: (function () {
+            xAxis: (function() {
+
+                const material = materials.red;
+
+                const arrowMatrix = (function () {
                     const translate = math.translateMat4c(0, radius + .1, 0, math.identityMat4());
                     const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [0, 0, 1], math.identityMat4());
                     return math.mulMat4(rotate, translate, math.identityMat4());
-                })(),
+                })();
+
+                const shaftMatrix = (function () {
+                    const translate = math.translateMat4c(0, radius / 2, 0, math.identityMat4());
+                    const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [0, 0, 1], math.identityMat4());
+                    return math.mulMat4(rotate, translate, math.identityMat4());
+                })();
+
+            const arrow = rootNode.addChild(new Mesh(rootNode, {
+                geometry: shapes.arrowHead,
+                material: material,
+                matrix: arrowMatrix,
                 pickable: false,
                 collidable: true,
                 clippable: false,
                 visible: false,
                 isObject: false
-            }), NO_STATE_INHERIT),
+            }), NO_STATE_INHERIT);
 
-            xAxisArrowHandle: rootNode.addChild(new Mesh(rootNode, {
+            const arrowHandle = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.arrowHeadHandle,
                 material: materials.pickable,
-                matrix: (function () {
-                    const translate = math.translateMat4c(0, radius + .1, 0, math.identityMat4());
-                    const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [0, 0, 1], math.identityMat4());
-                    return math.mulMat4(rotate, translate, math.identityMat4());
-                })(),
+                matrix: arrowMatrix,
                 pickable: true,
                 collidable: true,
                 clippable: false,
                 visible: false,
                 isObject: false
-            }), NO_STATE_INHERIT),
+            }), NO_STATE_INHERIT);
 
-            xAxis: rootNode.addChild(new Mesh(rootNode, {
+            const shaft = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.axis,
-                material: materials.red,
-                matrix: (function () {
-                    const translate = math.translateMat4c(0, radius / 2, 0, math.identityMat4());
-                    const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [0, 0, 1], math.identityMat4());
-                    return math.mulMat4(rotate, translate, math.identityMat4());
-                })(),
+                material: material,
+                matrix: shaftMatrix,
                 pickable: false,
                 collidable: true,
                 clippable: false,
                 visible: false,
                 isObject: false
-            }), NO_STATE_INHERIT),
+            }), NO_STATE_INHERIT);
 
-            xShaftHandle: rootNode.addChild(new Mesh(rootNode, {
+            const shaftHandle = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.axisHandle,
                 material: materials.pickable,
-                matrix: (function () {
-                    const translate = math.translateMat4c(0, radius / 2, 0, math.identityMat4());
-                    const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [0, 0, 1], math.identityMat4());
-                    return math.mulMat4(rotate, translate, math.identityMat4());
-                })(),
+                matrix: shaftMatrix,
                 pickable: true,
                 collidable: true,
                 clippable: false,
                 visible: false,
                 isObject: false
-            }), NO_STATE_INHERIT),
+            }), NO_STATE_INHERIT);
+
+                return {
+                    arrowHandleId: arrowHandle.id,
+                    shaftHandleId: shaftHandle.id,
+                    set visible(v) {
+                        arrow.visible = arrowHandle.visible = shaft.visible = shaftHandle.visible = v;
+                    },
+                    set culled(c) {
+                        arrow.culled = arrowHandle.culled = shaft.culled = shaftHandle.culled = c;
+                    }
+                };
+            })(),
 
             //----------------------------------------------------------------------------------------------------------
             //
             //----------------------------------------------------------------------------------------------------------
 
-            yAxisArrow: rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.arrowHead,
-                material: materials.green,
-                matrix: (function () {
+            yAxis: (function() {
+
+                const material = materials.green;
+
+                const arrowMatrix = (function () {
                     const translate = math.translateMat4c(0, radius + .1, 0, math.identityMat4());
                     const rotate = math.rotationMat4v(180 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
                     return math.mulMat4(rotate, translate, math.identityMat4());
-                })(),
+                })();
+
+                const shaftMatrix = math.translationMat4v([0, -radius / 2, 0], math.identityMat4());
+
+            const arrow = rootNode.addChild(new Mesh(rootNode, {
+                geometry: shapes.arrowHead,
+                material: material,
+                matrix: arrowMatrix,
                 pickable: false,
                 collidable: true,
                 clippable: false,
                 visible: false,
                 isObject: false
-            }), NO_STATE_INHERIT),
+            }), NO_STATE_INHERIT);
 
-            yAxisArrowHandle: rootNode.addChild(new Mesh(rootNode, {
+            const arrowHandle = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.arrowHeadHandle,
                 material: materials.pickable,
-                matrix: (function () {
-                    const translate = math.translateMat4c(0, radius + .1, 0, math.identityMat4());
-                    const rotate = math.rotationMat4v(180 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
-                    return math.mulMat4(rotate, translate, math.identityMat4());
-                })(),
+                matrix: arrowMatrix,
                 pickable: true,
                 collidable: true,
                 clippable: false,
                 visible: false,
                 isObject: false
-            }), NO_STATE_INHERIT),
+            }), NO_STATE_INHERIT);
 
-            yShaft: rootNode.addChild(new Mesh(rootNode, {
+            const shaft = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.axis,
-                material: materials.green,
-                position: [0, -radius / 2, 0],
+                material: material,
+                matrix: shaftMatrix,
                 pickable: false,
                 collidable: true,
                 clippable: false,
                 visible: false,
                 isObject: false
-            }), NO_STATE_INHERIT),
+            }), NO_STATE_INHERIT);
 
-            yShaftHandle: rootNode.addChild(new Mesh(rootNode, {
+            const shaftHandle = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.axisHandle,
                 material: materials.pickable,
-                position: [0, -radius / 2, 0],
+                matrix: shaftMatrix,
                 pickable: true,
                 collidable: true,
                 clippable: false,
                 visible: false,
                 isObject: false
-            }), NO_STATE_INHERIT),
+            }), NO_STATE_INHERIT);
+
+                return {
+                    arrowHandleId: arrowHandle.id,
+                    shaftHandleId: shaftHandle.id,
+                    set visible(v) {
+                        arrow.visible = arrowHandle.visible = shaft.visible = shaftHandle.visible = v;
+                    },
+                    set culled(c) {
+                        arrow.culled = arrowHandle.culled = shaft.culled = shaftHandle.culled = c;
+                    }
+                };
+            })(),
 
             //----------------------------------------------------------------------------------------------------------
             //
             //----------------------------------------------------------------------------------------------------------
 
-            zAxisArrow: rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.arrowHead,
-                material: materials.blue,
-                matrix: (function () {
+            zAxis: (function() {
+
+                const material = materials.blue;
+
+                const arrowMatrix = (function () {
                     const translate = math.translateMat4c(0, radius + .1, 0, math.identityMat4());
                     const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
                     return math.mulMat4(rotate, translate, math.identityMat4());
-                })(),
+                })();
+
+                const shaftMatrix = (function () {
+                    const translate = math.translateMat4c(0, radius / 2, 0, math.identityMat4());
+                    const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
+                    return math.mulMat4(rotate, translate, math.identityMat4());
+                })();
+
+            const arrow = rootNode.addChild(new Mesh(rootNode, {
+                geometry: shapes.arrowHead,
+                material: material,
+                matrix: arrowMatrix,
                 pickable: false,
                 collidable: true,
                 clippable: false,
                 visible: false,
                 isObject: false
-            }), NO_STATE_INHERIT),
+            }), NO_STATE_INHERIT);
 
-            zAxisArrowHandle: rootNode.addChild(new Mesh(rootNode, {
+            const arrowHandle = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.arrowHeadHandle,
                 material: materials.pickable,
-                matrix: (function () {
-                    const translate = math.translateMat4c(0, radius + .1, 0, math.identityMat4());
-                    const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
-                    return math.mulMat4(rotate, translate, math.identityMat4());
-                })(),
+                matrix: arrowMatrix,
                 pickable: true,
                 collidable: true,
                 clippable: false,
                 visible: false,
                 isObject: false
-            }), NO_STATE_INHERIT),
+            }), NO_STATE_INHERIT);
 
-
-            zShaft: rootNode.addChild(new Mesh(rootNode, {
+            const shaft = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.axis,
-                material: materials.blue,
-                matrix: (function () {
-                    const translate = math.translateMat4c(0, radius / 2, 0, math.identityMat4());
-                    const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
-                    return math.mulMat4(rotate, translate, math.identityMat4());
-                })(),
-                clippable: false,
+                material: material,
+                matrix: shaftMatrix,
                 pickable: false,
                 collidable: true,
+                clippable: false,
                 visible: false,
                 isObject: false
-            }), NO_STATE_INHERIT),
+            }), NO_STATE_INHERIT);
 
-            zShaftHandle: rootNode.addChild(new Mesh(rootNode, {
+            const shaftHandle = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.axisHandle,
                 material: materials.pickable,
-                matrix: (function () {
-                    const translate = math.translateMat4c(0, radius / 2, 0, math.identityMat4());
-                    const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
-                    return math.mulMat4(rotate, translate, math.identityMat4());
-                })(),
-                clippable: false,
+                matrix: shaftMatrix,
                 pickable: true,
                 collidable: true,
+                clippable: false,
                 visible: false,
                 isObject: false
-            }), NO_STATE_INHERIT)
+            }), NO_STATE_INHERIT);
+
+                return {
+                    arrowHandleId: arrowHandle.id,
+                    shaftHandleId: shaftHandle.id,
+                    set visible(v) {
+                        arrow.visible = arrowHandle.visible = shaft.visible = shaftHandle.visible = v;
+                    },
+                    set culled(c) {
+                        arrow.culled = arrowHandle.culled = shaft.culled = shaftHandle.culled = c;
+                    }
+                };
+            })()
         };
 
         this._affordanceMeshes = {
@@ -1014,32 +1053,32 @@ class Control {
                 const meshId = hit.entity.id;
                 switch (meshId) {
 
-                    case this._displayMeshes.xAxisArrowHandle.id:
+                    case this._displayMeshes.xAxis.arrowHandleId:
                         affordanceMesh = this._affordanceMeshes.xAxisArrow;
                         nextDragAction = DRAG_ACTIONS.xTranslate;
                         break;
 
-                    case this._displayMeshes.xShaftHandle.id:
+                    case this._displayMeshes.xAxis.shaftHandleId:
                         affordanceMesh = this._affordanceMeshes.xAxisArrow;
                         nextDragAction = DRAG_ACTIONS.xTranslate;
                         break;
 
-                    case this._displayMeshes.yAxisArrowHandle.id:
+                    case this._displayMeshes.yAxis.arrowHandleId:
                         affordanceMesh = this._affordanceMeshes.yAxisArrow;
                         nextDragAction = DRAG_ACTIONS.yTranslate;
                         break;
 
-                    case this._displayMeshes.yShaftHandle.id:
+                    case this._displayMeshes.yAxis.shaftHandleId:
                         affordanceMesh = this._affordanceMeshes.yAxisArrow;
                         nextDragAction = DRAG_ACTIONS.yTranslate;
                         break;
 
-                    case this._displayMeshes.zAxisArrowHandle.id:
+                    case this._displayMeshes.zAxis.arrowHandleId:
                         affordanceMesh = this._affordanceMeshes.zAxisArrow;
                         nextDragAction = DRAG_ACTIONS.zTranslate;
                         break;
 
-                    case this._displayMeshes.zShaftHandle.id:
+                    case this._displayMeshes.zAxis.shaftHandleId:
                         affordanceMesh = this._affordanceMeshes.zAxisArrow;
                         nextDragAction = DRAG_ACTIONS.zTranslate;
                         break;

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -41,11 +41,6 @@ class Control {
         const canvas = scene.canvas.canvas;
 
         this._visible = false;
-        const pos = math.vec3(); // Full-precision position of the center of the Control
-        const origin = math.vec3();
-        const rtcPos = math.vec3();
-
-        const handlers = { };
 
         let ignoreNextSectionPlaneDirUpdate = false;
 
@@ -125,6 +120,7 @@ class Control {
             alphaMode: "blend"
         });
 
+        const handlers = { };
         const addAxis = (rgb, axisDirection, hoopDirection) => {
             const material = colorMaterial(rgb);
 
@@ -403,7 +399,7 @@ class Control {
             let lastDist = -1;
             const setRootNodeScale = size => rootNode.scale = [size, size, size];
             const onSceneTick = scene.on("tick", () => {
-                const dist = Math.abs(math.distVec3(camera.eye, pos));
+                const dist = Math.abs(math.distVec3(camera.eye, rootNode.position));
                 if (camera.projection === "perspective") {
                     if (dist !== lastDist) {
                         setRootNodeScale(0.07 * dist * Math.tan(camera.perspective.fov * math.DEGTORAD));
@@ -465,10 +461,10 @@ class Control {
                 math.subVec3(p2, p1, p2);
                 const dot = math.dotVec3(p2, worldAxis);
                 math.mulVec3Scalar(worldAxis, dot, p1);
-                math.addVec3(pos, p1, pos);
-                rootNode.position = pos;
+                math.addVec3(rootNode.position, p1, p1);
+                rootNode.position = p1;
                 if (self._sectionPlane) {
-                    self._sectionPlane.pos = pos;
+                    self._sectionPlane.pos = rootNode.position;
                 }
             };
         })();
@@ -617,15 +613,8 @@ class Control {
         this.__setSectionPlane = sectionPlane => {
             this.id = sectionPlane.id;
             this._sectionPlane = sectionPlane;
-            const setPosFromSectionPlane = () => {
-                pos.set(sectionPlane.pos);
-                worldToRTCPos(pos, origin, rtcPos);
-                rootNode.origin = origin;
-                rootNode.position = rtcPos;
-            };
-            const setDirFromSectionPlane = () => {
-                rootNode.quaternion = math.vec3PairToQuaternion(zeroVec, sectionPlane.dir, quat);
-            };
+            const setPosFromSectionPlane = () => rootNode.position = sectionPlane.pos;
+            const setDirFromSectionPlane = () => rootNode.quaternion = math.vec3PairToQuaternion(zeroVec, sectionPlane.dir, quat);
             setPosFromSectionPlane();
             setDirFromSectionPlane();
             const onSectionPlanePos = sectionPlane.on("pos", setPosFromSectionPlane);

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -536,7 +536,7 @@ class Control {
                 isObject: false
             }), NO_STATE_INHERIT),
 
-            xAxisHandle: rootNode.addChild(new Mesh(rootNode, {
+            xShaftHandle: rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.axisHandle,
                 material: materials.pickable,
                 matrix: (function () {
@@ -658,7 +658,7 @@ class Control {
                 isObject: false
             }), NO_STATE_INHERIT),
 
-            zAxisHandle: rootNode.addChild(new Mesh(rootNode, {
+            zShaftHandle: rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.axisHandle,
                 material: materials.pickable,
                 matrix: (function () {
@@ -1020,7 +1020,7 @@ class Control {
                         nextDragAction = DRAG_ACTIONS.xTranslate;
                         break;
 
-                    case this._displayMeshes.xAxisHandle.id:
+                    case this._displayMeshes.xShaftHandle.id:
                         affordanceMesh = this._affordanceMeshes.xAxisArrow;
                         nextDragAction = DRAG_ACTIONS.xTranslate;
                         break;
@@ -1040,7 +1040,7 @@ class Control {
                         nextDragAction = DRAG_ACTIONS.zTranslate;
                         break;
 
-                    case this._displayMeshes.zAxisHandle.id:
+                    case this._displayMeshes.zShaftHandle.id:
                         affordanceMesh = this._affordanceMeshes.zAxisArrow;
                         nextDragAction = DRAG_ACTIONS.zTranslate;
                         break;

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -334,7 +334,15 @@ class Control {
             };
         };
 
-        const addAxis = (material, arrowMatrix, shaftMatrix) => {
+        const addAxis = (material, rotationQuat) => {
+            const rotation = math.quaternionToRotationMat4(rotationQuat, math.identityMat4());
+
+            const arrowT = math.translateMat4c(0, radius + .1, 0, math.identityMat4());
+            const arrowMatrix = math.mulMat4(rotation, arrowT, math.identityMat4());
+
+            const shaftT = math.translateMat4c(0, radius / 2, 0, math.identityMat4());
+            const shaftMatrix = math.mulMat4(rotation, shaftT, math.identityMat4());
+
             const arrow = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.arrowHead,
                 material: material,
@@ -548,40 +556,9 @@ class Control {
             //
             //----------------------------------------------------------------------------------------------------------
 
-            xAxis: addAxis(
-                materials.red,
-                (function () {
-                    const translate = math.translateMat4c(0, radius + .1, 0, math.identityMat4());
-                    const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [0, 0, 1], math.identityMat4());
-                    return math.mulMat4(rotate, translate, math.identityMat4());
-                })(),
-                (function () {
-                    const translate = math.translateMat4c(0, radius / 2, 0, math.identityMat4());
-                    const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [0, 0, 1], math.identityMat4());
-                    return math.mulMat4(rotate, translate, math.identityMat4());
-                })()),
-
-            yAxis: addAxis(
-                materials.green,
-                (function () {
-                    const translate = math.translateMat4c(0, radius + .1, 0, math.identityMat4());
-                    const rotate = math.rotationMat4v(180 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
-                    return math.mulMat4(rotate, translate, math.identityMat4());
-                })(),
-                math.translationMat4v([0, -radius / 2, 0], math.identityMat4())),
-
-            zAxis: addAxis(
-                materials.blue,
-                (function () {
-                    const translate = math.translateMat4c(0, radius + .1, 0, math.identityMat4());
-                    const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
-                    return math.mulMat4(rotate, translate, math.identityMat4());
-                })(),
-                (function () {
-                    const translate = math.translateMat4c(0, radius / 2, 0, math.identityMat4());
-                    const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
-                    return math.mulMat4(rotate, translate, math.identityMat4());
-                })())
+            xAxis: addAxis(materials.red,   math.angleAxisToQuaternion([ 0, 0, 1, -90 * math.DEGTORAD ])),
+            yAxis: addAxis(materials.green, math.angleAxisToQuaternion([ 1, 0, 0, 180 * math.DEGTORAD ])),
+            zAxis: addAxis(materials.blue,  math.angleAxisToQuaternion([ 1, 0, 0, -90 * math.DEGTORAD ]))
         };
 
         this._affordanceMeshes = {

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -327,23 +327,6 @@ class Control {
                 ambient: [0.0, 0.0, 0.0],
                 specular: [.6, .6, .3],
                 shininess: 80
-            }),
-
-            highlightBall: new EmphasisMaterial(rootNode, {
-                edges: false,
-                fill: true,
-                fillColor: [0.5, 0.5, 0.5],
-                fillAlpha: 0.5,
-                vertices: false
-            }),
-
-            highlightPlane: new EmphasisMaterial(rootNode, {
-                edges: true,
-                edgeWidth: 3,
-                fill: false,
-                fillColor: [0.5, 0.5, .5],
-                fillAlpha: 0.5,
-                vertices: false
             })
         };
 

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -334,6 +334,63 @@ class Control {
             };
         };
 
+        const addAxis = (material, arrowMatrix, shaftMatrix) => {
+            const arrow = rootNode.addChild(new Mesh(rootNode, {
+                geometry: shapes.arrowHead,
+                material: material,
+                matrix: arrowMatrix,
+                pickable: false,
+                collidable: true,
+                clippable: false,
+                visible: false,
+                isObject: false
+            }), NO_STATE_INHERIT);
+
+            const arrowHandle = rootNode.addChild(new Mesh(rootNode, {
+                geometry: shapes.arrowHeadHandle,
+                material: materials.pickable,
+                matrix: arrowMatrix,
+                pickable: true,
+                collidable: true,
+                clippable: false,
+                visible: false,
+                isObject: false
+            }), NO_STATE_INHERIT);
+
+            const shaft = rootNode.addChild(new Mesh(rootNode, {
+                geometry: shapes.axis,
+                material: material,
+                matrix: shaftMatrix,
+                pickable: false,
+                collidable: true,
+                clippable: false,
+                visible: false,
+                isObject: false
+            }), NO_STATE_INHERIT);
+
+            const shaftHandle = rootNode.addChild(new Mesh(rootNode, {
+                geometry: shapes.axisHandle,
+                material: materials.pickable,
+                matrix: shaftMatrix,
+                pickable: true,
+                collidable: true,
+                clippable: false,
+                visible: false,
+                isObject: false
+            }), NO_STATE_INHERIT);
+
+            return {
+                arrowHandleId: arrowHandle.id,
+                shaftHandleId: shaftHandle.id,
+                set visible(v) {
+                    arrow.visible = arrowHandle.visible = shaft.visible = shaftHandle.visible = v;
+                },
+                set culled(c) {
+                    arrow.culled = arrowHandle.culled = shaft.culled = shaftHandle.culled = c;
+                }
+            };
+        };
+
         this._displayMeshes = {
 
             plane: rootNode.addChild(new Mesh(rootNode, {
@@ -491,225 +548,40 @@ class Control {
             //
             //----------------------------------------------------------------------------------------------------------
 
-            xAxis: (function() {
-
-                const material = materials.red;
-
-                const arrowMatrix = (function () {
+            xAxis: addAxis(
+                materials.red,
+                (function () {
                     const translate = math.translateMat4c(0, radius + .1, 0, math.identityMat4());
                     const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [0, 0, 1], math.identityMat4());
                     return math.mulMat4(rotate, translate, math.identityMat4());
-                })();
-
-                const shaftMatrix = (function () {
+                })(),
+                (function () {
                     const translate = math.translateMat4c(0, radius / 2, 0, math.identityMat4());
                     const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [0, 0, 1], math.identityMat4());
                     return math.mulMat4(rotate, translate, math.identityMat4());
-                })();
+                })()),
 
-            const arrow = rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.arrowHead,
-                material: material,
-                matrix: arrowMatrix,
-                pickable: false,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT);
-
-            const arrowHandle = rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.arrowHeadHandle,
-                material: materials.pickable,
-                matrix: arrowMatrix,
-                pickable: true,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT);
-
-            const shaft = rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.axis,
-                material: material,
-                matrix: shaftMatrix,
-                pickable: false,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT);
-
-            const shaftHandle = rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.axisHandle,
-                material: materials.pickable,
-                matrix: shaftMatrix,
-                pickable: true,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT);
-
-                return {
-                    arrowHandleId: arrowHandle.id,
-                    shaftHandleId: shaftHandle.id,
-                    set visible(v) {
-                        arrow.visible = arrowHandle.visible = shaft.visible = shaftHandle.visible = v;
-                    },
-                    set culled(c) {
-                        arrow.culled = arrowHandle.culled = shaft.culled = shaftHandle.culled = c;
-                    }
-                };
-            })(),
-
-            //----------------------------------------------------------------------------------------------------------
-            //
-            //----------------------------------------------------------------------------------------------------------
-
-            yAxis: (function() {
-
-                const material = materials.green;
-
-                const arrowMatrix = (function () {
+            yAxis: addAxis(
+                materials.green,
+                (function () {
                     const translate = math.translateMat4c(0, radius + .1, 0, math.identityMat4());
                     const rotate = math.rotationMat4v(180 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
                     return math.mulMat4(rotate, translate, math.identityMat4());
-                })();
+                })(),
+                math.translationMat4v([0, -radius / 2, 0], math.identityMat4())),
 
-                const shaftMatrix = math.translationMat4v([0, -radius / 2, 0], math.identityMat4());
-
-            const arrow = rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.arrowHead,
-                material: material,
-                matrix: arrowMatrix,
-                pickable: false,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT);
-
-            const arrowHandle = rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.arrowHeadHandle,
-                material: materials.pickable,
-                matrix: arrowMatrix,
-                pickable: true,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT);
-
-            const shaft = rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.axis,
-                material: material,
-                matrix: shaftMatrix,
-                pickable: false,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT);
-
-            const shaftHandle = rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.axisHandle,
-                material: materials.pickable,
-                matrix: shaftMatrix,
-                pickable: true,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT);
-
-                return {
-                    arrowHandleId: arrowHandle.id,
-                    shaftHandleId: shaftHandle.id,
-                    set visible(v) {
-                        arrow.visible = arrowHandle.visible = shaft.visible = shaftHandle.visible = v;
-                    },
-                    set culled(c) {
-                        arrow.culled = arrowHandle.culled = shaft.culled = shaftHandle.culled = c;
-                    }
-                };
-            })(),
-
-            //----------------------------------------------------------------------------------------------------------
-            //
-            //----------------------------------------------------------------------------------------------------------
-
-            zAxis: (function() {
-
-                const material = materials.blue;
-
-                const arrowMatrix = (function () {
+            zAxis: addAxis(
+                materials.blue,
+                (function () {
                     const translate = math.translateMat4c(0, radius + .1, 0, math.identityMat4());
                     const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
                     return math.mulMat4(rotate, translate, math.identityMat4());
-                })();
-
-                const shaftMatrix = (function () {
+                })(),
+                (function () {
                     const translate = math.translateMat4c(0, radius / 2, 0, math.identityMat4());
                     const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
                     return math.mulMat4(rotate, translate, math.identityMat4());
-                })();
-
-            const arrow = rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.arrowHead,
-                material: material,
-                matrix: arrowMatrix,
-                pickable: false,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT);
-
-            const arrowHandle = rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.arrowHeadHandle,
-                material: materials.pickable,
-                matrix: arrowMatrix,
-                pickable: true,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT);
-
-            const shaft = rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.axis,
-                material: material,
-                matrix: shaftMatrix,
-                pickable: false,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT);
-
-            const shaftHandle = rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.axisHandle,
-                material: materials.pickable,
-                matrix: shaftMatrix,
-                pickable: true,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT);
-
-                return {
-                    arrowHandleId: arrowHandle.id,
-                    shaftHandleId: shaftHandle.id,
-                    set visible(v) {
-                        arrow.visible = arrowHandle.visible = shaft.visible = shaftHandle.visible = v;
-                    },
-                    set culled(c) {
-                        arrow.culled = arrowHandle.culled = shaft.culled = shaftHandle.culled = c;
-                    }
-                };
-            })()
+                })())
         };
 
         this._affordanceMeshes = {

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -709,15 +709,13 @@ class Control {
 
             canvas.addEventListener("mousedown", this._canvasMouseDownListener = (e) => {
                 e.preventDefault();
-                if (this._visible && nextDragAction) {
+                if (this._visible && (e.which === 1) && nextDragAction) { // Left button
                     this._viewer.cameraControl.pointerEnabled = false;
-                    if (e.which === 1) { // Left button
-                        down = true;
-                        var canvasPos = getClickCoordsWithinElement(e);
-                        dragAction = nextDragAction;
-                        lastCanvasPos[0] = canvasPos[0];
-                        lastCanvasPos[1] = canvasPos[1];
-                    }
+                    down = true;
+                    var canvasPos = getClickCoordsWithinElement(e);
+                    dragAction = nextDragAction;
+                    lastCanvasPos[0] = canvasPos[0];
+                    lastCanvasPos[1] = canvasPos[1];
                 }
             });
 
@@ -740,7 +738,7 @@ class Control {
             });
 
             canvas.addEventListener("mouseup", this._canvasMouseUpListener = (e) => {
-                if (this._visible) {
+                if (this._visible && down) {
                     this._viewer.cameraControl.pointerEnabled = true;
                     down = false;
                 }

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -264,26 +264,26 @@ class Control {
             }), NO_STATE_INHERIT);
 
             const lastCanvasPos = math.vec2();
-            handlers[arrowHandle.id] = handlers[shaftHandle.id] = [
-                bigArrowHead,
-                (initCanvasPos) => {
+            handlers[arrowHandle.id] = handlers[shaftHandle.id] = {
+                affordanceMesh: bigArrowHead,
+                initDragAction: (initCanvasPos) => {
                     lastCanvasPos.set(initCanvasPos);
                     return canvasPos => {
                         dragTranslateSectionPlane(rgb, lastCanvasPos, canvasPos);
                         lastCanvasPos.set(canvasPos);
                     };
                 }
-            ];
-            handlers[rotateHandle.id] = [
-                hoop,
-                (initCanvasPos) => {
+            };
+            handlers[rotateHandle.id] = {
+                affordanceMesh: hoop,
+                initDragAction: (initCanvasPos) => {
                     lastCanvasPos.set(initCanvasPos);
                     return canvasPos => {
                         dragRotateSectionPlane(rgb, lastCanvasPos, canvasPos);
                         lastCanvasPos.set(canvasPos);
                     };
                 }
-            ];
+            };
 
             return {
                 set visible(v) {
@@ -558,10 +558,10 @@ class Control {
                     }
                     const meshId = hit.entity.id;
                     if (meshId in handlers) {
-                        const [ affordanceMesh, dragAction ] = handlers[meshId];
-                        affordanceMesh.visible = true;
-                        lastAffordanceMesh = affordanceMesh;
-                        nextDragAction = dragAction;
+                        const handler = handlers[meshId];
+                        handler.affordanceMesh.visible = true;
+                        lastAffordanceMesh = handler.affordanceMesh;
+                        nextDragAction = handler.initDragAction;
                     } else {
                         lastAffordanceMesh = null;
                         nextDragAction = null;

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -556,7 +556,7 @@ class Control {
         const localToWorldVec = (function () {
             const mat = math.mat4();
             return function (localVec, worldVec) {
-                math.quaternionToMat4(self._rootNode.quaternion, mat);
+                math.quaternionToMat4(rootNode.quaternion, mat);
                 math.transformVec3(mat, localVec, worldVec);
                 math.normalizeVec3(worldVec);
                 return worldVec;
@@ -575,7 +575,7 @@ class Control {
                 math.cross3Vec3(planeNormal, worldAxis, planeNormal);
                 math.normalizeVec3(planeNormal);
                 return planeNormal;
-            }
+            };
         })();
 
         const dragTranslateSectionPlane = (function () {
@@ -596,7 +596,7 @@ class Control {
                 if (self._sectionPlane) {
                     self._sectionPlane.pos = self._pos;
                 }
-            }
+            };
         })();
 
         var dragRotateSectionPlane = (function () {
@@ -604,6 +604,8 @@ class Control {
             const p2 = math.vec4();
             const c = math.vec4();
             const worldAxis = math.vec4();
+            const dir = math.vec3();
+            const mat = math.mat4();
             return function (baseAxis, fromMouse, toMouse) {
                 localToWorldVec(baseAxis, worldAxis);
                 const hasData = getPointerPlaneIntersect(fromMouse, worldAxis, p1) && getPointerPlaneIntersect(toMouse, worldAxis, p2);
@@ -630,8 +632,13 @@ class Control {
                     incDegrees = -incDegrees;
                 }
                 self._rootNode.rotate(baseAxis, incDegrees);
-                rotateSectionPlane();
-            }
+
+                if (self.sectionPlane) {
+                    math.quaternionToMat4(rootNode.quaternion, mat);  // << ---
+                    math.transformVec3(mat, [0, 0, 1], dir);
+                    self._setSectionPlaneDir(dir);
+                }
+            };
         })();
 
         var getPointerPlaneIntersect = (function () {
@@ -660,18 +667,6 @@ class Control {
                     return true;
                 }
                 return false;
-            }
-        })();
-
-        const rotateSectionPlane = (function () {
-            const dir = math.vec3();
-            const mat = math.mat4();
-            return function () {
-                if (self.sectionPlane) {
-                    math.quaternionToMat4(rootNode.quaternion, mat);  // << ---
-                    math.transformVec3(mat, [0, 0, 1], dir);
-                    self._setSectionPlaneDir(dir);
-                }
             };
         })();
 

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -973,17 +973,10 @@ class Control {
                     canvasPos[0] = event.x;
                     canvasPos[1] = event.y;
                 } else {
-                    var element = event.target;
-                    var totalOffsetLeft = 0;
-                    var totalOffsetTop = 0;
-
-                    while (element.offsetParent) {
-                        totalOffsetLeft += element.offsetLeft;
-                        totalOffsetTop += element.offsetTop;
-                        element = element.offsetParent;
-                    }
-                    canvasPos[0] = event.pageX - totalOffsetLeft;
-                    canvasPos[1] = event.pageY - totalOffsetTop;
+                    const element = event.target;
+                    const rect = element.getBoundingClientRect();
+                    canvasPos[0] = event.clientX - rect.left;
+                    canvasPos[1] = event.clientY - rect.top;
                 }
                 return canvasPos;
             };

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -52,95 +52,6 @@ class Control {
     }
 
     /**
-     * Called by SectionPlanesPlugin to assign this Control to a SectionPlane.
-     * SectionPlanesPlugin keeps SectionPlaneControls in a reuse pool.
-     * Call with a null or undefined value to disconnect the Control ffrom whatever SectionPlane it was assigned to.
-     * @private
-     */
-    _setSectionPlane(sectionPlane) {
-        if (this._sectionPlane) {
-            this._sectionPlane.off(this._onSectionPlanePos);
-            this._sectionPlane.off(this._onSectionPlaneDir);
-            this._onSectionPlanePos = null;
-            this._onSectionPlaneDir = null;
-            this._sectionPlane = null;
-        }
-        if (sectionPlane) {
-            this.id = sectionPlane.id;
-            const setPosFromSectionPlane = () => {
-                const pos = sectionPlane.pos;
-                this._pos.set(pos);
-                worldToRTCPos(pos, this._origin, this._rtcPos);
-                this._rootNode.origin = this._origin;
-                this._rootNode.position = this._rtcPos;
-            };
-            const setDirFromSectionPlane = () => {
-                this._rootNode.quaternion = math.vec3PairToQuaternion(zeroVec, sectionPlane.dir, quat);
-            };
-            setPosFromSectionPlane();
-            setDirFromSectionPlane();
-            this._sectionPlane = sectionPlane;
-            this._onSectionPlanePos = sectionPlane.on("pos", setPosFromSectionPlane);
-            this._onSectionPlaneDir = sectionPlane.on("dir", () => {
-                if (!this._ignoreNextSectionPlaneDirUpdate) {
-                    setDirFromSectionPlane();
-                } else {
-                    this._ignoreNextSectionPlaneDirUpdate = false;
-                }
-            });
-        }
-    }
-
-    /**
-     * Gets the {@link SectionPlane} controlled by this Control.
-     * @returns {SectionPlane} The SectionPlane.
-     */
-    get sectionPlane() {
-        return this._sectionPlane;
-    }
-
-    /**
-     * Sets if this Control is visible.
-     *
-     * @type {Boolean}
-     */
-    setVisible(visible = true) {
-        if (this._visible === visible) {
-            return;
-        }
-        this._visible = visible;
-        var id;
-        for (id in this._displayMeshes) {
-            if (this._displayMeshes.hasOwnProperty(id)) {
-                this._displayMeshes[id].visible = visible;
-            }
-        }
-    }
-
-    /**
-     * Gets if this Control is visible.
-     *
-     * @type {Boolean}
-     */
-    getVisible() {
-        return this._visible;
-    }
-
-    /**
-     * Sets if this Control is culled. This is called by SectionPlanesPlugin to
-     * temporarily hide the Control while a snapshot is being taken by Viewer#getSnapshot().
-     * @param culled
-     */
-    setCulled(culled) {
-        var id;
-        for (id in this._displayMeshes) {
-            if (this._displayMeshes.hasOwnProperty(id)) {
-                this._displayMeshes[id].culled = culled;
-            }
-        }
-    }
-
-    /**
      * Builds the Entities that represent this Control.
      * @private
      */
@@ -731,6 +642,95 @@ class Control {
         this._setSectionPlane(null);
         this._rootNode.destroy();
         this._displayMeshes = {};
+    }
+
+    /**
+     * Called by SectionPlanesPlugin to assign this Control to a SectionPlane.
+     * SectionPlanesPlugin keeps SectionPlaneControls in a reuse pool.
+     * Call with a null or undefined value to disconnect the Control ffrom whatever SectionPlane it was assigned to.
+     * @private
+     */
+    _setSectionPlane(sectionPlane) {
+        if (this._sectionPlane) {
+            this._sectionPlane.off(this._onSectionPlanePos);
+            this._sectionPlane.off(this._onSectionPlaneDir);
+            this._onSectionPlanePos = null;
+            this._onSectionPlaneDir = null;
+            this._sectionPlane = null;
+        }
+        if (sectionPlane) {
+            this.id = sectionPlane.id;
+            const setPosFromSectionPlane = () => {
+                const pos = sectionPlane.pos;
+                this._pos.set(pos);
+                worldToRTCPos(pos, this._origin, this._rtcPos);
+                this._rootNode.origin = this._origin;
+                this._rootNode.position = this._rtcPos;
+            };
+            const setDirFromSectionPlane = () => {
+                this._rootNode.quaternion = math.vec3PairToQuaternion(zeroVec, sectionPlane.dir, quat);
+            };
+            setPosFromSectionPlane();
+            setDirFromSectionPlane();
+            this._sectionPlane = sectionPlane;
+            this._onSectionPlanePos = sectionPlane.on("pos", setPosFromSectionPlane);
+            this._onSectionPlaneDir = sectionPlane.on("dir", () => {
+                if (!this._ignoreNextSectionPlaneDirUpdate) {
+                    setDirFromSectionPlane();
+                } else {
+                    this._ignoreNextSectionPlaneDirUpdate = false;
+                }
+            });
+        }
+    }
+
+    /**
+     * Gets the {@link SectionPlane} controlled by this Control.
+     * @returns {SectionPlane} The SectionPlane.
+     */
+    get sectionPlane() {
+        return this._sectionPlane;
+    }
+
+    /**
+     * Sets if this Control is visible.
+     *
+     * @type {Boolean}
+     */
+    setVisible(visible = true) {
+        if (this._visible === visible) {
+            return;
+        }
+        this._visible = visible;
+        var id;
+        for (id in this._displayMeshes) {
+            if (this._displayMeshes.hasOwnProperty(id)) {
+                this._displayMeshes[id].visible = visible;
+            }
+        }
+    }
+
+    /**
+     * Gets if this Control is visible.
+     *
+     * @type {Boolean}
+     */
+    getVisible() {
+        return this._visible;
+    }
+
+    /**
+     * Sets if this Control is culled. This is called by SectionPlanesPlugin to
+     * temporarily hide the Control while a snapshot is being taken by Viewer#getSnapshot().
+     * @param culled
+     */
+    setCulled(culled) {
+        var id;
+        for (id in this._displayMeshes) {
+            if (this._displayMeshes.hasOwnProperty(id)) {
+                this._displayMeshes[id].culled = culled;
+            }
+        }
     }
 }
 

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -712,18 +712,14 @@ class Control {
                 if (this._visible && (e.which === 1) && nextDragAction) { // Left button
                     this._viewer.cameraControl.pointerEnabled = false;
                     down = true;
-                    var canvasPos = getClickCoordsWithinElement(e);
                     dragAction = nextDragAction;
-                    lastCanvasPos[0] = canvasPos[0];
-                    lastCanvasPos[1] = canvasPos[1];
+                    lastCanvasPos.set(getClickCoordsWithinElement(e));
                 }
             });
 
             canvas.addEventListener("mousemove", this._canvasMouseMoveListener = (e) => {
                 if (this._visible && down) {
                     const canvasPos = getClickCoordsWithinElement(e);
-                    const x = canvasPos[0];
-                    const y = canvasPos[1];
                     if (dragAction) {
                         const [ isTranslate, axis ] = dragAction;
                         if (isTranslate) {
@@ -732,8 +728,7 @@ class Control {
                             dragRotateSectionPlane(axis, lastCanvasPos, canvasPos);
                         }
                     }
-                    lastCanvasPos[0] = x;
-                    lastCanvasPos[1] = y;
+                    lastCanvasPos.set(canvasPos);
                 }
             });
 

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -943,16 +943,7 @@ class Control {
 
             const tempVec3a = math.vec3([0, 0, 0]);
 
-            let distDirty = true;
             let lastDist = -1;
-
-            this._onCameraViewMatrix = scene.camera.on("viewMatrix", () => {
-                distDirty = true;
-            });
-
-            this._onCameraProjMatrix = scene.camera.on("projMatrix", () => {
-                distDirty = true;
-            });
 
             this._onSceneTick = scene.on("tick", () => {
 
@@ -1316,9 +1307,6 @@ class Control {
         canvas.removeEventListener("mousedown", this._canvasMouseDownListener);
         canvas.removeEventListener("mousemove", this._canvasMouseMoveListener);
         canvas.removeEventListener("mouseup", this._canvasMouseUpListener);
-
-        camera.off(this._onCameraViewMatrix);
-        camera.off(this._onCameraProjMatrix);
 
         cameraControl.off(this._onCameraControlHover);
         cameraControl.off(this._onCameraControlHoverLeave);

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -722,12 +722,7 @@ class Control {
     }
 
     _destroy() {
-        this._unbindEvents();
-        this._destroyNodes();
-    }
-
-    _unbindEvents() {
-
+        // unbindEvents
         const viewer = this._viewer;
         const scene = viewer.scene;
         const canvas = scene.canvas.canvas;
@@ -742,9 +737,8 @@ class Control {
 
         cameraControl.off(this._onCameraControlHover);
         cameraControl.off(this._onCameraControlHoverLeave);
-    }
 
-    _destroyNodes() {
+        // destroyNodes
         this._setSectionPlane(null);
         this._rootNode.destroy();
         this._displayMeshes = {};

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -1020,7 +1020,7 @@ class Control {
             const worldAxis = math.vec4();
             return function (baseAxis, fromMouse, toMouse) {
                 localToWorldVec(baseAxis, worldAxis);
-                const planeNormal = getTranslationPlane(worldAxis, fromMouse, toMouse);
+                const planeNormal = getTranslationPlane(worldAxis);
                 getPointerPlaneIntersect(fromMouse, planeNormal, p1);
                 getPointerPlaneIntersect(toMouse, planeNormal, p2);
                 math.subVec3(p2, p1);
@@ -1044,7 +1044,7 @@ class Control {
                 localToWorldVec(baseAxis, worldAxis);
                 const hasData = getPointerPlaneIntersect(fromMouse, worldAxis, p1) && getPointerPlaneIntersect(toMouse, worldAxis, p2);
                 if (!hasData) { // Find intersections with view plane and project down to origin
-                    const planeNormal = getTranslationPlane(worldAxis, fromMouse, toMouse);
+                    const planeNormal = getTranslationPlane(worldAxis);
                     getPointerPlaneIntersect(fromMouse, planeNormal, p1, 1); // Ensure plane moves closer to camera so angles become workable
                     getPointerPlaneIntersect(toMouse, planeNormal, p2, 1);
                     var dot = math.dotVec3(p1, worldAxis);

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -284,8 +284,8 @@ class Control {
             };
         };
 
-        this._displayMeshes = { // Meshes that are always visible
-            plane: rootNode.addChild(new Mesh(rootNode, {
+        this._displayMeshes = [ // Meshes that are always visible
+            rootNode.addChild(new Mesh(rootNode, { // plane
                 geometry: new ReadableGeometry(rootNode, {
                     primitive: "triangles",
                     positions: [
@@ -319,7 +319,7 @@ class Control {
                 isObject: false
             }), NO_STATE_INHERIT),
 
-            planeFrame: rootNode.addChild(new Mesh(rootNode, { // Visible frame
+            rootNode.addChild(new Mesh(rootNode, { // Visible frame
                 geometry: new ReadableGeometry(rootNode, buildTorusGeometry({
                     center: [0, 0, 0],
                     radius: 1.7,
@@ -351,7 +351,7 @@ class Control {
                 isObject: false
             }), NO_STATE_INHERIT),
 
-            center: rootNode.addChild(new Mesh(rootNode, {
+            rootNode.addChild(new Mesh(rootNode, { // center
                 geometry: new ReadableGeometry(rootNode, buildSphereGeometry({
                     radius: 0.05
                 })),
@@ -373,10 +373,10 @@ class Control {
             //
             //----------------------------------------------------------------------------------------------------------
 
-            xAxis: addAxis([1,0,0], [ 1,  0,  0 ], [ 1, 0,  0 ]),
-            yAxis: addAxis([0,1,0], [ 0, -1,  0 ], [ 0, 1,  0 ]),
-            zAxis: addAxis([0,0,1], [ 0,  0, -1 ], [ 0, 0, -1 ])
-        };
+            addAxis([1,0,0], [ 1,  0,  0 ], [ 1, 0,  0 ]),
+            addAxis([0,1,0], [ 0, -1,  0 ], [ 0, 1,  0 ]),
+            addAxis([0,0,1], [ 0,  0, -1 ], [ 0, 0, -1 ])
+        ];
 
         // bindEvents
         const self = this;
@@ -642,11 +642,12 @@ class Control {
 
         this.__destroy = () => {
             cleanups.forEach(c => c());
-
-            // destroyNodes
             this._unbindSectionPlane();
             rootNode.destroy();
-            this._displayMeshes = {};
+            this._displayMeshes = [ ];
+            for (let id in handlers) {
+                delete handlers[id];
+            }
         };
     }
 
@@ -681,15 +682,9 @@ class Control {
      * @type {Boolean}
      */
     setVisible(visible = true) {
-        if (this._visible === visible) {
-            return;
-        }
-        this._visible = visible;
-        var id;
-        for (id in this._displayMeshes) {
-            if (this._displayMeshes.hasOwnProperty(id)) {
-                this._displayMeshes[id].visible = visible;
-            }
+        if (this._visible !== visible) {
+            this._visible = visible;
+            this._displayMeshes.forEach(m => m.visible = visible);
         }
     }
 
@@ -708,12 +703,7 @@ class Control {
      * @param culled
      */
     setCulled(culled) {
-        var id;
-        for (id in this._displayMeshes) {
-            if (this._displayMeshes.hasOwnProperty(id)) {
-                this._displayMeshes[id].culled = culled;
-            }
-        }
+        this._displayMeshes.forEach(m => m.culled = culled);
     }
 }
 

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -678,70 +678,50 @@ class Control {
         })();
 
         {
-            var mouseDownLeft;
-            var mouseDownMiddle;
-            var mouseDownRight;
-            var down = false;
-            var lastAffordanceMesh;
+            let down = false;
+            let lastAffordanceMesh = null;
 
             this._onCameraControlHover = this._viewer.cameraControl.on("hoverEnter", (hit) => {
-                if (!this._visible) {
-                    return;
-                }
-                if (down) {
-                    return;
-                }
-                grabbed = false;
-                if (lastAffordanceMesh) {
-                    lastAffordanceMesh.visible = false;
-                }
-                var affordanceMesh;
-                const meshId = hit.entity.id;
-                if (meshId in this._handlers) {
-                    const [ affordanceMesh, dragAction ] = this._handlers[meshId];
-                    affordanceMesh.visible = true;
-                    lastAffordanceMesh = affordanceMesh;
-                    nextDragAction = dragAction;
-                    grabbed = true;
-                } else {
-                    lastAffordanceMesh = null;
-                    nextDragAction = null;
-                    grabbed = false;
+                if (this._visible && (! down)) {
+                    if (lastAffordanceMesh) {
+                        lastAffordanceMesh.visible = false;
+                    }
+                    const meshId = hit.entity.id;
+                    if (meshId in this._handlers) {
+                        const [ affordanceMesh, dragAction ] = this._handlers[meshId];
+                        affordanceMesh.visible = true;
+                        lastAffordanceMesh = affordanceMesh;
+                        nextDragAction = dragAction;
+                        grabbed = true;
+                    } else {
+                        lastAffordanceMesh = null;
+                        nextDragAction = null;
+                        grabbed = false;
+                    }
                 }
             });
 
             this._onCameraControlHoverLeave = this._viewer.cameraControl.on("hoverOutEntity", (hit) => {
-                if (!this._visible) {
-                    return;
+                if (this._visible) {
+                    if (lastAffordanceMesh) {
+                        lastAffordanceMesh.visible = false;
+                    }
+                    lastAffordanceMesh = null;
+                    nextDragAction = null;
                 }
-                if (lastAffordanceMesh) {
-                    lastAffordanceMesh.visible = false;
-                }
-                lastAffordanceMesh = null;
-                nextDragAction = null;
             });
 
             canvas.addEventListener("mousedown", this._canvasMouseDownListener = (e) => {
                 e.preventDefault();
-                if (!this._visible) {
-                    return;
-                }
-                if (!grabbed) {
-                    return;
-                }
-                this._viewer.cameraControl.pointerEnabled = false;
-                switch (e.which) {
-                    case 1: // Left button
-                        mouseDownLeft = true;
+                if (this._visible && grabbed) {
+                    this._viewer.cameraControl.pointerEnabled = false;
+                    if (e.which === 1) { // Left button
                         down = true;
                         var canvasPos = getClickCoordsWithinElement(e);
                         dragAction = nextDragAction;
                         lastCanvasPos[0] = canvasPos[0];
                         lastCanvasPos[1] = canvasPos[1];
-                        break;
-
-                    default:
-                        break;
+                    }
                 }
             });
 
@@ -764,28 +744,13 @@ class Control {
             });
 
             canvas.addEventListener("mouseup", this._canvasMouseUpListener = (e) => {
-                if (!this._visible) {
-                    return;
+                if (this._visible) {
+                    this._viewer.cameraControl.pointerEnabled = true;
+                    if (down) {
+                        down = false;
+                        grabbed = false;
+                    }
                 }
-                this._viewer.cameraControl.pointerEnabled = true;
-                if (!down) {
-                    return;
-                }
-                switch (e.which) {
-                    case 1: // Left button
-                        mouseDownLeft = false;
-                        break;
-                    case 2: // Middle/both buttons
-                        mouseDownMiddle = false;
-                        break;
-                    case 3: // Right button
-                        mouseDownRight = false;
-                        break;
-                    default:
-                        break;
-                }
-                down = false;
-                grabbed = false;
             });
         }
     }

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -582,7 +582,6 @@ class Control {
                 collidable: true,
                 clippable: false,
                 visible: false,
-                opacity: 0.2,
                 isObject: false
             }), NO_STATE_INHERIT),
 

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -263,7 +263,13 @@ class Control {
 
         const meshesToAdd = [ ];
 
-        const addCurve = (material, highlightMaterial, matrix, matrix1, matrix2) => {
+        const addCurve = (material, highlightMaterial, direction, matrix1, matrix2) => {
+            const rotateToHorizontal = math.rotationMat4v(270 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
+            const rotation = math.quaternionToRotationMat4(math.vec3PairToQuaternion([ 0, 1, 0 ], direction), math.identityMat4());
+            const matrix = math.mulMat4(rotation, rotateToHorizontal, math.identityMat4());
+
+            const scale = math.scaleMat4v([0.6, 0.6, 0.6], math.identityMat4());
+
             const curve = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.curve,
                 material: material,
@@ -291,7 +297,7 @@ class Control {
             const arrow1 = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.arrowHead,
                 material: material,
-                matrix: matrix1,
+                matrix: math.mulMat4(matrix1, scale, math.identityMat4()),
                 pickable: true,
                 collidable: true,
                 clippable: false,
@@ -302,7 +308,7 @@ class Control {
             const arrow2 = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.arrowHead,
                 material: material,
-                matrix: matrix2,
+                matrix: math.mulMat4(matrix2, scale, math.identityMat4()),
                 pickable: true,
                 collidable: true,
                 clippable: false,
@@ -503,22 +509,16 @@ class Control {
             xCurve: addCurve(
                 materials.red,
                 materials.highlightRed,
-                (function () {
-                    const rotate2 = math.rotationMat4v(90 * math.DEGTORAD, [0, 1, 0], math.identityMat4());
-                    const rotate1 = math.rotationMat4v(270 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
-                    return math.mulMat4(rotate1, rotate2, math.identityMat4());
-                })(),
+                [1,0,0],
                 (function () {
                     const translate = math.translateMat4c(0., -0.07, -0.8, math.identityMat4());
-                    const scale = math.scaleMat4v([0.6, 0.6, 0.6], math.identityMat4());
                     const rotate = math.rotationMat4v(0 * math.DEGTORAD, [0, 0, 1], math.identityMat4());
-                    return math.mulMat4(math.mulMat4(translate, scale, math.identityMat4()), rotate, math.identityMat4());
+                    return math.mulMat4(translate, rotate, math.identityMat4());
                 })(),
                 (function () {
                     const translate = math.translateMat4c(0.0, -0.8, -0.07, math.identityMat4());
-                    const scale = math.scaleMat4v([0.6, 0.6, 0.6], math.identityMat4());
                     const rotate = math.rotationMat4v(90 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
-                    return math.mulMat4(math.mulMat4(translate, scale, math.identityMat4()), rotate, math.identityMat4());
+                    return math.mulMat4(translate, rotate, math.identityMat4());
                 })()),
 
             //----------------------------------------------------------------------------------------------------------
@@ -528,24 +528,16 @@ class Control {
             yCurve: addCurve(
                 materials.green,
                 materials.highlightGreen,
-                (function() {
-                    const q = math.identityQuaternion();
-                    math.eulerToQuaternion([-90, 0, 0], "XYZ", q);
-                    const m = math.mat4();
-                    math.quaternionToMat4(q, m);
-                    return m;
-                })(),
+                [0,1,0],
                 (function () {
                     const translate = math.translateMat4c(0.07, 0, -0.8, math.identityMat4());
-                    const scale = math.scaleMat4v([0.6, 0.6, 0.6], math.identityMat4());
                     const rotate = math.rotationMat4v(90 * math.DEGTORAD, [0, 0, 1], math.identityMat4());
-                    return math.mulMat4(math.mulMat4(translate, scale, math.identityMat4()), rotate, math.identityMat4());
+                    return math.mulMat4(translate, rotate, math.identityMat4());
                 })(),
                 (function () {
                     const translate = math.translateMat4c(0.8, 0.0, -0.07, math.identityMat4());
-                    const scale = math.scaleMat4v([0.6, 0.6, 0.6], math.identityMat4());
                     const rotate = math.rotationMat4v(90 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
-                    return math.mulMat4(math.mulMat4(translate, scale, math.identityMat4()), rotate, math.identityMat4());
+                    return math.mulMat4(translate, rotate, math.identityMat4());
                 })()),
 
             //----------------------------------------------------------------------------------------------------------
@@ -555,17 +547,15 @@ class Control {
             zCurve: addCurve(
                 materials.blue,
                 materials.highlightBlue,
-                math.rotationMat4v(180 * math.DEGTORAD, [1, 0, 0], math.identityMat4()),
+                [0,0,-1],
                 (function () {
                     const translate = math.translateMat4c(.8, -0.07, 0, math.identityMat4());
-                    const scale = math.scaleMat4v([0.6, 0.6, 0.6], math.identityMat4());
-                    return math.mulMat4(translate, scale, math.identityMat4());
+                    return translate;
                 })(),
                 (function () {
                     const translate = math.translateMat4c(.05, -0.8, 0, math.identityMat4());
-                    const scale = math.scaleMat4v([0.6, 0.6, 0.6], math.identityMat4());
                     const rotate = math.rotationMat4v(90 * math.DEGTORAD, [0, 0, 1], math.identityMat4());
-                    return math.mulMat4(math.mulMat4(translate, scale, math.identityMat4()), rotate, math.identityMat4());
+                    return math.mulMat4(translate, rotate, math.identityMat4());
                 })()),
 
             //----------------------------------------------------------------------------------------------------------

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -191,77 +191,61 @@ class Control {
 
         const rootNode = this._rootNode;
 
+        const arrowGeometry = (radiusBottom, height, radialSegments) => new ReadableGeometry(rootNode, buildCylinderGeometry({
+            radiusTop: 0.001,
+            radiusBottom: radiusBottom,
+            radialSegments: radialSegments,
+            heightSegments: 1,
+            height: height,
+            openEnded: false
+        }));
+
+        const tubeGeometry = (radius, height, radialSegments) => new ReadableGeometry(rootNode, buildCylinderGeometry({
+            radiusTop: radius,
+            radiusBottom: radius,
+            radialSegments: radialSegments,
+            heightSegments: 1,
+            height: height,
+            openEnded: false
+        }));
+
+        const torusGeometry = (tube, arcFraction, tubeSegments) => new ReadableGeometry(rootNode, buildTorusGeometry({
+            radius: hoopRadius,
+            tube: tube,
+            radialSegments: 64,
+            tubeSegments: tubeSegments,
+            arc: (Math.PI * 2.0) * arcFraction
+        }));
+
         const shapes = {// Reusable geometries
 
-            arrowHead: new ReadableGeometry(rootNode, buildCylinderGeometry({
-                radiusTop: 0.001,
-                radiusBottom: arrowRadius,
-                radialSegments: 32,
-                heightSegments: 1,
-                height: 0.2,
-                openEnded: false
-            })),
+            arrowHead: arrowGeometry(arrowRadius, 0.2, 32),
+            arrowHeadBig: arrowGeometry(0.09, 0.25, 32),
+            arrowHeadHandle: tubeGeometry(0.09, 0.37, 8),
 
-            arrowHeadBig: new ReadableGeometry(rootNode, buildCylinderGeometry({
-                radiusTop: 0.001,
-                radiusBottom: 0.09,
-                radialSegments: 32,
-                heightSegments: 1,
-                height: 0.25,
-                openEnded: false
-            })),
+            curve:       torusGeometry(tubeRadius, 0.25, 14),
+            curveHandle: torusGeometry(handleTubeRadius, 0.25, 14),
+            hoop:        torusGeometry(tubeRadius, 1, 8),
 
-            arrowHeadHandle: new ReadableGeometry(rootNode, buildCylinderGeometry({
-                radiusTop: 0.09,
-                radiusBottom: 0.09,
-                radialSegments: 8,
-                heightSegments: 1,
-                height: 0.37,
-                openEnded: false
-            })),
-
-            curve: new ReadableGeometry(rootNode, buildTorusGeometry({
-                radius: hoopRadius,
-                tube: tubeRadius,
-                radialSegments: 64,
-                tubeSegments: 14,
-                arc: (Math.PI * 2.0) / 4.0
-            })),
-
-            curveHandle: new ReadableGeometry(rootNode, buildTorusGeometry({
-                radius: hoopRadius,
-                tube: handleTubeRadius,
-                radialSegments: 64,
-                tubeSegments: 14,
-                arc: (Math.PI * 2.0) / 4.0
-            })),
-
-            hoop: new ReadableGeometry(rootNode, buildTorusGeometry({
-                radius: hoopRadius,
-                tube: tubeRadius,
-                radialSegments: 64,
-                tubeSegments: 8,
-                arc: (Math.PI * 2.0)
-            })),
-
-            axis: new ReadableGeometry(rootNode, buildCylinderGeometry({
-                radiusTop: tubeRadius,
-                radiusBottom: tubeRadius,
-                radialSegments: 20,
-                heightSegments: 1,
-                height: radius,
-                openEnded: false
-            })),
-
-            axisHandle: new ReadableGeometry(rootNode, buildCylinderGeometry({
-                radiusTop: 0.08,
-                radiusBottom: 0.08,
-                radialSegments: 20,
-                heightSegments: 1,
-                height: radius,
-                openEnded: false
-            }))
+            axis: tubeGeometry(tubeRadius, radius, 20),
+            axisHandle: tubeGeometry(0.08, radius, 20)
         };
+
+        const colorMaterial = (rgb) => new PhongMaterial(rootNode, {
+            diffuse: rgb,
+            emissive: rgb,
+            ambient: [0.0, 0.0, 0.0],
+            specular: [.6, .6, .3],
+            shininess: 80,
+            lineWidth: 2
+        });
+
+        const highlightMaterial = (rgb, fillAlpha) => new EmphasisMaterial(rootNode, {
+            edges: false,
+            fill: true,
+            fillColor: rgb,
+            fillAlpha: fillAlpha
+        });
 
         const materials = { // Reusable materials
 
@@ -271,53 +255,17 @@ class Control {
                 alphaMode: "blend"
             }),
 
-            red: new PhongMaterial(rootNode, {
-                diffuse: [1, 0.0, 0.0],
-                emissive: [1, 0.0, 0.0],
-                ambient: [0.0, 0.0, 0.0],
-                specular: [.6, .6, .3],
-                shininess: 80,
-                lineWidth: 2
-            }),
+            red: colorMaterial([1, 0.0, 0.0]),
 
-            highlightRed: new EmphasisMaterial(rootNode, { // Emphasis for red rotation affordance hoop
-                edges: false,
-                fill: true,
-                fillColor: [1, 0, 0],
-                fillAlpha: 0.6
-            }),
+            highlightRed: highlightMaterial([1, 0, 0], 0.6),
 
-            green: new PhongMaterial(rootNode, {
-                diffuse: [0.0, 1, 0.0],
-                emissive: [0.0, 1, 0.0],
-                ambient: [0.0, 0.0, 0.0],
-                specular: [.6, .6, .3],
-                shininess: 80,
-                lineWidth: 2
-            }),
+            green: colorMaterial([0.0, 1, 0.0]),
 
-            highlightGreen: new EmphasisMaterial(rootNode, { // Emphasis for green rotation affordance hoop
-                edges: false,
-                fill: true,
-                fillColor: [0, 1, 0],
-                fillAlpha: 0.6
-            }),
+            highlightGreen: highlightMaterial([0, 1, 0], 0.6),
 
-            blue: new PhongMaterial(rootNode, {
-                diffuse: [0.0, 0.0, 1],
-                emissive: [0.0, 0.0, 1],
-                ambient: [0.0, 0.0, 0.0],
-                specular: [.6, .6, .3],
-                shininess: 80,
-                lineWidth: 2
-            }),
+            blue: colorMaterial([0.0, 0.0, 1]),
 
-            highlightBlue: new EmphasisMaterial(rootNode, { // Emphasis for blue rotation affordance hoop
-                edges: false,
-                fill: true,
-                fillColor: [0, 0, 1],
-                fillAlpha: 0.2
-            }),
+            highlightBlue: highlightMaterial([0, 0, 1], 0.2),
 
             center: new PhongMaterial(rootNode, {
                 diffuse: [0.0, 0.0, 0.0],

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -498,8 +498,6 @@ class Control {
 
         const self = this;
 
-        var grabbed = false;
-
         const rootNode = this._rootNode;
 
         var nextDragAction = null; // As we hover grabbed an arrow or hoop, self is the action we would do if we then dragged it.
@@ -692,11 +690,9 @@ class Control {
                         affordanceMesh.visible = true;
                         lastAffordanceMesh = affordanceMesh;
                         nextDragAction = dragAction;
-                        grabbed = true;
                     } else {
                         lastAffordanceMesh = null;
                         nextDragAction = null;
-                        grabbed = false;
                     }
                 }
             });
@@ -713,7 +709,7 @@ class Control {
 
             canvas.addEventListener("mousedown", this._canvasMouseDownListener = (e) => {
                 e.preventDefault();
-                if (this._visible && grabbed) {
+                if (this._visible && nextDragAction) {
                     this._viewer.cameraControl.pointerEnabled = false;
                     if (e.which === 1) { // Left button
                         down = true;
@@ -746,10 +742,7 @@ class Control {
             canvas.addEventListener("mouseup", this._canvasMouseUpListener = (e) => {
                 if (this._visible) {
                     this._viewer.cameraControl.pointerEnabled = true;
-                    if (down) {
-                        down = false;
-                        grabbed = false;
-                    }
+                    down = false;
                 }
             });
         }

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -483,6 +483,7 @@ class Control {
                 pickable: false,
                 collidable: true,
                 clippable: false,
+                backfaces: true,
                 visible: false,
                 isObject: false
             }), NO_STATE_INHERIT),
@@ -494,6 +495,7 @@ class Control {
                 pickable: true,
                 collidable: true,
                 clippable: false,
+                backfaces: true,
                 visible: false,
                 isObject: false
             }), NO_STATE_INHERIT),

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -289,7 +289,7 @@ class Control {
             const initOffset = math.vec3();
             const tempVec3 = math.vec3();
             handlers[arrowHandle.id] = handlers[shaftHandle.id] = {
-                affordanceMesh: bigArrowHead,
+                setActivated: a => bigArrowHead.visible = a,
                 initDragAction: (initCanvasPos) => {
                     return closestPointOnAxis(initCanvasPos, initOffset) && math.subVec3(initOffset, rootNode.position, initOffset) && ((canvasPos) => {
                         if (closestPointOnAxis(canvasPos, tempVec3)) {
@@ -305,7 +305,7 @@ class Control {
 
             const lastCanvasPos = math.vec2();
             handlers[rotateHandle.id] = {
-                affordanceMesh: hoop,
+                setActivated: a => hoop.visible = a,
                 initDragAction: (initCanvasPos) => {
                     lastCanvasPos.set(initCanvasPos);
                     return canvasPos => {
@@ -555,23 +555,23 @@ class Control {
         })();
 
         {
-            let lastAffordanceMesh = null;
+            let deactivateActive = null;
             let dragAction = null; // Action we're doing while we drag an arrow or hoop.
             let nextDragAction = null; // As we hover grabbed an arrow or hoop, self is the action we would do if we then dragged it.
 
             const onCameraControlHover = cameraControl.on("hoverEnter", (hit) => {
                 if (this._visible && (! dragAction)) {
-                    if (lastAffordanceMesh) {
-                        lastAffordanceMesh.visible = false;
+                    if (deactivateActive) {
+                        deactivateActive();
                     }
                     const meshId = hit.entity.id;
                     if (meshId in handlers) {
                         const handler = handlers[meshId];
-                        handler.affordanceMesh.visible = true;
-                        lastAffordanceMesh = handler.affordanceMesh;
+                        handler.setActivated(true);
+                        deactivateActive = () => handler.setActivated(false);
                         nextDragAction = handler.initDragAction;
                     } else {
-                        lastAffordanceMesh = null;
+                        deactivateActive = null;
                         nextDragAction = null;
                     }
                 }
@@ -580,10 +580,10 @@ class Control {
 
             const onCameraControlHoverLeave = cameraControl.on("hoverOutEntity", (hit) => {
                 if (this._visible) {
-                    if (lastAffordanceMesh) {
-                        lastAffordanceMesh.visible = false;
+                    if (deactivateActive) {
+                        deactivateActive();
                     }
-                    lastAffordanceMesh = null;
+                    deactivateActive = null;
                     nextDragAction = null;
                 }
             });

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -805,7 +805,6 @@ class Control {
                 pickable: false,
                 collidable: true,
                 clippable: false,
-                backfaces: true,
                 visible: false,
                 isObject: false
             }), NO_STATE_INHERIT),

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -276,7 +276,9 @@ class Control {
             })
         };
 
-        const addCurve = (material, matrix, matrix1, matrix2) => {
+        const meshesToAdd = [ ];
+
+        const addCurve = (material, highlightMaterial, matrix, matrix1, matrix2) => {
             const curve = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.curve,
                 material: material,
@@ -323,13 +325,35 @@ class Control {
                 isObject: false
             }), NO_STATE_INHERIT);
 
+            const hoop = new Mesh(rootNode, {
+                geometry: shapes.hoop,
+                material: material,
+                highlighted: true,
+                highlightMaterial: highlightMaterial,
+                matrix: matrix,
+                pickable: false,
+                collidable: true,
+                clippable: false,
+                visible: false,
+                isObject: false
+            });
+
+            meshesToAdd.push(hoop);
+
             return {
                 handleId: handle.id,
+                hoop: hoop,
                 set visible(v) {
                     curve.visible = handle.visible = arrow1.visible = arrow2.visible = v;
+                    if (! v) {
+                        hoop.visible = v;
+                    }
                 },
                 set culled(c) {
-                    curve.culled = handle.culled = arrow1.culled = arrow2.culled = c;
+                    curve.culled = handle.culled = arrow1.culled = arrow2.culled;
+                    if (! c) {
+                        hoop.culled = c;
+                    }
                 }
             };
         };
@@ -473,6 +497,7 @@ class Control {
 
             xCurve: addCurve(
                 materials.red,
+                materials.highlightRed,
                 (function () {
                     const rotate2 = math.rotationMat4v(90 * math.DEGTORAD, [0, 1, 0], math.identityMat4());
                     const rotate1 = math.rotationMat4v(270 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
@@ -497,6 +522,7 @@ class Control {
 
             yCurve: addCurve(
                 materials.green,
+                materials.highlightGreen,
                 (function() {
                     const q = math.identityQuaternion();
                     math.eulerToQuaternion([-90, 0, 0], "XYZ", q);
@@ -523,6 +549,7 @@ class Control {
 
             zCurve: addCurve(
                 materials.blue,
+                materials.highlightBlue,
                 math.rotationMat4v(180 * math.DEGTORAD, [1, 0, 0], math.identityMat4()),
                 (function () {
                     const translate = math.translateMat4c(.8, -0.07, 0, math.identityMat4());
@@ -561,6 +588,8 @@ class Control {
             zAxis: addAxis(materials.blue,  math.angleAxisToQuaternion([ 1, 0, 0, -90 * math.DEGTORAD ]))
         };
 
+        meshesToAdd.forEach(m => rootNode.addChild(m, NO_STATE_INHERIT));
+
         this._affordanceMeshes = {
 
             planeFrame: rootNode.addChild(new Mesh(rootNode, {
@@ -590,49 +619,6 @@ class Control {
                 visible: false,
                 scale: [1, 1, 1],
                 rotation: [0, 0, 45],
-                isObject: false
-            }), NO_STATE_INHERIT),
-
-            xHoop: rootNode.addChild(new Mesh(rootNode, { // Full
-                geometry: shapes.hoop,
-                material: materials.red,
-                highlighted: true,
-                highlightMaterial: materials.highlightRed,
-                matrix: (function () {
-                    const rotate2 = math.rotationMat4v(90 * math.DEGTORAD, [0, 1, 0], math.identityMat4());
-                    const rotate1 = math.rotationMat4v(270 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
-                    return math.mulMat4(rotate1, rotate2, math.identityMat4());
-                })(),
-                pickable: false,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT),
-
-            yHoop: rootNode.addChild(new Mesh(rootNode, {
-                geometry: shapes.hoop,
-                material: materials.green,
-                highlighted: true,
-                highlightMaterial: materials.highlightGreen,
-                rotation: [-90, 0, 0],
-                pickable: false,
-                collidable: true,
-                clippable: false,
-                visible: false,
-                isObject: false
-            }), NO_STATE_INHERIT),
-
-            zHoop: rootNode.addChild(new Mesh(rootNode, { // Blue hoop about Z-axis
-                geometry: shapes.hoop,
-                material: materials.blue,
-                highlighted: true,
-                highlightMaterial: materials.highlightBlue,
-                matrix: math.rotationMat4v(180 * math.DEGTORAD, [1, 0, 0], math.identityMat4()),
-                pickable: false,
-                collidable: true,
-                clippable: false,
-                visible: false,
                 isObject: false
             }), NO_STATE_INHERIT),
 
@@ -933,17 +919,17 @@ class Control {
                         break;
 
                     case this._displayMeshes.xCurve.handleId:
-                        affordanceMesh = this._affordanceMeshes.xHoop;
+                        affordanceMesh = this._displayMeshes.xCurve.hoop;
                         nextDragAction = DRAG_ACTIONS.xRotate;
                         break;
 
                     case this._displayMeshes.yCurve.handleId:
-                        affordanceMesh = this._affordanceMeshes.yHoop;
+                        affordanceMesh = this._displayMeshes.yCurve.hoop;
                         nextDragAction = DRAG_ACTIONS.yRotate;
                         break;
 
                     case this._displayMeshes.zCurve.handleId:
-                        affordanceMesh = this._affordanceMeshes.zHoop;
+                        affordanceMesh = this._displayMeshes.zCurve.hoop;
                         nextDragAction = DRAG_ACTIONS.zRotate;
                         break;
 

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -499,6 +499,7 @@ class Control {
         const self = this;
 
         const rootNode = this._rootNode;
+        const setRootNodeScale = size => rootNode.scale = [size, size, size];
 
         var nextDragAction = null; // As we hover grabbed an arrow or hoop, self is the action we would do if we then dragged it.
         var dragAction = null; // Action we're doing while we drag an arrow or hoop.
@@ -509,30 +510,18 @@ class Control {
         const scene = this._viewer.scene;
 
         { // Keep gizmo screen size constant
-
             const tempVec3a = math.vec3([0, 0, 0]);
-
             let lastDist = -1;
-
             this._onSceneTick = scene.on("tick", () => {
-
                 const dist = Math.abs(math.lenVec3(math.subVec3(scene.camera.eye, this._pos, tempVec3a)));
-
-                if (dist !== lastDist) {
-                    if (camera.projection === "perspective") {
-                        const worldSize = (Math.tan(camera.perspective.fov * math.DEGTORAD)) * dist;
-                        const size = 0.07 * worldSize;
-                        rootNode.scale = [size, size, size];
-                        lastDist = dist;
+                if (camera.projection === "perspective") {
+                    if (dist !== lastDist) {
+                        setRootNodeScale(0.07 * dist * Math.tan(camera.perspective.fov * math.DEGTORAD));
                     }
+                } else if (camera.projection === "ortho") {
+                    setRootNodeScale(camera.ortho.scale / 10);
                 }
-
-                if (camera.projection === "ortho") {
-                    const worldSize = camera.ortho.scale / 10;
-                    const size = worldSize;
-                    rootNode.scale = [size, size, size];
-                    lastDist = dist;
-                }
+                lastDist = dist;
             });
         }
 

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -107,13 +107,6 @@ class Control {
         this._rootNode.quaternion = math.vec3PairToQuaternion(zeroVec, xyz, quat);
     }
 
-    _setSectionPlaneDir(dir) {
-        if (this._sectionPlane) {
-            this._ignoreNextSectionPlaneDirUpdate = true;
-            this._sectionPlane.dir = dir;
-        }
-    }
-
     /**
      * Sets if this Control is visible.
      *
@@ -625,7 +618,11 @@ class Control {
                 if (self.sectionPlane) {
                     math.quaternionToMat4(rootNode.quaternion, mat);  // << ---
                     math.transformVec3(mat, [0, 0, 1], dir);
-                    self._setSectionPlaneDir(dir);
+
+                    if (self._sectionPlane) {
+                        self._ignoreNextSectionPlaneDirUpdate = true;
+                        self._sectionPlane.dir = dir;
+                    }
                 }
             };
         })();

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -232,22 +232,11 @@ class Control {
             fillAlpha: fillAlpha
         });
 
-        const materials = { // Reusable materials
-
-            pickable: new PhongMaterial(rootNode, { // Invisible material for pickable handles, which define a pickable 3D area
-                diffuse: [1, 1, 0],
-                alpha: 0, // Invisible
-                alphaMode: "blend"
-            }),
-
-            center: new PhongMaterial(rootNode, {
-                diffuse: [0.0, 0.0, 0.0],
-                emissive: [0, 0, 0],
-                ambient: [0.0, 0.0, 0.0],
-                specular: [.6, .6, .3],
-                shininess: 80
-            })
-        };
+        const pickableMaterial = new PhongMaterial(rootNode, { // Invisible material for pickable handles, which define a pickable 3D area
+            diffuse: [1, 1, 0],
+            alpha: 0, // Invisible
+            alphaMode: "blend"
+        });
 
         const meshesToAdd = [ ];
 
@@ -282,7 +271,7 @@ class Control {
 
             const rotateHandle = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.curveHandle,
-                material: materials.pickable,
+                material: pickableMaterial,
                 matrix: hoopMatrix,
                 pickable: true,
                 collidable: true,
@@ -349,7 +338,7 @@ class Control {
 
             const arrowHandle = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.arrowHeadHandle,
-                material: materials.pickable,
+                material: pickableMaterial,
                 matrix: arrowMatrix,
                 pickable: true,
                 collidable: true,
@@ -371,7 +360,7 @@ class Control {
 
             const shaftHandle = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.axisHandle,
-                material: materials.pickable,
+                material: pickableMaterial,
                 matrix: shaftMatrix,
                 pickable: true,
                 collidable: true,
@@ -488,7 +477,13 @@ class Control {
                 geometry: new ReadableGeometry(rootNode, buildSphereGeometry({
                     radius: 0.05
                 })),
-                material: materials.center,
+                material: new PhongMaterial(rootNode, {
+                    diffuse: [0.0, 0.0, 0.0],
+                    emissive: [0, 0, 0],
+                    ambient: [0.0, 0.0, 0.0],
+                    specular: [.6, .6, .3],
+                    shininess: 80
+                }),
                 pickable: false,
                 collidable: true,
                 clippable: false,

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -239,8 +239,6 @@ class Control {
             alphaMode: "blend"
         });
 
-        const meshesToAdd = [ ];
-
         const addAxis = (rgb, axisDirection, hoopDirection) => {
             const material = colorMaterial(rgb);
 
@@ -304,7 +302,7 @@ class Control {
                 isObject: false
             }), NO_STATE_INHERIT);
 
-            const hoop = new Mesh(rootNode, {
+            const hoop = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.hoop,
                 material: material,
                 highlighted: true,
@@ -315,9 +313,7 @@ class Control {
                 clippable: false,
                 visible: false,
                 isObject: false
-            });
-
-            meshesToAdd.push(hoop);
+            }), NO_STATE_INHERIT);
 
 
             const axisRotation = math.quaternionToRotationMat4(math.vec3PairToQuaternion([ 0, 1, 0 ], axisDirection), math.identityMat4());
@@ -370,7 +366,7 @@ class Control {
                 isObject: false
             }), NO_STATE_INHERIT);
 
-            const bigArrowHead = new Mesh(rootNode, {
+            const bigArrowHead = rootNode.addChild(new Mesh(rootNode, {
                 geometry: shapes.arrowHeadBig,
                 material: material,
                 matrix: arrowMatrix,
@@ -379,9 +375,7 @@ class Control {
                 clippable: false,
                 visible: false,
                 isObject: false
-            });
-
-            meshesToAdd.push(bigArrowHead);
+            }), NO_STATE_INHERIT);
 
             this._handlers[arrowHandle.id] = this._handlers[shaftHandle.id] = [ bigArrowHead, [ true, rgb ] ];
             this._handlers[rotateHandle.id] = [ hoop, [ false, rgb ] ];
@@ -498,8 +492,6 @@ class Control {
             yAxis: addAxis([0,1,0], [ 0, -1,  0 ], [ 0, 1,  0 ]),
             zAxis: addAxis([0,0,1], [ 0,  0, -1 ], [ 0, 0, -1 ])
         };
-
-        meshesToAdd.forEach(m => rootNode.addChild(m, NO_STATE_INHERIT));
     }
 
     _bindEvents() {

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -67,15 +67,23 @@ class Control {
         }
         if (sectionPlane) {
             this.id = sectionPlane.id;
-            this._setPos(sectionPlane.pos);
-            this._setDir(sectionPlane.dir);
+            const setPosFromSectionPlane = () => {
+                const pos = sectionPlane.pos;
+                this._pos.set(pos);
+                worldToRTCPos(pos, this._origin, this._rtcPos);
+                this._rootNode.origin = this._origin;
+                this._rootNode.position = this._rtcPos;
+            };
+            const setDirFromSectionPlane = () => {
+                this._rootNode.quaternion = math.vec3PairToQuaternion(zeroVec, sectionPlane.dir, quat);
+            };
+            setPosFromSectionPlane();
+            setDirFromSectionPlane();
             this._sectionPlane = sectionPlane;
-            this._onSectionPlanePos = sectionPlane.on("pos", () => {
-                this._setPos(this._sectionPlane.pos);
-            });
+            this._onSectionPlanePos = sectionPlane.on("pos", setPosFromSectionPlane);
             this._onSectionPlaneDir = sectionPlane.on("dir", () => {
                 if (!this._ignoreNextSectionPlaneDirUpdate) {
-                    this._setDir(this._sectionPlane.dir);
+                    setDirFromSectionPlane();
                 } else {
                     this._ignoreNextSectionPlaneDirUpdate = false;
                 }
@@ -89,22 +97,6 @@ class Control {
      */
     get sectionPlane() {
         return this._sectionPlane;
-    }
-
-    /** @private */
-    _setPos(xyz) {
-
-        this._pos.set(xyz);
-
-        worldToRTCPos(this._pos, this._origin, this._rtcPos);
-
-        this._rootNode.origin = this._origin;
-        this._rootNode.position = this._rtcPos;
-    }
-
-    /** @private */
-    _setDir(xyz) {
-        this._rootNode.quaternion = math.vec3PairToQuaternion(zeroVec, xyz, quat);
     }
 
     /**

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -47,16 +47,7 @@ class Control {
 
         this._ignoreNextSectionPlaneDirUpdate = false;
 
-        this._createNodes();
-        this._bindEvents();
-    }
-
-    /**
-     * Builds the Entities that represent this Control.
-     * @private
-     */
-    _createNodes() {
-
+        // Builds the Entities that represent this Control.
         const NO_STATE_INHERIT = false;
         const scene = this._viewer.scene;
         const radius = 1.0;
@@ -388,13 +379,10 @@ class Control {
             yAxis: addAxis([0,1,0], [ 0, -1,  0 ], [ 0, 1,  0 ]),
             zAxis: addAxis([0,0,1], [ 0,  0, -1 ], [ 0, 0, -1 ])
         };
-    }
 
-    _bindEvents() {
-
+        // bindEvents
         const self = this;
 
-        const rootNode = this._rootNode;
         const setRootNodeScale = size => rootNode.scale = [size, size, size];
 
         var nextDragAction = null; // As we hover grabbed an arrow or hoop, self is the action we would do if we then dragged it.
@@ -403,7 +391,6 @@ class Control {
 
         const canvas = this._viewer.scene.canvas.canvas;
         const camera = this._viewer.camera;
-        const scene = this._viewer.scene;
 
         { // Keep gizmo screen size constant
             const tempVec3a = math.vec3([0, 0, 0]);

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -1295,16 +1295,6 @@ class Control {
                 down = false;
                 grabbed = false;
             });
-
-            canvas.addEventListener("wheel", this._canvasWheelListener = (e) => {
-                if (!this._visible) {
-                    return;
-                }
-                var delta = Math.max(-1, Math.min(1, -e.deltaY * 40));
-                if (delta === 0) {
-                    return;
-                }
-            });
         }
     }
 
@@ -1326,7 +1316,6 @@ class Control {
         canvas.removeEventListener("mousedown", this._canvasMouseDownListener);
         canvas.removeEventListener("mousemove", this._canvasMouseMoveListener);
         canvas.removeEventListener("mouseup", this._canvasMouseUpListener);
-        canvas.removeEventListener("wheel", this._canvasWheelListener);
 
         camera.off(this._onCameraViewMatrix);
         camera.off(this._onCameraProjMatrix);

--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -742,7 +742,7 @@ class Control {
                 material: materials.blue,
                 matrix: (function () {
                     const translate = math.translateMat4c(0, radius + .1, 0, math.identityMat4());
-                    const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [0.8, 0, 0], math.identityMat4());
+                    const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
                     return math.mulMat4(rotate, translate, math.identityMat4());
                 })(),
                 pickable: false,
@@ -757,7 +757,7 @@ class Control {
                 material: materials.pickable,
                 matrix: (function () {
                     const translate = math.translateMat4c(0, radius + .1, 0, math.identityMat4());
-                    const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [0.8, 0, 0], math.identityMat4());
+                    const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
                     return math.mulMat4(rotate, translate, math.identityMat4());
                 })(),
                 pickable: true,
@@ -909,7 +909,7 @@ class Control {
                 material: materials.blue,
                 matrix: (function () {
                     const translate = math.translateMat4c(0, radius + .1, 0, math.identityMat4());
-                    const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [0.8, 0, 0], math.identityMat4());
+                    const rotate = math.rotationMat4v(-90 * math.DEGTORAD, [1, 0, 0], math.identityMat4());
                     return math.mulMat4(rotate, translate, math.identityMat4());
                 })(),
                 pickable: false,


### PR DESCRIPTION
Main changes introduced by this PR:

XEOK-125 Change the way axis interaction is interpreted - looking for a point on the axis closest to the pointer ray (also #1717).
Instead intersecting the pointer/touch ray with a fixed plane (which would sometimes be parallel to the ray direction), the interaction now looks for a closest point between the ray and an axis line.

CHANGE SectionPlanesPlugin::Control to rely only on canvas events, and not on hoverEnter/hoverOutEntity (those would interfere with touch events).
This also removes a "weird" section plane control behaviour, when a mouse click would activate it, even if the pointer was not hovering the gizmo.

XCD-176 Add SectionPlanesPlugin::Control touch events support
