### PR TITLE
Cleaner edges with non-logarithmic depth buffer

### DIFF
--- a/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesColorRenderer.js
+++ b/src/viewer/scene/model/dtx/triangles/renderers/DTXTrianglesColorRenderer.js
@@ -601,6 +601,11 @@ export class DTXTrianglesColorRenderer {
         if (scene.logarithmicDepthBufferEnabled) {
              src.push("    gl_FragDepth = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;");
             //src.push("    gl_FragDepth = log2( vFragDepth ) * logDepthBufFC * 0.5;");
+        } else {
+            src.push("    float dx = dFdx(gl_FragCoord.z);")
+            src.push("    float dy = dFdy(gl_FragCoord.z);")
+            src.push("    float diff = sqrt(dx*dx+dy*dy);");
+            src.push("    gl_FragDepth = gl_FragCoord.z + diff;");
         }
 
         if (this._withSAO) {

--- a/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesColorRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesColorRenderer.js
@@ -225,6 +225,11 @@ export class TrianglesColorRenderer extends TrianglesBatchingRenderer {
             src.push("    float dy = dFdy(vFragDepth);")
             src.push("    float diff = sqrt(dx*dx+dy*dy);");
             src.push("    gl_FragDepth = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth + diff ) * logDepthBufFC * 0.5;");
+        } else {
+            src.push("    float dx = dFdx(gl_FragCoord.z);")
+            src.push("    float dy = dFdy(gl_FragCoord.z);")
+            src.push("    float diff = sqrt(dx*dx+dy*dy);");
+            src.push("    gl_FragDepth = gl_FragCoord.z + diff;");
         }
 
         if (this._withSAO) {

--- a/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesFlatColorRenderer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/renderers/TrianglesFlatColorRenderer.js
@@ -233,6 +233,11 @@ export class TrianglesFlatColorRenderer extends TrianglesBatchingRenderer {
 
         if (scene.logarithmicDepthBufferEnabled) {
             src.push("    gl_FragDepth = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;");
+        } else {
+            src.push("    float dx = dFdx(gl_FragCoord.z);")
+            src.push("    float dy = dFdy(gl_FragCoord.z);")
+            src.push("    float diff = sqrt(dx*dx+dy*dy);");
+            src.push("    gl_FragDepth = gl_FragCoord.z + diff;");
         }
 
         src.push("}");

--- a/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesColorRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesColorRenderer.js
@@ -238,6 +238,11 @@ class TrianglesColorRenderer extends TrianglesInstancingRenderer {
             src.push("    float dy = dFdy(vFragDepth);")
             src.push("    float diff = sqrt(dx*dx+dy*dy);");
             src.push("    gl_FragDepth = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth + diff ) * logDepthBufFC * 0.5;");
+        } else {
+            src.push("    float dx = dFdx(gl_FragCoord.z);")
+            src.push("    float dy = dFdy(gl_FragCoord.z);")
+            src.push("    float diff = sqrt(dx*dx+dy*dy);");
+            src.push("    gl_FragDepth = gl_FragCoord.z + diff;");
         }
 
         // Doing SAO blend in the main solid fill draw shader just so that edge lines can be drawn over the top

--- a/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesFlatColorRenderer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/renderers/TrianglesFlatColorRenderer.js
@@ -242,6 +242,11 @@ export class TrianglesFlatColorRenderer extends TrianglesInstancingRenderer {
 
         if (scene.logarithmicDepthBufferEnabled) {
             src.push("    gl_FragDepth = isPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;");
+        } else {
+            src.push("    float dx = dFdx(gl_FragCoord.z);")
+            src.push("    float dy = dFdy(gl_FragCoord.z);")
+            src.push("    float diff = sqrt(dx*dx+dy*dy);");
+            src.push("    gl_FragDepth = gl_FragCoord.z + diff;");
         }
 
         src.push("}");


### PR DESCRIPTION
Solves #1792 

@xeolabs you will need to check if I missed some renderer 🙂 

👇 These before/after images were taken with:

```js
viewer.camera.perspective.far = 10000000;
viewer.camera.perspective.near = 0.1;
```

The tested model is:

- `assets/models/xkt/v10/glb/archicad-demoprojekt.xkt`

## Before

![image](https://github.com/user-attachments/assets/da9ead2e-3e5e-4297-9814-a47da591cd5f)

## After

![image](https://github.com/user-attachments/assets/4bc97f03-8702-4cd0-af9c-1c27270651a5)
