### PR TITLE
XEOK-205 Fix math.mat4ToEuler to return angles in degrees, not radians

### DIFF
--- a/src/viewer/scene/math/math.js
+++ b/src/viewer/scene/math/math.js
@@ -1965,7 +1965,7 @@ const math = {
      * @param {Number[]} mat The 4x4 matrix.
      * @param {String} order Desired Euler angle order: "XYZ", "YXZ", "ZXY" etc.
      * @param {Number[]} [dest] Destination Euler angles, created by default.
-     * @returns {Number[]} The Euler angles.
+     * @returns {Number[]} The Euler angles (in degrees).
      */
     mat4ToEuler(mat, order, dest = math.vec4()) {
         const clamp = math.clamp;
@@ -2056,6 +2056,10 @@ const math = {
                 dest[1] = 0;
             }
         }
+
+        dest[0] *= math.RADTODEG;
+        dest[1] *= math.RADTODEG;
+        dest[2] *= math.RADTODEG;
 
         return dest;
     },
@@ -2866,7 +2870,7 @@ const math = {
     /**
      * Initializes a quaternion from Euler angles.
      *
-     * @param {Number[]} euler The Euler angles.
+     * @param {Number[]} euler The Euler angles (in degrees).
      * @param {String} order Euler angle order: "XYZ", "YXZ", "ZXY" etc.
      * @param {Number[]} [dest] Destination quaternion, created by default.
      * @returns {Number[]} The quaternion.


### PR DESCRIPTION
The fix corrects `math.mat4ToEuler` and `math.quaternionToEuler` to return angles in degrees (instead of radians), to be symmetrical with `math.eulerToQuaternion` input semantict (which is angles in degrees).
WARNING: Potentially breaking change for users that relied in their application code on either `math.mat4ToEuler` or `math.quaternionToEuler`.