### PR TITLE
XEOK-257 Fix buildPlaneGeometry normals

### DIFF
--- a/src/viewer/scene/geometry/builders/buildPlaneGeometry.js
+++ b/src/viewer/scene/geometry/builders/buildPlaneGeometry.js
@@ -122,7 +122,7 @@ function buildPlaneGeometry(cfg = {}) {
             positions[offset + 1] = centerY;
             positions[offset + 2] = -z + centerZ;
 
-            normals[offset + 2] = -1;
+            normals[offset + 1] = 1;
 
             uvs[offset2] = (ix) / planeX;
             uvs[offset2 + 1] = ((planeZ - iz) / planeZ);


### PR DESCRIPTION
Vertex coordinates lie on the X-Z plane, but their normals are `[0,0,-1]`, and should be `[0,1,0]` instead.
Or should it be `[0,-1,0]`?
The winding of both plane triangles is CCW when looked at from above, which suggests the normal should point upwards, so `[0,1,0]`.