### PR TITLE
XCD-272 SectionCaps cleanup

### DIFF
--- a/src/viewer/scene/sectionCaps/SectionCaps.js
+++ b/src/viewer/scene/sectionCaps/SectionCaps.js
@@ -143,7 +143,7 @@ class SectionCaps {
                 this._sectionPlanes.push(sectionPlane);
                 sectionPlane.on('pos', onSectionPlaneUpdated);
                 sectionPlane.on('dir', onSectionPlaneUpdated);
-                sectionPlane.once('destroyed', ((sectionPlane) => {
+                sectionPlane.once('destroyed', (() => {
                     const sectionPlaneId = sectionPlane.id;
                     if (sectionPlaneId) {
                         this._sectionPlanes = this._sectionPlanes.filter((sectionPlane) => sectionPlane.id !== sectionPlaneId);

--- a/src/viewer/scene/sectionCaps/SectionCaps.js
+++ b/src/viewer/scene/sectionCaps/SectionCaps.js
@@ -143,6 +143,7 @@ class SectionCaps {
                 this._sectionPlanes.push(sectionPlane);
                 sectionPlane.on('pos', onSectionPlaneUpdated);
                 sectionPlane.on('dir', onSectionPlaneUpdated);
+                sectionPlane.on('active', onSectionPlaneUpdated);
                 sectionPlane.once('destroyed', (() => {
                     const sectionPlaneId = sectionPlane.id;
                     if (sectionPlaneId) {
@@ -184,7 +185,7 @@ class SectionCaps {
         this._updateTimeout = setTimeout(() => {
             clearTimeout(this._updateTimeout);
             const sceneModels = Object.keys(this.scene.models).map((key) => this.scene.models[key]);
-            this._addHatches(sceneModels, this._sectionPlanes);
+            this._addHatches(sceneModels, this._sectionPlanes.filter(sectionPlane => sectionPlane.active));
             this._setAllDirty(false);
         }, 100);
     }

--- a/src/viewer/scene/sectionCaps/SectionCaps.js
+++ b/src/viewer/scene/sectionCaps/SectionCaps.js
@@ -160,11 +160,14 @@ class SectionCaps {
 
             this._onTick = this.scene.on("tick", () => {
                 //on ticks we only check if there is a model that we have saved vertices for,
-                //but it's no more available on the scene
+                //but it's no more available on the scene, or if its visibility changed
                 let dirty = false;
                 for(const sceneModelId in this._sceneModelsData) {
                     if(!this.scene.models[sceneModelId]){
                         delete this._sceneModelsData[sceneModelId];
+                        dirty = true;
+                    } else if (this._sceneModelsData[sceneModelId].visible !== (!!this.scene.models[sceneModelId].visible)) {
+                        this._sceneModelsData[sceneModelId].visible = !!this.scene.models[sceneModelId].visible;
                         dirty = true;
                     }
                 }
@@ -186,7 +189,7 @@ class SectionCaps {
         this._deletePreviousModels();
         this._updateTimeout = setTimeout(() => {
             clearTimeout(this._updateTimeout);
-            const sceneModels = Object.keys(this.scene.models).map((key) => this.scene.models[key]);
+            const sceneModels = Object.values(this.scene.models).filter(sceneModel => sceneModel.visible);
             this._addHatches(sceneModels, this._sectionPlanes.filter(sectionPlane => sectionPlane.active));
             this._setAllDirty(false);
         }, 100);

--- a/src/viewer/scene/sectionCaps/SectionCaps.js
+++ b/src/viewer/scene/sectionCaps/SectionCaps.js
@@ -264,10 +264,7 @@ class SectionCaps {
 
                     const capSegments = [];
                     const vertCount = indices.length;
-                    
-                    // Preallocate intersection result array
-                    const intersectionBuffer = new Float32Array(3);
-                    
+
                     for (let i = 0; i < vertCount; i += 3) {
                         // Reuse triangle buffer instead of creating new arrays
                         for (let j = 0; j < 3; j++) {
@@ -288,17 +285,12 @@ class SectionCaps {
                             // Inline the distance calculations to avoid function calls
                             const d1 = planeEquation.A * p1[0] + planeEquation.B * p1[1] + planeEquation.C * p1[2] + planeEquation.D;
                             const d2 = planeEquation.A * p2[0] + planeEquation.B * p2[1] + planeEquation.C * p2[2] + planeEquation.D;
-                            
+
                             if (d1 * d2 > 0) continue;
-                            
+
                             const t = -d1 / (d2 - d1);
-                            // Reuse intersection buffer
-                            intersectionBuffer[0] = p1[0] + t * (p2[0] - p1[0]);
-                            intersectionBuffer[1] = p1[1] + t * (p2[1] - p1[1]);
-                            intersectionBuffer[2] = p1[2] + t * (p2[2] - p1[2]);
-                            
-                            // Clone the buffer for storage
-                            intersections.push(new Float32Array(intersectionBuffer));
+
+                            intersections.push(math.lerpVec3(t, 0, 1, p1, p2, math.vec3()));
                         }
 
                         if(intersections.length === 2) capSegments.push(intersections);

--- a/src/viewer/scene/sectionCaps/SectionCaps.js
+++ b/src/viewer/scene/sectionCaps/SectionCaps.js
@@ -162,12 +162,16 @@ class SectionCaps {
             this._onTick = this.scene.on("tick", () => {
                 //on ticks we only check if there is a model that we have saved vertices for,
                 //but it's no more available on the scene
+                let dirty = false;
                 for(const key in this._verticesMap) {
                     if(!this.scene.models[key]){
                         delete this._verticesMap[key];
                         delete this._indicesMap[key];
-                        this._update();
+                        dirty = true;
                     }
+                }
+                if (dirty) {
+                    this._update();
                 }
             })
         }

--- a/src/viewer/scene/sectionCaps/SectionCaps.js
+++ b/src/viewer/scene/sectionCaps/SectionCaps.js
@@ -200,21 +200,9 @@ class SectionCaps {
 
     _addHatches(sceneModels, planes) {
 
-        if (planes.length <= 0) return;
-
         planes.forEach((plane) => {
             sceneModels.forEach((sceneModel) => {
-                //#region creating a plane equation
-                //we create a plane equation that will be used to slice through each triangle
-                const planeEquation = {
-                    A: plane.dir[0],
-                    B: plane.dir[1],
-                    C: plane.dir[2],
-                    D: -(plane.dir[0] * plane.pos[0] + plane.dir[1] * plane.pos[1] + plane.dir[2] * plane.pos[2])
-                }
-                //#endregion
-                
-                if(!this._doesPlaneIntersectBoundingBox(sceneModel.aabb, planeEquation)) return;
+                if(!this._doesPlaneIntersectBoundingBox(sceneModel.aabb, plane)) return;
 
                 if(!this._dirtyMap[sceneModel.id]) return;
 
@@ -236,7 +224,7 @@ class SectionCaps {
 
                     const object = objects[objectId];
 
-                    if(!this._doesPlaneIntersectBoundingBox(object.aabb, planeEquation)) return;
+                    if(!this._doesPlaneIntersectBoundingBox(object.aabb, plane)) return;
 
                     if(!this._sceneModelsData[sceneModel.id]) {
                         this._sceneModelsData[sceneModel.id] = {
@@ -281,10 +269,9 @@ class SectionCaps {
                         for (let i = 0; i < 3; i++) {
                             const p1 = triangle[i];
                             const p2 = triangle[(i + 1) % 3];
-                            
-                            // Inline the distance calculations to avoid function calls
-                            const d1 = planeEquation.A * p1[0] + planeEquation.B * p1[1] + planeEquation.C * p1[2] + planeEquation.D;
-                            const d2 = planeEquation.A * p2[0] + planeEquation.B * p2[1] + planeEquation.C * p2[2] + planeEquation.D;
+
+                            const d1 = plane.dist + math.dotVec3(plane.dir, p1);
+                            const d2 = plane.dist + math.dotVec3(plane.dir, p2);
 
                             if (d1 * d2 > 0) continue;
 
@@ -570,7 +557,7 @@ class SectionCaps {
 
     }
 
-    _doesPlaneIntersectBoundingBox(bb, planeEquation) {
+    _doesPlaneIntersectBoundingBox(bb, plane) {
         const min = [bb[0], bb[1], bb[2]];
         const max = [bb[3], bb[4], bb[5]];
 
@@ -590,10 +577,7 @@ class SectionCaps {
         let hasNegative = false;
 
         for (const corner of corners) {
-            const distance = planeEquation.A * corner[0] +
-                planeEquation.B * corner[1] +
-                planeEquation.C * corner[2] +
-                planeEquation.D;
+            const distance = plane.dist + math.dotVec3(plane.dir, corner);
 
             if (distance > 0) hasPositive = true;
             if (distance < 0) hasNegative = true;


### PR DESCRIPTION
Adds missing SectionCaps cleanup when:
* SectionPlane is destroyed (`sectionPlane.destroy()`)
* SectionPlane is deactivated (`sectionPlane.active = false`)
* SceneModel is hidden (`sceneModel.visible = false`)