### PR TITLE
XEOK-107: Allow users to use 6 separate images on the skybox

### DIFF
--- a/src/plugins/SkyboxesPlugin/SkyboxesPlugin.js
+++ b/src/plugins/SkyboxesPlugin/SkyboxesPlugin.js
@@ -12,46 +12,27 @@ import {Skybox} from "../../viewer/scene/skybox/Skybox.js"
  * });
  *
  * // Add a GLTFModelsPlugin
- * var gltfLoaderPlugin = new GLTFModelsPlugin(viewer, {
- *     id: "GLTFModels"  // Default value
- * });
+ * var xktLoaderPlugin = new XKTLoaderPlugin(viewer);
  *
  * // Add a SkyboxesPlugin
- * var skyboxesPlugin = new SkyboxesPlugin(viewer, {
- *     id: "Skyboxes" // Default value
- * });
+ * var skyboxesPlugin = new SkyboxesPlugin(viewer);
+ * 
+ * // Create a skybox
+ * skyBoxesPlugin.createSkybox({
+ *     src: [
+ *         "./assets/images/posx.jpg",
+ *         "./assets/images/negx.jpg",
+ *         "./assets/images/posy.jpg",
+ *         "./assets/images/negy.jpg",
+ *         "./assets/images/posz.jpg",
+ *         "./assets/images/negz.jpg"
+ *     ]
+ * })
  *
