### PR TITLE
Prepend version info in build files

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "@playwright/test": "^1.49.1",
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-node-resolve": "^13.2.1",
-    "@rollup/plugin-replace": "^6.0.2",
     "@types/node": "^22.10.6",
     "auto-changelog": "^2.4.0",
     "dotenv": "^16.4.7",
@@ -78,6 +77,7 @@
     "eslint": "^8.13.0",
     "parse5": "^7.0.0",
     "rollup": "^2.70.2",
+    "rollup-plugin-banner": "^0.2.1",
     "rollup-plugin-terser": "^7.0.2",
     "typedoc": "^0.22.15"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,21 @@
 import {nodeResolve} from '@rollup/plugin-node-resolve';
 import { getBabelOutputPlugin } from '@rollup/plugin-babel';
-import replace from '@rollup/plugin-replace';
 import { readFileSync } from 'fs';
+import { execSync } from 'child_process';
+import banner from 'rollup-plugin-banner';
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf8'));
+
+let gitCommitHash = 'unknown';
+try {
+    gitCommitHash = execSync('git rev-parse HEAD').toString().trim();
+} catch(err) {
+    console.warn('Unable to get git commit hash: ', err.message);
+}
+
+const buildTimeStamp = new Date().toISOString();
+
+const versionInfo = `xeokit-sdk v${pkg.version}\n Commit: ${gitCommitHash}\n Built: ${buildTimeStamp}`;
 
 export default {
     input: './src/index.js',
@@ -34,10 +46,6 @@ export default {
             browser: true,
             preferBuiltins: false
         }),
-        replace({
-            delimiters: ['', ''],
-            '__VIEWER_VERSION__': JSON.stringify(pkg.version),
-            preventAssignment: true
-        }),
+        banner(versionInfo)
     ]
 }

--- a/rollup.minified.config.js
+++ b/rollup.minified.config.js
@@ -1,10 +1,22 @@
 import {nodeResolve} from '@rollup/plugin-node-resolve';
 import { terser } from "rollup-plugin-terser";
 import { getBabelOutputPlugin } from '@rollup/plugin-babel';
-import replace from '@rollup/plugin-replace';
 import { readFileSync } from 'fs';
+import { execSync } from 'child_process';
+import banner from 'rollup-plugin-banner';
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf8'));
+
+let gitCommitHash = 'unknown';
+try {
+    gitCommitHash = execSync('git rev-parse HEAD').toString().trim();
+} catch(err) {
+    console.warn('Unable to get git commit hash: ', err.message);
+}
+
+const buildTimeStamp = new Date().toISOString();
+
+const versionInfo = `xeokit-sdk v${pkg.version}\n Commit: ${gitCommitHash}\n Built: ${buildTimeStamp}`;
 
 export default {
     input: './src/index.js',
@@ -36,10 +48,6 @@ export default {
             preferBuiltins: false
         }),
         terser(),
-        replace({
-            delimiters: ['', ''],
-            '__VIEWER_VERSION__': JSON.stringify(pkg.version),
-            preventAssignment: true
-        }),
+        banner(versionInfo)
     ]
 }

--- a/src/viewer/Viewer.js
+++ b/src/viewer/Viewer.js
@@ -7,8 +7,6 @@ import html2canvas from 'html2canvas/dist/html2canvas.esm.js';
 import {math} from "./scene/math/math.js";
 import {transformToNode} from "../plugins/lib/ui/index.js";
 
-const VIEWER_VERSION = '__VIEWER_VERSION__';
-
 /**
  * The 3D Viewer at the heart of the xeokit SDK.
  *
@@ -69,10 +67,6 @@ class Viewer {
      * your expected usage.
      */
     constructor(cfg) {
-
-        this.version = VIEWER_VERSION;
-
-        console.info('Xeokit SDK Version: ', this.version);
 
         /**
          * The Viewer's current language setting.

--- a/src/viewer/scene/scene/Scene.js
+++ b/src/viewer/scene/scene/Scene.js
@@ -359,9 +359,6 @@ class Scene extends Component {
             throw "Mandatory config expected: valid canvasId or canvasElement";
         }
 
-        //set the viewer version on canvas data
-        canvas.dataset.viewerVersion = viewer.version;
-
         /**
          * @type {{[key: string]: {wrapperFunc: Function, tickSubId: string}}}
          */


### PR DESCRIPTION
Hi @xeolabs and @MichalDybizbanskiCreoox!

I removed the version info from Viewer.js and Scene.js and prepended that information in build files.

After these changes, the version is stored and retrieved like this.

<img width="1439" alt="Screenshot 2025-03-13 at 12 44 05 AM" src="https://github.com/user-attachments/assets/25eb3fcf-05e0-4db6-a1b3-3f11cee5ebf1" />
