### PR TITLE
Turning on the reuse of geometry

### DIFF
--- a/examples/performance/FastNavPlugin_HolterTower.html
+++ b/examples/performance/FastNavPlugin_HolterTower.html
@@ -121,9 +121,7 @@
     // Load a model
     //------------------------------------------------------------------------------------------------------------------
 
-    const xktLoader = new XKTLoaderPlugin(viewer, {
-        reuseGeometries: false
-    });
+    const xktLoader = new XKTLoaderPlugin(viewer);
 
     const t0 = performance.now();
 

--- a/examples/performance/FastNavPlugin_defaultScaleCanvasResolutionFactor.html
+++ b/examples/performance/FastNavPlugin_defaultScaleCanvasResolutionFactor.html
@@ -123,9 +123,7 @@
     // Load a model
     //------------------------------------------------------------------------------------------------------------------
 
-    const xktLoader = new XKTLoaderPlugin(viewer, {
-        reuseGeometries: false
-    });
+    const xktLoader = new XKTLoaderPlugin(viewer);
 
     const t0 = performance.now();
 

--- a/examples/performance/FastNavPlugin_hideElementsWithComplexGeometry.html
+++ b/examples/performance/FastNavPlugin_hideElementsWithComplexGeometry.html
@@ -134,9 +134,7 @@
     // Load a model
     //------------------------------------------------------------------------------------------------------------------
 
-    const xktLoader = new XKTLoaderPlugin(viewer, {
-        reuseGeometries: true
-    });
+    const xktLoader = new XKTLoaderPlugin(viewer);
 
     const t0 = performance.now();
 

--- a/examples/performance/FastNavPlugin_hideElementsWithComplexGeometry.html
+++ b/examples/performance/FastNavPlugin_hideElementsWithComplexGeometry.html
@@ -135,7 +135,7 @@
     //------------------------------------------------------------------------------------------------------------------
 
     const xktLoader = new XKTLoaderPlugin(viewer, {
-        reuseGeometries: false
+        reuseGeometries: true
     });
 
     const t0 = performance.now();

--- a/examples/performance/FastNavPlugin_hideElementsWithTypes.html
+++ b/examples/performance/FastNavPlugin_hideElementsWithTypes.html
@@ -130,9 +130,7 @@
     // Load a model
     //------------------------------------------------------------------------------------------------------------------
 
-    const xktLoader = new XKTLoaderPlugin(viewer, {
-        reuseGeometries: true
-    });
+    const xktLoader = new XKTLoaderPlugin(viewer);
 
     const t0 = performance.now();
 

--- a/examples/performance/FastNavPlugin_hideElementsWithTypes.html
+++ b/examples/performance/FastNavPlugin_hideElementsWithTypes.html
@@ -131,7 +131,7 @@
     //------------------------------------------------------------------------------------------------------------------
 
     const xktLoader = new XKTLoaderPlugin(viewer, {
-        reuseGeometries: false
+        reuseGeometries: true
     });
 
     const t0 = performance.now();

--- a/examples/performance/FastNavPlugin_showElementsWithTypes.html
+++ b/examples/performance/FastNavPlugin_showElementsWithTypes.html
@@ -130,9 +130,7 @@
     // Load a model
     //------------------------------------------------------------------------------------------------------------------
 
-    const xktLoader = new XKTLoaderPlugin(viewer, {
-        reuseGeometries: true
-    });
+    const xktLoader = new XKTLoaderPlugin(viewer);
 
     const t0 = performance.now();
 

--- a/examples/performance/FastNavPlugin_showElementsWithTypes.html
+++ b/examples/performance/FastNavPlugin_showElementsWithTypes.html
@@ -131,7 +131,7 @@
     //------------------------------------------------------------------------------------------------------------------
 
     const xktLoader = new XKTLoaderPlugin(viewer, {
-        reuseGeometries: false
+        reuseGeometries: true
     });
 
     const t0 = performance.now();

--- a/examples/performance/resolutionScaling_HolterTower.html
+++ b/examples/performance/resolutionScaling_HolterTower.html
@@ -98,9 +98,7 @@
     // Load a model
     //------------------------------------------------------------------------------------------------------------------
 
-    const xktLoader = new XKTLoaderPlugin(viewer, {
-        reuseGeometries: false
-    });
+    const xktLoader = new XKTLoaderPlugin(viewer);
 
     const t0 = performance.now();
 


### PR DESCRIPTION
Hello @xeolabs,

I had to turn it on, because when Diyan  tried these examples with different file, which was quite heavy, then it was crashing browser or showing only part of the model.

My question: is there a scenario when having it turned off may be beneficial?