### PR TITLE
[REFACTOR] Listen only onCameraMatrix

### DIFF
--- a/src/plugins/FastNavPlugin/FastNavPlugin.js
+++ b/src/plugins/FastNavPlugin/FastNavPlugin.js
@@ -165,7 +165,6 @@ class FastNavPlugin extends Plugin {
             fastMode = false;
         };
 
-        this._onCanvasBoundary = viewer.scene.canvas.on("boundary", switchToLowQuality);
         this._onCameraMatrix = viewer.scene.camera.on("matrix", switchToLowQuality);
 
         this._onSceneTick = viewer.scene.on("tick", (tickEvent) => {
@@ -176,23 +175,6 @@ class FastNavPlugin extends Plugin {
             if ((!this._delayBeforeRestore) || timer <= 0) {
                 switchToHighQuality();
             }
-        });
-
-        let down = false;
-
-        this._onSceneMouseDown = viewer.scene.input.on("mousedown", () => {
-            down = true;
-        });
-
-        this._onSceneMouseUp = viewer.scene.input.on("mouseup", () => {
-            down = false;
-        });
-
-        this._onSceneMouseMove = viewer.scene.input.on("mousemove", () => {
-            if (!down) {
-                return;
-            }
-            switchToLowQuality();
         });
     }
 


### PR DESCRIPTION
This PR is a result of suggestion from Michał to check if we really need to listen all different events or maybe listening to onCameraMatrix is enough. For me it seems that listening to onCameraMatrix is enough, because for:

- mouse interactions
- keyboard interactions
- browser window resizing

it all seems to still trigger the FastNavPlugin mode properly. But please check it before the merge, and let me know if there is some other reason to listen other types that makes it worth keeping them.