### PR TITLE
Upgrade loaders.gl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@xeokit/xeokit-sdk",
-  "version": "2.6.64",
+  "version": "2.6.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@xeokit/xeokit-sdk",
-      "version": "2.6.64",
-      "license": "See LICENSE.txt",
+      "version": "2.6.65",
+      "license": "AGPL-3.0",
       "dependencies": {
-        "@loaders.gl/core": "^3.2.6",
-        "@loaders.gl/gltf": "^3.2.6",
-        "@loaders.gl/las": "^3.2.6",
+        "@loaders.gl/core": "^4.3.3",
+        "@loaders.gl/gltf": "^4.3.3",
+        "@loaders.gl/las": "^4.3.3",
         "html2canvas": "^1.4.1"
       },
       "devDependencies": {
@@ -1688,6 +1688,7 @@
       "version": "7.16.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
       "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
+      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -1698,7 +1699,8 @@
     "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
       "version": "0.13.9",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+      "dev": true
     },
     "node_modules/@babel/template": {
       "version": "7.18.10",
@@ -1963,106 +1965,132 @@
       }
     },
     "node_modules/@loaders.gl/core": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-3.2.6.tgz",
-      "integrity": "sha512-7aYWjkA7Shprd5pe4pAUHXlCfP5TMvIevHrg93UiLlwROrTM0ui0akcqGxOaL6SKoKBDtRvBaQ6YB51sf3KLqQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-4.3.3.tgz",
+      "integrity": "sha512-RaQ3uNg4ZaVqDRgvJ2CjaOjeeHdKvbKuzFFgbGnflVB9is5bu+h3EKc3Jke7NGVvLBsZ6oIXzkwHijVsMfxv8g==",
       "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "@loaders.gl/loader-utils": "3.2.6",
-        "@loaders.gl/worker-utils": "3.2.6",
-        "@probe.gl/log": "^3.5.0",
-        "probe.gl": "^3.4.0"
+        "@loaders.gl/loader-utils": "4.3.3",
+        "@loaders.gl/schema": "4.3.3",
+        "@loaders.gl/worker-utils": "4.3.3",
+        "@probe.gl/log": "^4.0.2"
       }
     },
     "node_modules/@loaders.gl/draco": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-3.2.6.tgz",
-      "integrity": "sha512-jwtnAZmW/STqJfMg3+zCudKlK79ddlVxSjkGOARGHvW0FMXHWqj0POVvA3Z4NMijyYfNr9X/zBr+mZpHSnM7qA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-4.3.3.tgz",
+      "integrity": "sha512-f2isxvOoH4Pm5p4mGvNN9gVigUwX84j9gdKNMV1aSo56GS1KE3GS2rXaIoy1qaIHMzkPySUTEcOTwayf0hWU7A==",
       "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "@loaders.gl/loader-utils": "3.2.6",
-        "@loaders.gl/schema": "3.2.6",
-        "@loaders.gl/worker-utils": "3.2.6",
-        "draco3d": "1.4.1"
+        "@loaders.gl/loader-utils": "4.3.3",
+        "@loaders.gl/schema": "4.3.3",
+        "@loaders.gl/worker-utils": "4.3.3",
+        "draco3d": "1.5.7"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.3.0"
       }
     },
     "node_modules/@loaders.gl/gltf": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-3.2.6.tgz",
-      "integrity": "sha512-hY0LAU6FJpltq/V3nEqNszLf6KF20odo7/C9AAMNMl/ayUfIJjryuDAt56HMhQYowKW437OhzFrs5MR7LPk29w==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-4.3.3.tgz",
+      "integrity": "sha512-M7jQ7KIB5itctDmGYuT9gndmjNwk1lwQ+BV4l5CoFp38e4xJESPglj2Kj8csWdm3WJhrxIYEP4GpjXK02n8DSQ==",
       "dependencies": {
-        "@loaders.gl/draco": "3.2.6",
-        "@loaders.gl/images": "3.2.6",
-        "@loaders.gl/loader-utils": "3.2.6",
-        "@loaders.gl/textures": "3.2.6"
+        "@loaders.gl/draco": "4.3.3",
+        "@loaders.gl/images": "4.3.3",
+        "@loaders.gl/loader-utils": "4.3.3",
+        "@loaders.gl/schema": "4.3.3",
+        "@loaders.gl/textures": "4.3.3",
+        "@math.gl/core": "^4.1.0"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.3.0"
       }
     },
     "node_modules/@loaders.gl/images": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-3.2.6.tgz",
