### PR TITLE
FIX: allow to change the `snapRadius` during snap picking

### DIFF
--- a/src/viewer/scene/webgl/Renderer.js
+++ b/src/viewer/scene/webgl/Renderer.js
@@ -1302,13 +1302,16 @@ const Renderer = function (scene, options) {
 
             const snapRadiusInPixels = snapRadius || 30;
 
-            const vertexPickBuffer = renderBufferManager.getRenderBuffer("uniquePickColors-aabs", {
-                depthTexture: true,
-                size: [
-                    2 * snapRadiusInPixels + 1,
-                    2 * snapRadiusInPixels + 1,
-                ]
-            });
+            const vertexPickBuffer = renderBufferManager.getRenderBuffer(
+                `uniquePickColors-aabs-${snapRadiusInPixels}`,
+                {
+                    depthTexture: true,
+                    size: [
+                        2 * snapRadiusInPixels + 1,
+                        2 * snapRadiusInPixels + 1,
+                    ]
+                }
+            );
 
             frameCtx.snapVectorA = [
                 canvasPos ? getClipPosX(canvasPos[0] * resolutionScale, gl.drawingBufferWidth) : 0,


### PR DESCRIPTION
## Description

@xeolabs Sometimes, it is a needed use case to allow changing the snap radius during snap picking.

Current implementation caches the `RenderBuffer` related to snap picking without taking into account the snap radius.

Today, the size of the `RenderBuffer` will be set only during the first call to `snapPick`, but not adjusted when needed afterwards.

If the snap radius is changed after having done already some snap picking, the related `RenderBuffer` will get stuck in the previous snap radius, causing shader errors.

This PR is a very easy fix to this problem. It consists in making the name of the cached `RenderBuffer` depend on the snap radius. Thus, the limitation is mitigated and the bug is soolved.