### PR TITLE
[FEATURE] Load only specified elements

### DIFF
--- a/examples/buildings/index.html
+++ b/examples/buildings/index.html
@@ -273,6 +273,7 @@
             ["xkt_vbo_federated_Clinic", "Viewing a federated BIM model loaded from XKT into SceneModels"],
             ["xkt_vbo_DemoProjekt", "Viewing a BIM model exported from ArchiCAD"],
             ["xkt_vbo_OTCConferenceCenter", "OTC Conference Center model, loaded from XKT into SceneModel"],
+            ["xkt_vbo_includeIds", "Loading an XKT model with only selected elements with specific ids"],
 
             "#XKT + Data Textures",
 

--- a/examples/buildings/xkt_vbo_includeIds.html
+++ b/examples/buildings/xkt_vbo_includeIds.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>xeokit Example</title>
+    <link href="../css/pageStyle.css" rel="stylesheet"/>
+    <style></style>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
+</head>
+<body>
+<input type="checkbox" id="info-button"/>
+<label for="info-button" class="info-button"><i class="far fa-3x fa-question-circle"></i></label>
+<canvas id="myCanvas"></canvas>
+<canvas id="myNavCubeCanvas"></canvas>
+<div id="treeViewContainer"></div>
+<div class="slideout-sidebar">
+    <img class="info-icon" style="width:280px; padding-bottom:10px;" src="../../assets/images/bim_icon.png"/>
+    <h1>XKTLoaderPlugin</h1>
+    <h2>Loading an XKT model with only selected elements with specific ids</h2>
+      <h3>Stats</h3>
+    <ul>
+        <li>
+            <div id="time">Loading JavaScript modules...</div>
+        </li>
+    </ul>
+    <h3>Components used</h3>
+    <ul>
+        <li>
+            <a href="../../docs/class/src/viewer/Viewer.js~Viewer.html"
+               target="_other">Viewer</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js~XKTLoaderPlugin.html"
+               target="_other">XKTLoaderPlugin</a>
+        </li>
+    </ul>
+    <h3>Assets</h3>
+    <ul>
+        <li><a href="https://www.cityjson.org/" target="_other">Model source</a></li>
+    </ul>
+</div>
+</body>
+
+<script type="module">
+
+    import {Viewer, XKTLoaderPlugin} from "../../dist/xeokit-sdk.min.es.js";
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas",
+        transparent: true,
+        saoEnabled: true
+    });
+
+    viewer.scene.camera.eye = [14.915582703146043, 14.396781491179095, 5.431098754133695];
+    viewer.scene.camera.look = [6.599999999999998, 8.34099990051474, -4.159999575600315];
+    viewer.scene.camera.up = [-0.2820584034861215, 0.9025563895259413, -0.3253229483893775];
+
+    const xktLoader = new XKTLoaderPlugin(viewer);
+
+    const sceneModel = xktLoader.load({
+        id: "myModel",
+        src: "../../assets/models/xkt/v10/glTF-Embedded/Duplex_A_20110505.glTFEmbedded.xkt",
+        saoEnabled: true,
+        edges: true,
+        dtxEnabled: true,
+        includeIds: ["2O2Fr$t4X7Zf8NOew3FLOH", "1hOSvn6df7F8_7GcBWlS_W", "1hOSvn6df7F8_7GcBWlS4Q", "1hOSvn6df7F8_7GcBWlS1M", "1hOSvn6df7F8_7GcBWlS2V"], // Here it is specified which elements should be loaded
+    });
+
+    sceneModel.on("loaded", ()=>{
+        viewer.cameraFlight.jumpTo(sceneModel);
+    });
+
+    const t0 = performance.now();
+    document.getElementById("time").innerHTML = "Loading model...";
+    sceneModel.on("loaded", function () {
+        const t1 = performance.now();
+        document.getElementById("time").innerHTML = "Model loaded in " + Math.floor(t1 - t0) / 1000.0 + " seconds<br>Objects: " + sceneModel.numEntities;
+    });
+
+    window.viewer = viewer;
+
+</script>
+</html>

