### PR TITLE
Much cleaner edge rendering when enabling logarithmic depth buffer

### DIFF
--- a/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesColorRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesColorRenderer.js
@@ -221,7 +221,10 @@ export class TrianglesColorRenderer extends TrianglesBatchingRenderer {
         }
 
         if (scene.logarithmicDepthBufferEnabled) {
-            src.push("    gl_FragDepth = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;");
+            src.push("    float dx = dFdx(vFragDepth);")
+            src.push("    float dy = dFdy(vFragDepth);")
+            src.push("    float diff = sqrt(dx*dx+dy*dy);");
+            src.push("    gl_FragDepth = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth + diff ) * logDepthBufFC * 0.5;");
         }
 
         if (this._withSAO) {

--- a/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesColorRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesColorRenderer.js
@@ -234,7 +234,10 @@ class TrianglesColorRenderer extends TrianglesInstancingRenderer {
         }
 
         if (scene.logarithmicDepthBufferEnabled) {
-            src.push("    gl_FragDepth = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;");
+            src.push("    float dx = dFdx(vFragDepth);")
+            src.push("    float dy = dFdy(vFragDepth);")
+            src.push("    float diff = sqrt(dx*dx+dy*dy);");
+            src.push("    gl_FragDepth = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth + diff ) * logDepthBufFC * 0.5;");
         }
 
         // Doing SAO blend in the main solid fill draw shader just so that edge lines can be drawn over the top


### PR DESCRIPTION
## Descrption

Use the same gradient technique has here https://github.com/xeokit/xeokit-sdk/issues/1162#issuecomment-1778744218 for much better visual quality in edge rendering when the logarithmic depth buffer is enabled.

## Screenshots: Before / After

The screenshots below were taken with a far plane distance equal to 1M km!

### Before (i)

<img width="1088" alt="image" src="https://github.com/user-attachments/assets/ab0a6193-9c89-44fd-83f9-bd4291aacfc3" />

### After (i)

<img width="1133" alt="image" src="https://github.com/user-attachments/assets/a980769d-9d1a-4222-81bd-6db40b230e49" />

### Before (ii)

<img width="994" alt="image" src="https://github.com/user-attachments/assets/29f6b22c-2a1d-4675-8218-be50f6829b5e" />

### After (ii)

<img width="1029" alt="image" src="https://github.com/user-attachments/assets/a9135a1e-df50-4207-8c87-6eb08eddc800" />

## Explanation

Sub-pixel z-fighting (explained here https://github.com/xeokit/xeokit-sdk/issues/1162#issuecomment-1774049269) makes edge drawing worse when logarithmic depth buffer is enabled, possibly because the dynamic range of the Z values get compressed (via the `log` function) together with much bigger far plane distances being used with logarithmic z-buffer.

As the rendering of edged surfaces happens in two stages in xeokit-sdk...

- a) first, regular surfaces are rendered, and this initializes the Z-buffer
- b) on top of it, edges are rendered, which then z-fight with the pre-initialized z-buffer in "a)"

... the reduced dynamic range affects more the case where log-depth-buffer is enabled.

This PR makes use of the gradient trick so, during the regular surface rendering, their z-values are "pushed" far away from the camera to the same distance where their immediate furthest neighbour pixel is.

This makes the z-buffer pre-initialization much more friendly with stage "b)", and fixes the sub-pixel z-fighting problem.