### PR TITLE
Support section handle responsiveness on viewer canvas placed on non-top position of scrolled document

### DIFF
--- a/src/plugins/SectionPlanesPlugin/Control.js
+++ b/src/plugins/SectionPlanesPlugin/Control.js
@@ -482,8 +482,8 @@ class Control {
             const canvasPos = math.vec2();
 
             const copyCanvasPos = (event, vec2) => {
-                vec2[0] = event.clientX;
-                vec2[1] = event.clientY;
+                vec2[0] = event.pageX;
+                vec2[1] = event.pageY;
                 transformToNode(canvas.ownerDocument.documentElement, canvas, vec2);
             };
 


### PR DESCRIPTION
SectionPlanesPlugin' handles were unresponsive to mouse events when viewer container was placed in document with some other content above. This change fixes it.