### PR TITLE
[FIX] Use color and opacity for LineSet

### DIFF
--- a/examples/scenegraph/LineSet_grid.html
+++ b/examples/scenegraph/LineSet_grid.html
@@ -89,7 +89,8 @@
     new LineSet(viewer.scene, {
         positions: geometryArrays.positions,
         indices: geometryArrays.indices,
-        color: [0, 0.6, 0]
+        color: [0, 0.6, 0],
+        opacity: [0.3]
     });
 
 </script>

--- a/src/viewer/scene/LineSet/LineSet.js
+++ b/src/viewer/scene/LineSet/LineSet.js
@@ -66,7 +66,7 @@ class LineSet extends Component {
      * @param {String} [cfg.id] Optional ID, unique among all components in the parent {@link Scene}, generated automatically when omitted.
      * @param {Number[]} cfg.positions World-space 3D vertex positions.
      * @param {Number[]} [cfg.indices] Indices to connect ````positions```` into line segments. Note that these are separate line segments, not a polyline.
-     * @param {Number[]} [cfg.color=[0,0,0]] The color of this ````LineSet````. This is both emissive and diffuse.
+     * @param {Number[]} [cfg.color=[1,1,1]] The color of this ````LineSet````. This is both emissive and diffuse.
      * @param {Boolean} [cfg.visible=true] Indicates whether or not this ````LineSet```` is visible.
      * @param {Number} [cfg.opacity=1.0] ````LineSet````'s initial opacity factor.
      */
@@ -86,6 +86,8 @@ class LineSet extends Component {
             }
         }
 
+        this._color = cfg.color || [1, 1, 1];
+
         this._sceneModel = new SceneModel(this, {
             isModel: false // Don't register in Scene.models
         });
@@ -94,7 +96,8 @@ class LineSet extends Component {
             id: "linesMesh",
             primitive: "lines",
             positions: this._positions,
-            indices: this._indices
+            indices: this._indices,
+            color: this._color,
         })
 
         this._sceneModel.createEntity({

--- a/src/viewer/scene/LineSet/LineSet.js
+++ b/src/viewer/scene/LineSet/LineSet.js
@@ -87,6 +87,7 @@ class LineSet extends Component {
         }
 
         this._color = cfg.color || [1, 1, 1];
+        this._opacity = cfg.opacity || 1.0;
 
         this._sceneModel = new SceneModel(this, {
             isModel: false // Don't register in Scene.models
@@ -98,6 +99,7 @@ class LineSet extends Component {
             positions: this._positions,
             indices: this._indices,
             color: this._color,
+            opacity: this._opacity,
         })
 
         this._sceneModel.createEntity({

--- a/types/viewer/scene/LineSet/LineSet.d.ts
+++ b/types/viewer/scene/LineSet/LineSet.d.ts
@@ -66,7 +66,7 @@ export declare class LineSet extends Component {
      * @param {string} [cfg.id] Optional ID, unique among all components in the parent {@link Scene}, generated automatically when omitted.
      * @param {number[]} cfg.positions World-space 3D vertex positions.
      * @param {number[]} [cfg.indices] Indices to connect ````positions```` into line segments. Note that these are separate line segments, not a polyline.
-     * @param {number[]} [cfg.color=[0,0,0]] The color of this ````LineSet````. This is both emissive and diffuse.
+     * @param {number[]} [cfg.color=[1,1,1]] The color of this ````LineSet````. This is both emissive and diffuse.
      * @param {boolean} [cfg.visible=true] Indicates whether or not this ````LineSet```` is visible.
      * @param {number} [cfg.opacity=1.0] ````LineSet````'s initial opacity factor.
      */


### PR DESCRIPTION
This PR introduces 3 separate changes:
1. It uses color for LineSet:
![image](https://github.com/user-attachments/assets/ea641908-dfe3-4c93-849c-4b034e197a8b)
2. It changes the default color to [1,1,1] (white), to not change the current behaviour (right now it was all white no matter if there was a color).
3. It uses also opacity for LineSet:
![2025-04-14_14h55_56](https://github.com/user-attachments/assets/68ed9209-f4d5-442f-af02-f950bf8c41dc)

Looking for the feedback :)