### PR TITLE
chore: fix percy token passing, remove percy abel once test done

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,13 +7,13 @@ on:
     branches:
       - master
     types: [labeled]
- 
+
 jobs:
   build:
-    # Run this job on push to master when *not* publishing a tag 
+    # Run this job on push to master when *not* publishing a tag
     # and on 'percy' labeled pull requests
     if: |
-      (${{ github.event_name == 'push' }} && startsWith(github.ref, 'refs/tags/') != true) || 
+      (${{ github.event_name == 'push' }} && startsWith(github.ref, 'refs/tags/') != true) ||
       (${{ github.event_name == 'pull_request' }} && ${{ github.event.label.name == 'percy' }})
     runs-on: ubuntu-latest
 
@@ -34,8 +34,6 @@ jobs:
 
       - name: Test
         run: |
-          echo "$DOT_ENV" > .env 
+          echo "PERCY_TOKEN=${{ secrets.PERCY_TOKEN }}" > .env
           npx playwright install --with-deps chromium
           npm run test
-        env:
-          DOT_ENV: ${{ secrets.PERCY_ENV }}


### PR DESCRIPTION
GH actions did not pick up percy token correctly. This change is fixing this problem. I also added removing label's so reviewer  does not have to do it manually in case re-running tests. 