### PR TITLE
Embed xeokit version number for identification

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@playwright/test": "^1.49.1",
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-node-resolve": "^13.2.1",
+    "@rollup/plugin-replace": "^6.0.2",
     "@types/node": "^22.10.6",
     "auto-changelog": "^2.4.0",
     "dotenv": "^16.4.7",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,9 @@
 import {nodeResolve} from '@rollup/plugin-node-resolve';
 import { getBabelOutputPlugin } from '@rollup/plugin-babel';
+import replace from '@rollup/plugin-replace';
+import { readFileSync } from 'fs';
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf8'));
 
 export default {
     input: './src/index.js',
@@ -29,6 +33,11 @@ export default {
         nodeResolve({
             browser: true,
             preferBuiltins: false
-        })
+        }),
+        replace({
+            delimiters: ['', ''],
+            '__VIEWER_VERSION__': JSON.stringify(pkg.version),
+            preventAssignment: true
+        }),
     ]
 }

--- a/rollup.minified.config.js
+++ b/rollup.minified.config.js
@@ -1,6 +1,10 @@
 import {nodeResolve} from '@rollup/plugin-node-resolve';
 import { terser } from "rollup-plugin-terser";
 import { getBabelOutputPlugin } from '@rollup/plugin-babel';
+import replace from '@rollup/plugin-replace';
+import { readFileSync } from 'fs';
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf8'));
 
 export default {
     input: './src/index.js',
@@ -31,6 +35,11 @@ export default {
             browser: true,
             preferBuiltins: false
         }),
-        terser()
+        terser(),
+        replace({
+            delimiters: ['', ''],
+            '__VIEWER_VERSION__': JSON.stringify(pkg.version),
+            preventAssignment: true
+        }),
     ]
 }

--- a/src/viewer/Viewer.js
+++ b/src/viewer/Viewer.js
@@ -7,6 +7,8 @@ import html2canvas from 'html2canvas/dist/html2canvas.esm.js';
 import {math} from "./scene/math/math.js";
 import {transformToNode} from "../plugins/lib/ui/index.js";
 
+const VIEWER_VERSION = '__VIEWER_VERSION__';
+
 /**
  * The 3D Viewer at the heart of the xeokit SDK.
  *
@@ -67,6 +69,10 @@ class Viewer {
      * your expected usage.
      */
     constructor(cfg) {
+
+        this.version = VIEWER_VERSION;
+
+        console.info('Xeokit SDK Version: ', this.version);
 
         /**
          * The Viewer's current language setting.

--- a/src/viewer/scene/scene/Scene.js
+++ b/src/viewer/scene/scene/Scene.js
@@ -359,6 +359,9 @@ class Scene extends Component {
             throw "Mandatory config expected: valid canvasId or canvasElement";
         }
 
+        //set the viewer version on canvas data
+        canvas.dataset.viewerVersion = viewer.version;
+
         /**
          * @type {{[key: string]: {wrapperFunc: Function, tickSubId: string}}}
          */


### PR DESCRIPTION
@xeolabs please have a look at this PR that:
1. Prints xeokit version number being used in the console
2. Add xeokit version number as a dataset on the canvas being used.

What I did to achieve this:
1. Created a placeholder string in viewer.js file.
2. This string is replaced by the origin version number taken from package.json, when the project is built.
3. We output this string in Viewer.js and also supply this string to Scene.js that sets this string as a dataset value on the canvas being used.

Please let me know if you think this is not the right way or you have a better approach in mind.