-      "integrity": "sha512-4Dgpw/uOQLEi3bvxUVg5n+nSlMlGCRnl1K0M8kZbsNc0aaV57cnQK2whsA8xM/pkCl3YE+nG8yo8IniK25j4lA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-4.3.3.tgz",
+      "integrity": "sha512-s4InjIXqEu0T7anZLj4OBUuDBt2BNnAD0GLzSexSkBfQZfpXY0XJNl4mMf5nUKb5NDfXhIKIqv8y324US+I28A==",
       "dependencies": {
-        "@loaders.gl/loader-utils": "3.2.6"
+        "@loaders.gl/loader-utils": "4.3.3"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.3.0"
       }
     },
     "node_modules/@loaders.gl/las": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/las/-/las-3.2.6.tgz",
-      "integrity": "sha512-UUmMRbzqYzUTgBZgGjsfe0juKig7ot7+dSohboT6o3FA7pqjozi2Pdb+vdO3W+EjsAbLLPgCJhmG7BvbqhHgOg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/las/-/las-4.3.3.tgz",
+      "integrity": "sha512-mzvasLZW6vqTaONYSvxBx4+yOnQC7pcI/wAyqHgPQI3NuBbR98xgwFcpoOxJ2AKILXHdneOTUVF4+iDLcWGmvw==",
       "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "@loaders.gl/loader-utils": "3.2.6",
-        "@loaders.gl/schema": "3.2.6",
-        "apache-arrow": "^4.0.0"
+        "@loaders.gl/loader-utils": "4.3.3",
+        "@loaders.gl/schema": "4.3.3",
+        "laz-perf": "^0.0.6"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.3.0"
       }
     },
     "node_modules/@loaders.gl/loader-utils": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-3.2.6.tgz",
-      "integrity": "sha512-OXVEhimpcn37VBs+QTUFZE8vjzr3zZKc0O5vuOsFijLmoT85J7f7G1rSJ9RY3eRM+au+VvIp6Pqt6fBGbe+lDg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.3.3.tgz",
+      "integrity": "sha512-8erUIwWLiIsZX36fFa/seZsfTsWlLk72Sibh/YZJrPAefuVucV4mGGzMBZ96LE2BUfJhadn250eio/59TUFbNw==",
       "dependencies": {
-        "@babel/runtime": "^7.3.1",
-        "@loaders.gl/worker-utils": "3.2.6",
-        "@probe.gl/stats": "^3.5.0"
-      }
-    },
-    "node_modules/@loaders.gl/loader-utils/node_modules/@probe.gl/stats": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-3.5.0.tgz",
-      "integrity": "sha512-IH2M+F3c8HR1DTroBARePUFG7wIewumtKA0UFqx51Z7S4hKrD60wFbpMmg0AcF4FvHAXMBoC+kYi1UKW9XbAOw==",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0"
+        "@loaders.gl/schema": "4.3.3",
+        "@loaders.gl/worker-utils": "4.3.3",
+        "@probe.gl/log": "^4.0.2",
+        "@probe.gl/stats": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.3.0"
       }
     },
     "node_modules/@loaders.gl/schema": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-3.2.6.tgz",
