### PR TITLE
Feature/context menu position relative to offset parent

### DIFF
--- a/src/extras/ContextMenu/ContextMenu.js
+++ b/src/extras/ContextMenu/ContextMenu.js
@@ -753,15 +753,15 @@ class ContextMenu {
                             const showOnLeft = (itemRect.left - subMenuWidth) > offsetRect.left;
                         
                             if(showOnRight)
-                                self._showMenu(subMenu.id, itemRect.right - 5, itemRect.top - 1);
+                                self._showMenu(subMenu.id, itemRect.right - 5, itemRect.top + window.scrollY - 1);
                             else if (showOnLeft)
-                                self._showMenu(subMenu.id, itemRect.left - subMenuWidth, itemRect.top - 1);
+                                self._showMenu(subMenu.id, itemRect.left - subMenuWidth, itemRect.top + window.scrollY - 1);
                             else {
                                 const spaceOnLeft = itemRect.left - offsetRect.left, spaceOnRight = offsetRect.right - itemRect.right;
                                 if(spaceOnRight > spaceOnLeft) 
-                                    self._showMenu(subMenu.id, itemRect.right - 5 - (subMenuWidth - spaceOnRight), itemRect.top - 1);
+                                    self._showMenu(subMenu.id, itemRect.right - 5 - (subMenuWidth - spaceOnRight), itemRect.top + window.scrollY - 1);
                                 else 
-                                    self._showMenu(subMenu.id, itemRect.left - spaceOnLeft, itemRect.top - 1);
+                                    self._showMenu(subMenu.id, itemRect.left - spaceOnLeft, itemRect.top + window.scrollY - 1);
                             }
 
                             lastSubMenu = subMenu;
@@ -956,9 +956,10 @@ class ContextMenu {
         const menuWidth = menuElement.offsetWidth;
 
         const offsetRect = this._offsetParent.getBoundingClientRect();
-
-        if ((pageY + menuHeight) > offsetRect.bottom) {
-            pageY = offsetRect.bottom - menuHeight;
+        
+        const bottomContainerBorder = offsetRect.bottom + window.scrollY;
+        if ((pageY + menuHeight) > bottomContainerBorder) {
+            pageY = bottomContainerBorder- menuHeight;
         }
         if ((pageX + menuWidth) > offsetRect.right) {
             pageX = offsetRect.right - menuWidth;
@@ -966,7 +967,7 @@ class ContextMenu {
 
 
         menuElement.style.left = pageX - offsetRect.left + 'px';
-        menuElement.style.top = pageY - offsetRect.top + 'px';
+        menuElement.style.top = pageY - offsetRect.top - window.scrollY + 'px';
     }
 
     _hideMenuElement(menuElement) {

--- a/src/extras/ContextMenu/ContextMenu.js
+++ b/src/extras/ContextMenu/ContextMenu.js
@@ -298,20 +298,13 @@ class ContextMenu {
         this._shown = false;    // True when the ContextMenu is visible
         this._nextId = 0;
         this._parentNode = cfg.parentNode || document.body;
-
+        this._offsetParent = (this._parentNode instanceof ShadowRoot) ? this._parentNode.host : this._parentNode;
+        
         /**
          * Subscriptions to events fired at this ContextMenu.
          * @private
          */
         this._eventSubs = {};
-
-        let offsetParent;
-        if (this._parentNode.host) {
-            offsetParent = this._parentNode.host;
-        } else {
-            offsetParent = this._parentNode;
-        }
-        this._offsetParent = offsetParent;
 
         if (cfg.hideOnMouseDown !== false) {
             this._parentNode.addEventListener("mousedown", (event) => {

--- a/src/extras/ContextMenu/ContextMenu.js
+++ b/src/extras/ContextMenu/ContextMenu.js
@@ -518,7 +518,7 @@ class ContextMenu {
         for (let i = 0, len = this._menuList.length; i < len; i++) {
             const menu = this._menuList[i];
             const menuElement = menu.menuElement;
-            menuElement.parentElement.removeChild(menuElement);
+            menuElement.remove();
         }
         this._itemsCfg = [];
         this._rootMenu = null;

--- a/src/extras/ContextMenu/ContextMenu.js
+++ b/src/extras/ContextMenu/ContextMenu.js
@@ -305,6 +305,14 @@ class ContextMenu {
          */
         this._eventSubs = {};
 
+        let offsetParent;
+        if (this._parentNode.host) {
+            offsetParent = this._parentNode.host;
+        } else {
+            offsetParent = this._parentNode;
+        }
+        this._offsetParent = offsetParent;
+
         if (cfg.hideOnMouseDown !== false) {
             this._parentNode.addEventListener("mousedown", (event) => {
                 if (!event.target.classList.contains("xeokit-context-menu-item")) {
@@ -738,17 +746,18 @@ class ContextMenu {
 
                             const itemRect = itemElement.getBoundingClientRect();
                             const menuRect = subMenuElement.getBoundingClientRect();
+                            const offsetRect = self._offsetParent.getBoundingClientRect();
 
                             const subMenuWidth = 200; // TODO
-                            const showOnRight = (itemRect.right + subMenuWidth) < window.innerWidth;
-                            const showOnLeft = (itemRect.left - subMenuWidth) > 0;
-
+                            const showOnRight = (itemRect.right + subMenuWidth) < offsetRect.right;
+                            const showOnLeft = (itemRect.left - subMenuWidth) > offsetRect.left;
+                        
                             if(showOnRight)
                                 self._showMenu(subMenu.id, itemRect.right - 5, itemRect.top - 1);
                             else if (showOnLeft)
                                 self._showMenu(subMenu.id, itemRect.left - subMenuWidth, itemRect.top - 1);
                             else {
-                                const spaceOnLeft = itemRect.left, spaceOnRight = window.innerWidth - itemRect.right;
+                                const spaceOnLeft = itemRect.left - offsetRect.left, spaceOnRight = offsetRect.right - itemRect.right;
                                 if(spaceOnRight > spaceOnLeft) 
                                     self._showMenu(subMenu.id, itemRect.right - 5 - (subMenuWidth - spaceOnRight), itemRect.top - 1);
                                 else 
@@ -945,14 +954,19 @@ class ContextMenu {
         menuElement.style.display = 'block';
         const menuHeight = menuElement.offsetHeight;
         const menuWidth = menuElement.offsetWidth;
-        if ((pageY + menuHeight) > window.innerHeight) {
-            pageY = window.innerHeight - menuHeight;
+
+        const offsetRect = this._offsetParent.getBoundingClientRect();
+
+        if ((pageY + menuHeight) > offsetRect.bottom) {
+            pageY = offsetRect.bottom - menuHeight;
         }
-        if ((pageX + menuWidth) > window.innerWidth) {
-            pageX = window.innerWidth - menuWidth;
+        if ((pageX + menuWidth) > offsetRect.right) {
+            pageX = offsetRect.right - menuWidth;
         }
-        menuElement.style.left = pageX + 'px';
-        menuElement.style.top = pageY + 'px';
+
+
+        menuElement.style.left = pageX - offsetRect.left + 'px';
+        menuElement.style.top = pageY - offsetRect.top + 'px';
     }
 
     _hideMenuElement(menuElement) {

--- a/src/extras/ContextMenu/ContextMenu.js
+++ b/src/extras/ContextMenu/ContextMenu.js
@@ -746,9 +746,9 @@ class ContextMenu {
                             const showOnLeft = (itemRect.left - subMenuWidth) > offsetRect.left;
                         
                             if(showOnRight)
-                                self._showMenu(subMenu.id, itemRect.right - 5, itemRect.top + window.scrollY - 1);
+                                self._showMenu(subMenu.id, itemRect.right + window.scrollX - 5, itemRect.top + window.scrollY - 1);
                             else if (showOnLeft)
-                                self._showMenu(subMenu.id, itemRect.left - subMenuWidth, itemRect.top + window.scrollY - 1);
+                                self._showMenu(subMenu.id, itemRect.left - subMenuWidth + window.scrollX, itemRect.top + window.scrollY - 1);
                             else {
                                 const spaceOnLeft = itemRect.left - offsetRect.left, spaceOnRight = offsetRect.right - itemRect.right;
                                 if(spaceOnRight > spaceOnLeft) 
@@ -951,15 +951,16 @@ class ContextMenu {
         const offsetRect = this._offsetParent.getBoundingClientRect();
         
         const bottomContainerBorder = offsetRect.bottom + window.scrollY;
+        const rightContainerBorder = offsetRect.right + window.scrollX;
         if ((pageY + menuHeight) > bottomContainerBorder) {
             pageY = bottomContainerBorder- menuHeight;
         }
-        if ((pageX + menuWidth) > offsetRect.right) {
-            pageX = offsetRect.right - menuWidth;
+        if ((pageX + menuWidth) > rightContainerBorder) {
+            pageX = rightContainerBorder - menuWidth;
         }
 
 
-        menuElement.style.left = pageX - offsetRect.left + 'px';
+        menuElement.style.left = pageX - offsetRect.left - window.scrollX + 'px';
         menuElement.style.top = pageY - offsetRect.top - window.scrollY + 'px';
     }
 


### PR DESCRIPTION
Changes will allow positioning of ````ContextMenu```` relative to viewer canvas' container instead of 'window'. Also supports viewer canvases not attached to the top of the document.
Additionally I've changed ````_clear()```` method to remove menuElement directly to prevent errors in some cases.