### PR TITLE
Refactor/owner html nodes

### DIFF
--- a/src/extras/ContextMenu/ContextMenu.js
+++ b/src/extras/ContextMenu/ContextMenu.js
@@ -282,7 +282,7 @@ class ContextMenu {
      * @param {Boolean} [cfg.enabled=true] Whether this ````ContextMenu```` is initially enabled. {@link ContextMenu#show} does nothing while this is ````false````.
      * @param {Boolean} [cfg.hideOnMouseDown=true] Whether this ````ContextMenu```` automatically hides whenever we mouse-down or tap anywhere in the page.
      * @param {Boolean} [cfg.hideOnAction=true] Whether this ````ContextMenu```` automatically hides after we select a menu item. Se false if we want the menu to remain shown and show any updates to its item titles, after we've selected an item.
-     * @param {Node | undefined} [cfg.rootDOMNode] Optional reference of an existing DOM Node (e.g. ShadowRoot), which encapsulates all HTML elements related to viewer plugins, defaults to ````document.body````.
+     * @param {Node | undefined} [cfg.parentNode] Optional reference to an existing DOM Node (e.g. ShadowRoot), to which the menu's HTML element will be appended, defaults to ````document.body````.
      */
     constructor(cfg = {}) {
 
@@ -297,7 +297,7 @@ class ContextMenu {
         this._itemMap = {};     // Items mapped to their IDs
         this._shown = false;    // True when the ContextMenu is visible
         this._nextId = 0;
-        this._rootDOMNode = cfg.rootDOMNode || document.body;
+        this._parentNode = cfg.parentNode || document.body;
 
         /**
          * Subscriptions to events fired at this ContextMenu.
@@ -306,12 +306,12 @@ class ContextMenu {
         this._eventSubs = {};
 
         if (cfg.hideOnMouseDown !== false) {
-            this._rootDOMNode.addEventListener("mousedown", (event) => {
+            this._parentNode.addEventListener("mousedown", (event) => {
                 if (!event.target.classList.contains("xeokit-context-menu-item")) {
                     this.hide();
                 }
             });
-            this._rootDOMNode.addEventListener("touchstart", this._canvasTouchStartHandler = (event) => {
+            this._parentNode.addEventListener("touchstart", this._canvasTouchStartHandler = (event) => {
                 if (!event.target.classList.contains("xeokit-context-menu-item")) {
                     this.hide();
                 }
@@ -672,7 +672,7 @@ class ContextMenu {
 
         const htmlString = html.join("");
         menuElement.innerHTML = htmlString;
-        this._rootDOMNode.appendChild(menuElement);
+        this._parentNode.appendChild(menuElement);
 
         menu.menuElement = menuElement;
 
@@ -706,7 +706,7 @@ class ContextMenu {
                         const item = groupItems[j];
                         const itemSubMenu = item.subMenu;
 
-                        item.itemElement = this._rootDOMNode.querySelector(`#${item.id}`);
+                        item.itemElement = this._parentNode.querySelector(`#${item.id}`);
 
                         if (!item.itemElement) {
                             console.error("ContextMenu item element not found: " + item.id);

--- a/src/plugins/NavCubePlugin/CubeTextureCanvas.js
+++ b/src/plugins/NavCubePlugin/CubeTextureCanvas.js
@@ -5,10 +5,10 @@ import {math} from "../../viewer/scene/math/math.js";
  */
 function CubeTextureCanvas(viewer, navCubeScene, cfg = {}) {
 
-    const rootDOMNode = cfg.rootDOMNode || document.body;
     const cubeColor = "lightgrey";
     const cubeHighlightColor = cfg.hoverColor || "rgba(0,0,0,0.4)";
     const textColor = cfg.textColor || "black";
+    const parentNode = cfg.canvasElement || document.body;
 
     const height = 500;
     const width = height + (height / 3);
@@ -120,7 +120,7 @@ function CubeTextureCanvas(viewer, navCubeScene, cfg = {}) {
     this._textureCanvas.style.visibility = "hidden";
     this._textureCanvas.style["z-index"] = 2000000;
 
-    rootDOMNode.appendChild(this._textureCanvas);
+    parentNode.appendChild(this._textureCanvas);
 
     const context = this._textureCanvas.getContext("2d");
 

--- a/src/plugins/NavCubePlugin/NavCubePlugin.js
+++ b/src/plugins/NavCubePlugin/NavCubePlugin.js
@@ -102,7 +102,6 @@ class NavCubePlugin extends Plugin {
      * @param {Boolean} [cfg.synchProjection=false] Sets whether the NavCube switches between perspective and orthographic projections in synchrony with the {@link Camera}. When ````false````, the NavCube will always be rendered with perspective projection.
      * @param {Boolean} [cfg.isProjectNorth] sets whether the NavCube switches between true north and project north - using the project north offset angle.
      * @param {number} [cfg.projectNorthOffsetAngle] sets the NavCube project north offset angle - when the {@link isProjectNorth} is true.
-     * @param {Node | undefined} [cfg.rootDOMNode] Optional reference of an existing DOM Node (e.g. ShadowRoot), which encapsulates all HTML elements related to viewer plugins, defaults to ````document````.
      */
     constructor(viewer, cfg = {}) {
 
@@ -112,13 +111,11 @@ class NavCubePlugin extends Plugin {
 
         var visible = true;
 
-        const rootDOMNode = cfg.rootDOMNode || document;
         try {
             this._navCubeScene = new Scene(viewer, {
                 canvasId: cfg.canvasId,
                 canvasElement: cfg.canvasElement,
                 transparent: true,
-                rootDOMNode: rootDOMNode
             });
 
             this._navCubeCanvas = this._navCubeScene.canvas.canvas;

--- a/src/viewer/scene/scene/Scene.js
+++ b/src/viewer/scene/scene/Scene.js
@@ -347,15 +347,12 @@ class Scene extends Component {
      * configures renderer logic for the specified number of SectionPlanes, eliminating the need for setting up logic with each SectionPlane creation and thereby enhancing
      * responsiveness. It is important to consider that each SectionPlane imposes rendering performance, so it is recommended to set this value to a quantity that aligns with
      * your expected usage.
-     * @param {Node | undefined} [cfg.rootDOMNode] Optional reference of an existing DOM Node (e.g. ShadowRoot), which encapsulates all HTML elements related to viewer plugins, defaults to ````document````.
      * @throws {String} Throws an exception when  canvasId or canvasElement are missing or they aren't pointing to a valid HTMLCanvasElement.
      */
     constructor(viewer, cfg = {}) {
 
         super(null, cfg);
-
-        const rootDOMNode = cfg.rootDOMNode || document;
-        const canvas = cfg.canvasElement || rootDOMNode.querySelector(`#${cfg.canvasId}`);
+        const canvas = cfg.canvasElement || document.querySelector(`#${cfg.canvasId}`);
 
         if (!(canvas instanceof HTMLCanvasElement)) {
             throw "Mandatory config expected: valid canvasId or canvasElement";

--- a/types/plugins/NavCubePlugin/NavCubePlugin.d.ts
+++ b/types/plugins/NavCubePlugin/NavCubePlugin.d.ts
@@ -40,8 +40,6 @@ export declare type NavCubePluginConfiguration = {
   fitVisible?: boolean;
   /** Sets whether the NavCube switches between perspective and orthographic projections in synchrony with the {@link Camera}. When ````false````, the NavCube will always be rendered with perspective projection. */
   synchProjection?: boolean;
-  /** Optional reference of an existing DOM Node(e.g.ShadowRoot), that encapsulates all HTML elements related to viewer plugins, defaults to ````document````. */
-  rootDOMNode?: Node;
 };
 
 /**


### PR DESCRIPTION
- removed ````rootDOMNode```` parameter from NavCube related classes - ````canasELement```` will be used as a parent node for navCube texture canvas,
- renamed ````rootDOMNOde```` parameter in ContextMenu to ````parentNode````