-      "integrity": "sha512-Hy7VRe8dVDnX9nnObpwyk8XcQmfJfn1Iqxc8ATtq0CLH9Prep4pQII8kB6fVZ14clqVm8432zkfINQ0l6ug2RA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.3.3.tgz",
+      "integrity": "sha512-zacc9/8je+VbuC6N/QRfiTjRd+BuxsYlddLX1u5/X/cg9s36WZZBlU1oNKUgTYe8eO6+qLyYx77yi+9JbbEehw==",
       "dependencies": {
-        "@types/geojson": "^7946.0.7",
-        "apache-arrow": "^4.0.0"
+        "@types/geojson": "^7946.0.7"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.3.0"
       }
     },
     "node_modules/@loaders.gl/textures": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/textures/-/textures-3.2.6.tgz",
-      "integrity": "sha512-NdfpVXjRtNV8Pl3098LL8lBg6hD5ZD+IuIjXAsBVUlDvqBdxnUFfKrpLSPPaiY1F6DpjKe/GeprG89q11OxJIQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/textures/-/textures-4.3.3.tgz",
+      "integrity": "sha512-qIo4ehzZnXFpPKl1BGQG4G3cAhBSczO9mr+H/bT7qFwtSirWVlqsvMlx1Q4VpmouDu+tudwwOlq7B3yqU5P5yQ==",
       "dependencies": {
-        "@loaders.gl/images": "3.2.6",
-        "@loaders.gl/loader-utils": "3.2.6",
-        "@loaders.gl/schema": "3.2.6",
-        "@loaders.gl/worker-utils": "3.2.6",
-        "ktx-parse": "^0.0.4",
+        "@loaders.gl/images": "4.3.3",
+        "@loaders.gl/loader-utils": "4.3.3",
+        "@loaders.gl/schema": "4.3.3",
+        "@loaders.gl/worker-utils": "4.3.3",
+        "@math.gl/types": "^4.1.0",
+        "ktx-parse": "^0.7.0",
         "texture-compressor": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.3.0"
       }
     },
     "node_modules/@loaders.gl/worker-utils": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-3.2.6.tgz",
-      "integrity": "sha512-iT+vyrsUsoo/fodBAz5ihRzXvwjaZka73MdcBGtgsuyQeRbYcM3G5d4sBieque5fY9IXYFcTLg+TwCzVxQBWbQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.3.1"
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.3.3.tgz",
+      "integrity": "sha512-eg45Ux6xqsAfqPUqJkhmbFZh9qfmYuPfA+34VcLtfeXIwAngeP6o4SrTmm9LWLGUKiSh47anCEV1p7borDgvGQ==",
+      "peerDependencies": {
+        "@loaders.gl/core": "^4.3.0"
       }
+    },
+    "node_modules/@math.gl/core": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@math.gl/core/-/core-4.1.0.tgz",
+      "integrity": "sha512-FrdHBCVG3QdrworwrUSzXIaK+/9OCRLscxI2OUy6sLOHyHgBMyfnEGs99/m3KNvs+95BsnQLWklVfpKfQzfwKA==",
+      "dependencies": {
+        "@math.gl/types": "4.1.0"
+      }
+    },
+    "node_modules/@math.gl/types": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@math.gl/types/-/types-4.1.0.tgz",
+      "integrity": "sha512-clYZdHcmRvMzVK5fjeDkQlHUzXQSNdZ7s4xOqC3nJPgz4C/TZkUecTo9YS4PruZqtDda/ag4erndP0MIn40dGA=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2474,29 +2502,22 @@
       }
     },
     "node_modules/@probe.gl/env": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@probe.gl/env/-/env-3.5.0.tgz",
-      "integrity": "sha512-YdlpZZshhyYxvWDBmZ5RIW2pTR14Pw4p9czMlt/v7F6HbFzWfAdmH7q6xVwFRYxUpQLwhWensWyv4aFysiWl4g==",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0"
-      }
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@probe.gl/env/-/env-4.1.0.tgz",
+      "integrity": "sha512-5ac2Jm2K72VCs4eSMsM7ykVRrV47w32xOGMvcgqn8vQdEMF9PRXyBGYEV9YbqRKWNKpNKmQJVi4AHM/fkCxs9w=="
     },
     "node_modules/@probe.gl/log": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@probe.gl/log/-/log-3.5.0.tgz",
