### PR TITLE
XEOK-191 Fix math.transformPoint4 call

### DIFF
--- a/src/viewer/scene/model/dtx/triangles/DTXTrianglesLayer.js
+++ b/src/viewer/scene/model/dtx/triangles/DTXTrianglesLayer.js
@@ -1122,8 +1122,7 @@ export class DTXTrianglesLayer {
                 worldPos[2] = positions[i + 2];
                 worldPos[3] = 1.0;
                 math.decompressPosition(worldPos, positionsDecodeMatrix);
-                math.transformPoint4(this.model.worldMatrix, worldPos, worldPos);
-                math.transformPoint4(this.model.worldMatrix, worldPos, worldPos);
+                math.mulMat4v4(this.model.worldMatrix, worldPos, worldPos);
                 worldPos[0] += offsetX;
                 worldPos[1] += offsetY;
                 worldPos[2] += offsetZ;


### PR DESCRIPTION
The `math.transformPoint4` gives an incorrect result, if the second and third argument point to the same object.