### PR TITLE
add optional parameter 'rootDOMNode' to allow working with ShadowRoot

### DIFF
--- a/src/plugins/NavCubePlugin/CubeTextureCanvas.js
+++ b/src/plugins/NavCubePlugin/CubeTextureCanvas.js
@@ -5,6 +5,7 @@ import {math} from "../../viewer/scene/math/math.js";
  */
 function CubeTextureCanvas(viewer, navCubeScene, cfg = {}) {
 
+    const rootDOMNode = cfg.rootDOMNode || document.body;
     const cubeColor = "lightgrey";
     const cubeHighlightColor = cfg.hoverColor || "rgba(0,0,0,0.4)";
     const textColor = cfg.textColor || "black";
@@ -119,8 +120,7 @@ function CubeTextureCanvas(viewer, navCubeScene, cfg = {}) {
     this._textureCanvas.style.visibility = "hidden";
     this._textureCanvas.style["z-index"] = 2000000;
 
-    const body = document.getElementsByTagName("body")[0];
-    body.appendChild(this._textureCanvas);
+    rootDOMNode.appendChild(this._textureCanvas);
 
     const context = this._textureCanvas.getContext("2d");
 

--- a/src/plugins/NavCubePlugin/NavCubePlugin.js
+++ b/src/plugins/NavCubePlugin/NavCubePlugin.js
@@ -102,6 +102,7 @@ class NavCubePlugin extends Plugin {
      * @param {Boolean} [cfg.synchProjection=false] Sets whether the NavCube switches between perspective and orthographic projections in synchrony with the {@link Camera}. When ````false````, the NavCube will always be rendered with perspective projection.
      * @param {Boolean} [cfg.isProjectNorth] sets whether the NavCube switches between true north and project north - using the project north offset angle.
      * @param {number} [cfg.projectNorthOffsetAngle] sets the NavCube project north offset angle - when the {@link isProjectNorth} is true.
+     * @param {Node | undefined} [cfg.rootDOMNode] Optional reference of an existing DOM Node (e.g. ShadowRoot), which encapsulates all HTML elements related to viewer plugins, defaults to ````document````.
      */
     constructor(viewer, cfg = {}) {
 
@@ -111,11 +112,13 @@ class NavCubePlugin extends Plugin {
 
         var visible = true;
 
+        const rootDOMNode = cfg.rootDOMNode || document;
         try {
             this._navCubeScene = new Scene(viewer, {
                 canvasId: cfg.canvasId,
                 canvasElement: cfg.canvasElement,
-                transparent: true
+                transparent: true,
+                rootDOMNode: rootDOMNode
             });
 
             this._navCubeCanvas = this._navCubeScene.canvas.canvas;

--- a/src/viewer/scene/scene/Scene.js
+++ b/src/viewer/scene/scene/Scene.js
@@ -347,13 +347,15 @@ class Scene extends Component {
      * configures renderer logic for the specified number of SectionPlanes, eliminating the need for setting up logic with each SectionPlane creation and thereby enhancing
      * responsiveness. It is important to consider that each SectionPlane imposes rendering performance, so it is recommended to set this value to a quantity that aligns with
      * your expected usage.
-     * @throws {String} Throws an exception when both canvasId or canvasElement are missing or they aren't pointing to a valid HTMLCanvasElement.
+     * @param {Node | undefined} [cfg.rootDOMNode] Optional reference of an existing DOM Node (e.g. ShadowRoot), which encapsulates all HTML elements related to viewer plugins, defaults to ````document````.
+     * @throws {String} Throws an exception when  canvasId or canvasElement are missing or they aren't pointing to a valid HTMLCanvasElement.
      */
     constructor(viewer, cfg = {}) {
 
         super(null, cfg);
 
-        const canvas = cfg.canvasElement || document.getElementById(cfg.canvasId);
+        const rootDOMNode = cfg.rootDOMNode || document;
+        const canvas = cfg.canvasElement || rootDOMNode.querySelector(`#${cfg.canvasId}`);
 
         if (!(canvas instanceof HTMLCanvasElement)) {
             throw "Mandatory config expected: valid canvasId or canvasElement";

--- a/types/plugins/NavCubePlugin/NavCubePlugin.d.ts
+++ b/types/plugins/NavCubePlugin/NavCubePlugin.d.ts
@@ -40,6 +40,8 @@ export declare type NavCubePluginConfiguration = {
   fitVisible?: boolean;
   /** Sets whether the NavCube switches between perspective and orthographic projections in synchrony with the {@link Camera}. When ````false````, the NavCube will always be rendered with perspective projection. */
   synchProjection?: boolean;
+  /** Optional reference of an existing DOM Node(e.g.ShadowRoot), that encapsulates all HTML elements related to viewer plugins, defaults to ````document````. */
+  rootDOMNode?: Node;
 };
 
 /**


### PR DESCRIPTION
Changes from this PR are related to creating web components using viewer and related html elements, where they are inside of ShadowRoot.
Elements that are nested inside of ShadowRoot element tree cannot be searched by querying document object, because they are isolated from the rest of the DOM. Also globally set CSS classes don't affect them.
Here I propose an optional 'rootDOMNode' parameter, to which we can pass the ShadowRoot and then append children to it or query the root element instead doing it on document object. The parameter can be used in NavCubePlugin (and it's TextureCanvas), Scene and ContextMenu configs.