-      "integrity": "sha512-nW/qz2X1xY08WU/TsmJP6/6IPNcaY5fS/vLjpC4ahJuE2Mezga4hGM/R2X5JWE/nkPc+BsC5GnAnD13rwAxS7g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@probe.gl/log/-/log-4.1.0.tgz",
+      "integrity": "sha512-r4gRReNY6f+OZEMgfWEXrAE2qJEt8rX0HsDJQXUBMoc+5H47bdB7f/5HBHAmapK8UydwPKL9wCDoS22rJ0yq7Q==",
       "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@probe.gl/env": "3.5.0"
+        "@probe.gl/env": "4.1.0"
       }
     },
     "node_modules/@probe.gl/stats": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-3.4.1.tgz",
-      "integrity": "sha512-1Ol5cH8MQqIrGNgU4NCBj2cw1qiXYfHP1QCFX+u/xyrvgwLkPrOGkdSYMzw4VKTjJzNae4i7urOTf2m2hduZzQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0"
-      }
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-4.1.0.tgz",
+      "integrity": "sha512-EI413MkWKBDVNIfLdqbeNSJTs7ToBz/KVGkwi3D+dQrSIkRI2IYbWGAU3xX+D6+CI4ls8ehxMhNpUVMaZggDvQ=="
     },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -2586,15 +2607,10 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
-    "node_modules/@types/flatbuffers": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@types/flatbuffers/-/flatbuffers-1.10.0.tgz",
-      "integrity": "sha512-7btbphLrKvo5yl/5CC2OCxUSMx1wV1wvGT1qDXkSt7yi00/YW7E8k6qzXqJHsp+WU0eoG7r6MTQQXI9lIvd0qA=="
-    },
     "node_modules/@types/geojson": {
-      "version": "7946.0.8",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
-      "integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA=="
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="
     },
     "node_modules/@types/node": {
       "version": "22.10.6",
@@ -2605,11 +2621,6 @@
       "dependencies": {
         "undici-types": "~6.20.0"
       }
-    },
-    "node_modules/@types/text-encoding-utf-8": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
-      "integrity": "sha512-AQ6zewa0ucLJvtUi5HsErbOFKAcQfRLt9zFLlUOvcXBy2G36a+ZDpCHSGdzJVUD8aNURtIjh9aSjCStNMRCcRQ=="
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -2696,46 +2707,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/apache-arrow": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-4.0.1.tgz",
-      "integrity": "sha512-DyF7GXCbSjsw4P5C8b+qW7OnJKa6w9mJI0mhV0+EfZbVZCmhfiF6ffqcnrI/kzBrRqn9hH/Ft9n5+m4DTbBJpg==",
-      "dependencies": {
-        "@types/flatbuffers": "^1.10.0",
-        "@types/node": "^14.14.37",
-        "@types/text-encoding-utf-8": "^1.0.1",
-        "command-line-args": "5.1.1",
-        "command-line-usage": "6.1.1",
-        "flatbuffers": "1.12.0",
-        "json-bignum": "^0.0.3",
-        "pad-left": "^2.1.0",
-        "text-encoding-utf-8": "^1.0.2",
-        "tslib": "^2.2.0"
-      },
-      "bin": {
-        "arrow2csv": "bin/arrow2csv.js"
-      }
-    },
-    "node_modules/apache-arrow/node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-      "license": "MIT"
-    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dependencies": {
         "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/array-back": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/asn1": {