- * // Load a glTF model
- * const model = gltfLoaderPlugin.load({
+ * // Load an XKT model
+ * const model = xktLoaderPlugin.load({
  *     id: "myModel",
- *     src: "./models/gltf/mygltfmodel.gltf"
- * });
- *
- * // Create three directional World-space lights. "World" means that they will appear as if part
- * // of the world, instead of "View", where they move with the user's head.
- *
- * skyboxesPlugin.createLight({
- *     id: "keyLight",
- *     dir: [0.8, -0.6, -0.8],
- *     color: [1.0, 0.3, 0.3],
- *     intensity: 1.0,
- *     space: "world"
- * });
- *
- * skyboxesPlugin.createLight({
- *     id: "fillLight",
- *     dir: [-0.8, -0.4, -0.4],
- *     color: [0.3, 1.0, 0.3],
- *     intensity: 1.0,
- *     space: "world"
- * });
- *
- * skyboxesPlugin.createDirLight({
- *     id: "rimLight",
- *     dir: [0.2, -0.8, 0.8],
- *     color: [0.6, 0.6, 0.6],
- *     intensity: 1.0,
- *     space: "world"
+ *     src: "./models/xkt/myModel.xkt"
  * });
  *
  * @class SkyboxesPlugin
@@ -77,23 +58,17 @@ class SkyboxesPlugin extends Plugin {
     /**
      Creates a skybox.
 
-     @param {String} id Unique ID to assign to the skybox.
      @param {Object} params Skybox configuration.
+     @param {String} [params.id] Optional ID, unique among all components in the parent {Scene}, generated automatically when omitted.
+     @param {String | String[]} [params.src=null] Path to skybox texture
+     @param {Number} [params.encoding=LinearEncoding] Texture encoding format.  See the {@link Texture#encoding} property for more info.
+     @param {Number} [params.size=1000] Size of this Skybox, given as the distance from the center at ````[0,0,0]```` to each face.
      @param {Boolean} [params.active=true] Whether the skybox plane is initially active. Only skyboxes while this is true.
      @returns {Skybox} The new skybox.
      */
-    createSkybox(id, params) {
-        if (this.viewer.scene.components[id]) {
-            this.error("Component with this ID already exists: " + id);
-            return this;
-        }
-        var skybox = new Skybox(this.viewer.scene, {
-            id: id,
-            pos: params.pos,
-            dir: params.dir,
-            active: true || params.active
-        });
-        this.skyboxes[id] = skybox;
+    createSkybox(params) {
+        const skybox = new Skybox(this.viewer.scene, params);
+        this.skyboxes[skybox.id] = skybox;
         return skybox;
     }
 

--- a/src/viewer/scene/skybox/Skybox.js
+++ b/src/viewer/scene/skybox/Skybox.js
@@ -3,6 +3,7 @@ import {Mesh} from "../mesh/Mesh.js";
 import {ReadableGeometry} from "../geometry/ReadableGeometry.js";
 import {PhongMaterial} from "../materials/PhongMaterial.js";
 import {Texture} from "../materials/Texture.js";
+import { ClampToEdgeWrapping, LinearEncoding } from "../constants/constants.js";
 
 /**
  * @desc A Skybox.
@@ -14,14 +15,40 @@ class Skybox extends Component {
      * @param {Component} owner Owner component. When destroyed, the owner will destroy this PointLight as well.
      * @param {*} [cfg]  Skybox configuration
      * @param {String} [cfg.id] Optional ID, unique among all components in the parent {Scene}, generated automatically when omitted.
-     * @param {String} [cfg.src=null] Path to skybox texture
-     * @param {String} [cfg.encoding="linear"] Texture encoding format.  See the {@link Texture#encoding} property for more info.
+     * @param {String | String[]} [cfg.src=null] Path to skybox texture
+     * @param {Number} [cfg.encoding=LinearEncoding] Texture encoding format.  See the {@link Texture#encoding} property for more info.
      * @param {Number} [cfg.size=1000] Size of this Skybox, given as the distance from the center at ````[0,0,0]```` to each face.
      * @param {Boolean} [cfg.active=true] True when this Skybox is visible.
      */
     constructor(owner, cfg = {}) {
 
         super(owner, cfg);
+
+        const useMultipleTexture = typeof cfg.src === "object" && cfg.src !== null;
+
+        if (useMultipleTexture) {
+            this._createCombinedTexture(cfg).then(combinedTexture => {
+                this._createSkyboxMesh(cfg, combinedTexture);
+            }).catch(e => this.error(e));
+        } else {
+            this._createSkyboxMesh(cfg);
+        }
+    }
+
+    /**
+     * 
+     * @private
+     * @param {*} cfg 
+     * @param {Texture} combinedTexture 
+     */
+    _createSkyboxMesh(cfg, combinedTexture = null) {
+        const texture = combinedTexture || new Texture(this, {
+            src: cfg.src,
+            flipY: true,
+            wrapS: ClampToEdgeWrapping,
+            wrapT: ClampToEdgeWrapping,
+            encoding: cfg.encoding || LinearEncoding
+        });
 
         this._skyboxMesh = new Mesh(this, {
 
@@ -53,13 +80,7 @@ class Skybox extends Component {
                 diffuse: [0, 0, 0],
                 specular: [0, 0, 0],
                 emissive: [1, 1, 1],
-                emissiveMap: new Texture(this, {
-                    src: cfg.src,
-                    flipY: true,
-                    wrapS: "clampToEdge",
-                    wrapT: "clampToEdge",
-                    encoding: cfg.encoding || "sRGB"
-                }),
+                emissiveMap: texture,
                 backfaces: true // Show interior faces of our skybox geometry
             }),
             // stationary: true,
@@ -73,6 +94,86 @@ class Skybox extends Component {
         this.active = cfg.active;
     }
 
+    /**
+     * 
+     * @private
+     * @param {*} cfg 
+     * @returns {Texture}
+     */
+    async _createCombinedTexture(cfg) {
+        const [
+            posX,
+            negX,
+            posY,
+            negY,
+            posZ,
+            negZ
+        ] = cfg.src;
+
+        if (!posX || !negX || !posY || !negY || !posZ || !negZ) {
+            throw new Error("All six skybox textures must be provided");
+        }
+
+        const canvas = document.createElement('canvas');
+        const ctx = canvas.getContext('2d');
+
+        const loadImage = src => {
+            return new Promise((resolve, reject) => {
+                const img = new Image();
+                img.crossOrigin = "anonymous";
+                img.onload = () => resolve(img);
+                img.onerror = () => reject(new Error(`Failed to load image: ${src}`));
+                img.src = src;
+            });
+        };
+
+        try {
+            const [imgPosX, imgNegX, imgPosY, imgNegY, imgPosZ, imgNegZ] = await Promise.all([
+                loadImage(posX),
+                loadImage(negX),
+                loadImage(posY),
+                loadImage(negY),
+                loadImage(posZ),
+                loadImage(negZ)
+            ]);
+
+            const imageSize = imgPosX.width;
+            if (
+                imgNegX.width !== imageSize || imgPosY.width !== imageSize ||
+                imgNegY.width !== imageSize || imgPosZ.width !== imageSize ||
+                imgNegZ.width !== imageSize
+            ) {
+                throw new Error("All skybox textures must have the same dimensions");
+            }
+
+            // Set canvas size for the Christ cross layout (3×4 grid)
+            canvas.width = imageSize * 4;
+            canvas.height = imageSize * 3;
+
+            ctx.fillStyle = 'black';
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+            ctx.drawImage(imgNegX, imageSize * 0, imageSize * 1, imageSize, imageSize);  // -X (left)
+            ctx.drawImage(imgPosX, imageSize * 2, imageSize * 1, imageSize, imageSize);  // +X (right)
+            ctx.drawImage(imgPosY, imageSize * 1, imageSize * 0, imageSize, imageSize);  // +Y (top)
+            ctx.drawImage(imgNegY, imageSize * 1, imageSize * 2, imageSize, imageSize);  // -Y (bottom)
+            ctx.drawImage(imgPosZ, imageSize * 1, imageSize * 1, imageSize, imageSize);  // +Z (front)
+            ctx.drawImage(imgNegZ, imageSize * 3, imageSize * 1, imageSize, imageSize);  // -Z (back)
+
+            const combinedTexture = new Texture(this, {
+                image: canvas,
+                flipY: true,
+                wrapS: ClampToEdgeWrapping,
+                wrapT: ClampToEdgeWrapping,
+                encoding: cfg.encoding || LinearEncoding
+            });
+
+            return combinedTexture;
+        } catch (error) {
+            console.error("Error creating combined skybox texture:", error);
+            throw error;
+        }
+    }
 
     /**
      * Sets the size of this Skybox, given as the distance from the center at [0,0,0] to each face.

--- a/types/plugins/SkyboxesPlugin/SkyboxesPlugin.d.ts
+++ b/types/plugins/SkyboxesPlugin/SkyboxesPlugin.d.ts
@@ -1,4 +1,4 @@
-import { Plugin, Viewer } from "../../viewer";
+import { Plugin, Viewer, Skybox } from "../../viewer";
 
 /**
  * {@link Viewer} plugin that manages skyboxes
@@ -12,14 +12,21 @@ export declare class SkyboxesPlugin extends Plugin {
   
   /**
    * Creates a skybox.
-   * @param {String} id Unique ID to assign to the skybox.
    * @param {Object} params Skybox configuration.
+   * @param {String} [params.id] Optional ID, unique among all components in the parent {Scene}, generated automatically when omitted.
+   * @param {String | String[]} [params.src=null] Path to skybox texture
+   * @param {Number} [params.encoding=LinearEncoding] Texture encoding format.  See the {@link Texture#encoding} property for more info.
+   * @param {Number} [params.size=1000] Size of this Skybox, given as the distance from the center at ````[0,0,0]```` to each face.
    * @param {Boolean} [params.active=true] Whether the skybox plane is initially active. Only skyboxes while this is true.
    * @returns {Skybox} The new skybox.
    */
-  createSkybox(id: string, params: {
+  createSkybox(params: {
+      id?: string,
+      src: string | string[],
+      encoding?: number,
+      size?: number,
       active?: boolean;
-  }): any; //Skybox;
+  }): Skybox; //Skybox;
   
   /**
    * Destroys a skybox.
@@ -31,4 +38,11 @@ export declare class SkyboxesPlugin extends Plugin {
    Destroys all skyboxes.
     */
   clear(): void;
+
+  /**
+   * Destroys this plugin.
+   *
+   * Clears skyboxes from the Viewer first.
+   */
+  destroy(): void;
 }

--- a/types/viewer/scene/skybox/Skybox.d.ts
+++ b/types/viewer/scene/skybox/Skybox.d.ts
@@ -4,9 +4,9 @@ export declare type SkyboxConfiguration = {
     /** Optional ID, unique among all components in the parent {Scene}, generated automatically when omitted. */
     id?: string;
     /** Path to skybox texture */
-    src: string;
+    src: string | string[];
     /** Texture encoding format.  See the {@link Texture#encoding} property for more info. */
-    encoding?: string;
+    encoding?: number;
     /** Size of this Skybox, given as the distance from the center at ````[0,0,0]```` to each face. */
     size?: number;
     /** True when this Skybox is visible. */


### PR DESCRIPTION
Hi @xeolabs!

I did not add the ability for the users to change a particular image used to create the cube texture based on threeJS' implementation of CubeTextureLoader. If user needs to change any image used in the skybox texture, they would need to destroy the existing skybox and create a new one.