--- a/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
+++ b/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
@@ -748,6 +748,34 @@ class XKTLoaderPlugin extends Plugin {
     }
 
     /**
+     * Gets the whitelist of the specified elements loaded by this XKTLoaderPlugin.
+     *
+     * When loading models with metadata, causes this XKTLoaderPlugin to only load objects whose ids are in this
+     * list. An object's id is indicated by its {@link MetaObject}'s {@link MetaObject#id}.
+     *
+     * Default value is ````undefined````.
+     *
+     * @type {String[]}
+     */
+    get includeIds() {
+        return this._includeIds;
+    }
+
+    /**
+     * Sets the whitelist of the specified elements by this XKTLoaderPlugin.
+     *
+     * When loading models with metadata, causes this XKTLoaderPlugin to only load objects whose ids are in this
+     * list. An object's id is indicated by its {@link MetaObject}'s {@link MetaObject#id}.
+     *
+     * Default value is ````undefined````.
+     *
+     * @type {String[]}
+     */
+    set includeIds(value) {
+        this._includeIds = value;
+    }
+
+    /**
      * Gets whether we load objects that don't have IFC types.
      *
      * When loading models with metadata and this is ````true````, XKTLoaderPlugin will not load objects
@@ -921,7 +949,10 @@ class XKTLoaderPlugin extends Plugin {
         }
 
         if (includeIds) {
-            options.includeIdsMap = includeIds;
+            options.includeIdsMap = {};
+            for (let i = 0, len = includeIds.length; i < len; i++) {
+                options.includeIdsMap[includeIds[i]] = true;
+            }
         }
 
         if (objectDefaults) {

--- a/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
+++ b/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
@@ -859,6 +859,7 @@ class XKTLoaderPlugin extends Plugin {
      * @param {{String:Object}} [params.objectDefaults] Map of initial default states for each loaded {@link Entity} that represents an object. Default value is {@link IFCObjectDefaults}.
      * @param {String[]} [params.includeTypes] When loading metadata, only loads objects that have {@link MetaObject}s with {@link MetaObject#type} values in this list.
      * @param {String[]} [params.excludeTypes] When loading metadata, never loads objects that have {@link MetaObject}s with {@link MetaObject#type} values in this list.
+     * @param {String[]} [params.includeIds] When loading metadata, only loads objects that have {@link MetaObject}s with {@link MetaObject#id} values in this list.
      * @param {Boolean} [params.edges=false] Whether or not xeokit renders the model with edges emphasized.
      * @param {Number[]} [params.origin=[0,0,0]] The model's World-space double-precision 3D origin. Use this to position the model within xeokit's World coordinate system, using double-precision coordinates.
      * @param {Number[]} [params.position=[0,0,0]] The model single-precision 3D position, relative to the ````origin```` parameter.
@@ -900,6 +901,7 @@ class XKTLoaderPlugin extends Plugin {
         const options = {};
         const includeTypes = params.includeTypes || this._includeTypes;
         const excludeTypes = params.excludeTypes || this._excludeTypes;
+        const includeIds = params.includeIds || this._includeIds;
         const objectDefaults = params.objectDefaults || this._objectDefaults;
 
         options.reuseGeometries = (params.reuseGeometries !== null && params.reuseGeometries !== undefined) ? params.reuseGeometries : (this._reuseGeometries !== false);
@@ -916,6 +918,10 @@ class XKTLoaderPlugin extends Plugin {
             for (let i = 0, len = excludeTypes.length; i < len; i++) {
                 options.excludeTypesMap[excludeTypes[i]] = true;
             }
+        }
+
+        if (includeIds) {
+            options.includeIdsMap = includeIds;
         }
 
         if (objectDefaults) {

--- a/src/plugins/XKTLoaderPlugin/parsers/ParserV10.js
+++ b/src/plugins/XKTLoaderPlugin/parsers/ParserV10.js
@@ -320,6 +320,12 @@ function load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx)
                     continue;
                 }
 
+                // Mask loading of object ids
+
+                if (options.includeIdsMap && metaObject.id && (!options.includeIdsMap[metaObject.id])) {
+                    continue;
+                }
+
                 // Get initial property values for object types
 
                 const props = options.objectDefaults ? options.objectDefaults[metaObject.type] || options.objectDefaults["DEFAULT"] : null;

--- a/src/plugins/XKTLoaderPlugin/parsers/ParserV11.js
+++ b/src/plugins/XKTLoaderPlugin/parsers/ParserV11.js
@@ -315,7 +315,7 @@ function load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx)
 
                 // Mask loading of object ids
 
-                if (options.includeIdsMap && (!options.includeIdsMap[metaObject.id])) {
+                if (options.includeIdsMap && metaObject.id && (!options.includeIdsMap[metaObject.id])) {
                     continue;
                 }
 

--- a/src/plugins/XKTLoaderPlugin/parsers/ParserV11.js
+++ b/src/plugins/XKTLoaderPlugin/parsers/ParserV11.js
@@ -313,6 +313,12 @@ function load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx)
                     continue;
                 }
 
+                // Mask loading of object ids
+
+                if (options.includeIdsMap && (!options.includeIdsMap[metaObject.id])) {
+                    continue;
+                }
+
                 // Get initial property values for object types
 
                 const props = options.objectDefaults ? options.objectDefaults[metaObject.type] || options.objectDefaults["DEFAULT"] : null;

--- a/src/plugins/XKTLoaderPlugin/parsers/ParserV6.js
+++ b/src/plugins/XKTLoaderPlugin/parsers/ParserV6.js
@@ -180,6 +180,12 @@ function load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx)
                     continue;
                 }
 
+                // Mask loading of object ids
+
+                if (options.includeIdsMap && metaObject.id && (!options.includeIdsMap[metaObject.id])) {
+                    continue;
+                }
+
                 // Get initial property values for object types
 
                 const props = options.objectDefaults ? options.objectDefaults[metaObject.type] || options.objectDefaults["DEFAULT"] : null;

--- a/src/plugins/XKTLoaderPlugin/parsers/ParserV7.js
+++ b/src/plugins/XKTLoaderPlugin/parsers/ParserV7.js
@@ -230,6 +230,12 @@ function load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx)
                     continue;
                 }
 
+                // Mask loading of object ids
+
+                if (options.includeIdsMap && metaObject.id && (!options.includeIdsMap[metaObject.id])) {
+                    continue;
+                }
+
                 // Get initial property values for object types
 
                 const props = options.objectDefaults ? options.objectDefaults[metaObject.type] || options.objectDefaults["DEFAULT"] : null;

--- a/src/plugins/XKTLoaderPlugin/parsers/ParserV8.js
+++ b/src/plugins/XKTLoaderPlugin/parsers/ParserV8.js
@@ -273,6 +273,12 @@ function load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx)
                     continue;
                 }
 
+                // Mask loading of object ids
+
+                if (options.includeIdsMap && metaObject.id && (!options.includeIdsMap[metaObject.id])) {
+                    continue;
+                }
+
                 // Get initial property values for object types
 
                 const props = options.objectDefaults ? options.objectDefaults[metaObject.type] || options.objectDefaults["DEFAULT"] : null;

--- a/src/plugins/XKTLoaderPlugin/parsers/ParserV9.js
+++ b/src/plugins/XKTLoaderPlugin/parsers/ParserV9.js
@@ -230,6 +230,12 @@ function load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx)
                     continue;
                 }
 
+                // Mask loading of object ids
+
+                if (options.includeIdsMap && metaObject.id && (!options.includeIdsMap[metaObject.id])) {
+                    continue;
+                }
+
                 // Get initial property values for object types
 
                 const props = options.objectDefaults ? options.objectDefaults[metaObject.type] || options.objectDefaults["DEFAULT"] : null;


### PR DESCRIPTION
Related to XCD-253

The goal is to add an option to load only specified elements (for .xkt loading).

This PR introduces such option to specify "includeIds" with elements that we want to load.

In this PR such option was added to V6-V11 parsers.

There is also the new example file with how it should work:
![image](https://github.com/user-attachments/assets/932167bc-7e74-4650-80e6-6d1c15a06ec8)

Types & docs will be updated once this part will be accepted.