@@ -3186,6 +3163,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -3199,7 +3177,8 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -3212,85 +3191,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/command-line-args": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
-      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
-      "dependencies": {
-        "array-back": "^3.0.1",
-        "find-replace": "^3.0.0",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/command-line-usage": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.1.tgz",
-      "integrity": "sha512-F59pEuAR9o1SF/bD0dQBDluhpT4jJQNWUHEuVBqpDmCUo6gPjCi+m9fCWnWZVR/oG6cMTUms4h+3NPl74wGXvA==",
-      "dependencies": {
-        "array-back": "^4.0.1",
-        "chalk": "^2.4.2",
-        "table-layout": "^1.0.1",
-        "typical": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/array-back": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
-      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/typical": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/commander": {
@@ -3476,14 +3376,6 @@
       "dev": true,
       "dependencies": {
         "ms": "2.0.0"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -3672,9 +3564,9 @@
       }
     },
     "node_modules/draco3d": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.4.1.tgz",
-      "integrity": "sha512-9Rxonc70xiovBC+Bq1h57SNZIHzWTibU1VfIGp5z3Xx8dPtv4yT5uGhiH7P5uvJRR2jkrvHafRxR7bTANkvfpg=="
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ=="
     },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
@@ -3738,6 +3630,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -4675,17 +4568,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/find-replace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
-      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
-      "dependencies": {
-        "array-back": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -4698,11 +4580,6 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
-    },
-    "node_modules/flatbuffers": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.12.0.tgz",
-      "integrity": "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ=="
     },
     "node_modules/flatted": {
       "version": "3.2.5",
@@ -5017,6 +4894,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -5512,14 +5390,6 @@
         "jsesc": "bin/jsesc"
       }
     },
-    "node_modules/json-bignum": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
-      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -5606,9 +5476,14 @@
       }
     },
     "node_modules/ktx-parse": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/ktx-parse/-/ktx-parse-0.0.4.tgz",
-      "integrity": "sha512-LY3nrmfXl+wZZdPxgJ3ZmLvG+wkOZZP3/dr4RbQj1Pk3Qwz44esOOSFFVQJcNWpXAtiNIC66WgXufX/SYgYz6A=="
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ktx-parse/-/ktx-parse-0.7.1.tgz",
+      "integrity": "sha512-FeA3g56ksdFNwjXJJsc1CCc7co+AJYDp6ipIp878zZ2bU8kWROatLYf39TQEd4/XRSUvBXovQ8gaVKWPXsCLEQ=="
+    },
+    "node_modules/laz-perf": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/laz-perf/-/laz-perf-0.0.6.tgz",
+      "integrity": "sha512-ZBqC+BBlofznDIY3SfjXDBVdIhYfz7bq8HAHztlw4XOnu++nHiWtCGPgzpdeAhPkByc68DaKNy3E3rY4XrdRtQ=="
     },
     "node_modules/levn": {
       "version": "0.3.0",
@@ -5648,11 +5523,6 @@
       "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
       "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU=",
       "dev": true
-    },
-    "node_modules/lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -6035,17 +5905,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/pad-left": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pad-left/-/pad-left-2.1.0.tgz",
-      "integrity": "sha512-HJxs9K9AztdIQIAIa/OIazRAUW/L6B9hbQDxO4X07roW3eo9XqZc2ur9bn1StH9CnbbI9EgvejHQX7CBpCF1QA==",
-      "dependencies": {
-        "repeat-string": "^1.5.4"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/pako": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
@@ -6237,15 +6096,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/probe.gl": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/probe.gl/-/probe.gl-3.4.1.tgz",
-      "integrity": "sha512-k/6YoZr6cBwnFpQLs/s4yZ8cCxapQzRrxl16EQg1b2wYXLlerDJ4PkNoQ3YDN9yu3Jcipipr+Avy1GRpyBF6ZA==",
-      "dependencies": {
-        "@babel/runtime": "^7.0.0",
-        "@probe.gl/stats": "3.4.1"
-      }
-    },
     "node_modules/psl": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
@@ -6337,14 +6187,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/reduce-flatten": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
-      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -6432,14 +6274,6 @@
       "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
-      }
-    },
-    "node_modules/repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/repeating": {
@@ -6928,36 +6762,6 @@
         "url": "https://www.buymeacoffee.com/systeminfo"
       }
     },
-    "node_modules/table-layout": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
-      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
-      "dependencies": {
-        "array-back": "^4.0.1",
-        "deep-extend": "~0.6.0",
-        "typical": "^5.2.0",
-        "wordwrapjs": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/table-layout/node_modules/array-back": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
-      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/table-layout/node_modules/typical": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/taffydb": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.7.3.tgz",
@@ -6993,11 +6797,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/text-encoding-utf-8": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
-      "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
     },
     "node_modules/text-segmentation": {
       "version": "1.0.3",
@@ -7079,7 +6878,8 @@
     "node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -7193,14 +6993,6 @@
       },
       "engines": {
         "node": ">=4.2.0"
-      }
-    },
-    "node_modules/typical": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/uglify-js": {
@@ -7428,26 +7220,6 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
-    },
-    "node_modules/wordwrapjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
-      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
-      "dependencies": {
-        "reduce-flatten": "^2.0.0",
-        "typical": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/wordwrapjs/node_modules/typical": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
   },
   "homepage": "https://xeokit.io",
   "dependencies": {
-    "@loaders.gl/core": "^3.2.6",
-    "@loaders.gl/gltf": "^3.2.6",
-    "@loaders.gl/las": "^3.2.6",
+    "@loaders.gl/core": "^4.3.3",
+    "@loaders.gl/gltf": "^4.3.3",
+    "@loaders.gl/las": "^4.3.3",
     "html2canvas": "^1.4.1"
   },
   "devDependencies": {

--- a/src/plugins/GLTFLoaderPlugin/GLTFSceneModelLoader.js
+++ b/src/plugins/GLTFLoaderPlugin/GLTFSceneModelLoader.js
@@ -4,7 +4,7 @@ import {core} from "../../viewer/scene/core.js";
 import {sRGBEncoding} from "../../viewer/scene/constants/constants.js";
 import {worldToRTCPositions} from "../../viewer/scene/math/rtcCoords.js";
 import {parse} from '@loaders.gl/core';
-import {GLTFLoader} from '@loaders.gl/gltf/dist/esm/gltf-loader.js';
+import {GLTFLoader, postProcessGLTF} from '@loaders.gl/gltf';
 
 import {
     ClampToEdgeWrapping,
@@ -104,6 +104,7 @@ function parseGLTF(plugin, src, gltf, metaModelJSON, options, sceneModel, ok) {
     parse(gltf, GLTFLoader, {
         baseUri: options.basePath
     }).then((gltfData) => {
+        const processedGLTF = postProcessGLTF(gltfData);
         const ctx = {
             src: src,
             entityId: options.entityId,
@@ -115,7 +116,7 @@ function parseGLTF(plugin, src, gltf, metaModelJSON, options, sceneModel, ok) {
             basePath: options.basePath,
             handlenode: options.handlenode,
             backfaces: !!options.backfaces,
-            gltfData: gltfData,
+            gltfData: processedGLTF,
             scene: sceneModel.scene,
             plugin: plugin,
             sceneModel: sceneModel,

--- a/src/plugins/LASLoaderPlugin/LASLoaderPlugin.js
+++ b/src/plugins/LASLoaderPlugin/LASLoaderPlugin.js
@@ -4,7 +4,7 @@ import {Plugin} from "../../viewer/Plugin.js";
 import {LASDefaultDataSource} from "./LASDefaultDataSource.js";
 import {math} from "../../viewer/index.js";
 import {parse} from '@loaders.gl/core';
-import {LASLoader} from '@loaders.gl/las/dist/esm/las-loader.js';
+import {LASLoader} from '@loaders.gl/las';
 import {loadLASHeader} from "./loadLASHeader";
 
 const MAX_VERTICES = 500000; // TODO: Rough estimate


### PR DESCRIPTION
Upgrade loaders.gl from 3.2.6 -> 4.3.3

This internally affects `LASLoaderPlugin` and `GLTFLoaderPlugin`, and does not introduce API changes.