### PR TITLE
Allow to read geometry directly from the GPU (VBO triangles layers)

### DIFF
--- a/src/viewer/scene/Entity.js
+++ b/src/viewer/scene/Entity.js
@@ -492,6 +492,12 @@ class Entity {
     }
 
     /**
+     * Gets the complete geometry of this entity.
+     */
+    getGeometryData() {
+    }
+
+    /**
      * Destroys this Entity.
      */
     destroy() {

--- a/src/viewer/scene/model/SceneModelEntity.js
+++ b/src/viewer/scene/model/SceneModelEntity.js
@@ -687,6 +687,32 @@ export class SceneModelEntity {
         }
     }
 
+    readGeometryData() {
+        let positionsBase = 0;
+        const positions = [];
+        const indices = [];
+
+        for (let i = 0, len = this.meshes.length; i < len; i++) {
+            const mesh = this.meshes[i];
+
+            if (layer.readGeometryData) {
+                const meshGeom = mesh.layer.readGeometryData(mesh.portionId);
+    
+                for (let j = 0, len = meshGeom.indices.length; j < len; j++) {
+                    indices.push(meshGeom.indices[j]+positionsBase);
+                }
+    
+                for (let j = 0, len = meshGeom.positions.length; j < len; j++) {
+                    positions.push(meshGeom.positions[j]);
+                }
+    
+                positionsBase += meshGeom.positions.length / 3;                
+            }
+        }
+
+        return { indices, positions };
+    }
+
     /**
      * Returns the volume of this SceneModelEntity.
      *

--- a/src/viewer/scene/model/SceneModelEntity.js
+++ b/src/viewer/scene/model/SceneModelEntity.js
@@ -687,7 +687,7 @@ export class SceneModelEntity {
         }
     }
 
-    readGeometryData() {
+    getGeometryData() {
         let positionsBase = 0;
         const positions = [];
         const indices = [];

--- a/src/viewer/scene/model/SceneModelEntity.js
+++ b/src/viewer/scene/model/SceneModelEntity.js
@@ -695,7 +695,7 @@ export class SceneModelEntity {
         for (let i = 0, len = this.meshes.length; i < len; i++) {
             const mesh = this.meshes[i];
 
-            if (layer.readGeometryData) {
+            if (mesh.layer.readGeometryData) {
                 const meshGeom = mesh.layer.readGeometryData(mesh.portionId);
     
                 for (let j = 0, len = meshGeom.indices.length; j < len; j++) {

--- a/src/viewer/scene/model/vbo/batching/triangles/VBOBatchingTrianglesLayer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/VBOBatchingTrianglesLayer.js
@@ -869,7 +869,7 @@ export class VBOBatchingTrianglesLayer {
         return {count, offset}
     }
 
-    getData(portionId) {
+    readGeometryData(portionId) {
         if (!this._finalized) {
             throw "Not finalized";
         }

--- a/src/viewer/scene/model/vbo/batching/triangles/VBOBatchingTrianglesLayer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/VBOBatchingTrianglesLayer.js
@@ -875,11 +875,42 @@ export class VBOBatchingTrianglesLayer {
         }
 
         const portion = this._portions[portionId];
+        const state = this._state;
+        const sceneModelMatrix = this.model.matrix;
+        const positionsDecodeMatrix = state.positionsDecodeMatrix;
 
-        return {
-            indices: this._state.indicesBuf.getData(portion.indicesBaseIndex, portion.numIndices).map(i => i - portion.vertsBaseIndex),
-            positions: this._state.positionsBuf.getData(portion.vertsBaseIndex, portion.numVerts),
-        };
+        const origin = math.vec4();
+        origin.set(state.origin, 0); origin[3] = 1;
+        math.mulMat4v4(sceneModelMatrix, origin, origin);
+
+        const indices = state.indicesBuf.getData(
+            portion.indicesBaseIndex, portion.numIndices
+        ).map(i => i - portion.vertsBaseIndex);
+
+        const matrix = math.mulMat4(
+            sceneModelMatrix,
+            positionsDecodeMatrix,
+            new Array(16)
+        );
+
+        matrix[12] += origin[0];
+        matrix[13] += origin[1];
+        matrix[14] += origin[2];
+
+        const positionsQuantized = state.positionsBuf.getData(
+            portion.vertsBaseIndex, portion.numVerts
+        );
+
+        const positions = math.transformPositions3(
+            matrix,
+            positionsQuantized,
+            new Array(positionsQuantized.length)
+        );
+
+        // const aabb = math.positions3ToAABB3(positions);
+        // console.log({aabbToniBatching: aabb});
+
+        return { indices, positions };
     }
 
     // ---------------------- COLOR RENDERING -----------------------------------

--- a/src/viewer/scene/model/vbo/batching/triangles/VBOBatchingTrianglesLayer.js
+++ b/src/viewer/scene/model/vbo/batching/triangles/VBOBatchingTrianglesLayer.js
@@ -869,6 +869,19 @@ export class VBOBatchingTrianglesLayer {
         return {count, offset}
     }
 
+    getData(portionId) {
+        if (!this._finalized) {
+            throw "Not finalized";
+        }
+
+        const portion = this._portions[portionId];
+
+        return {
+            indices: this._state.indicesBuf.getData(portion.indicesBaseIndex, portion.numIndices).map(i => i - portion.vertsBaseIndex),
+            positions: this._state.positionsBuf.getData(portion.vertsBaseIndex, portion.numVerts),
+        };
+    }
+
     // ---------------------- COLOR RENDERING -----------------------------------
 
     drawColorOpaque(renderFlags, frameCtx) {

--- a/src/viewer/scene/model/vbo/instancing/triangles/VBOInstancingTrianglesLayer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/VBOInstancingTrianglesLayer.js
@@ -785,7 +785,7 @@ export class VBOInstancingTrianglesLayer {
         this._state.modelMatrixCol2Buf.setData(tempFloat32Vec4, offset);
     }
 
-    getData(portionId) {
+    readGeometryData(portionId) {
         if (!this._finalized) {
             throw "Not finalized";
         }

--- a/src/viewer/scene/model/vbo/instancing/triangles/VBOInstancingTrianglesLayer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/VBOInstancingTrianglesLayer.js
@@ -785,15 +785,62 @@ export class VBOInstancingTrianglesLayer {
         this._state.modelMatrixCol2Buf.setData(tempFloat32Vec4, offset);
     }
 
-    getData(_portionId) {
+    getData(portionId) {
         if (!this._finalized) {
             throw "Not finalized";
         }
 
-        return {
-            indices: this._state.indicesBuf.getData(),
-            positions: this._state.positionsBuf.getData()
-        }
+        const state = this._state;
+        const sceneModelMatrix = this.model.matrix;
+
+        const col0 = state.modelMatrixCol0Buf.getData(portionId, 1);
+        const col1 = state.modelMatrixCol1Buf.getData(portionId, 1);
+        const col2 = state.modelMatrixCol2Buf.getData(portionId, 1);
+
+        const portionMatrix = [
+            col0[0], col1[0], col2[0], 0,
+            col0[1], col1[1], col2[1], 0,
+            col0[2], col1[2], col2[2], 0,
+            col0[3], col1[3], col2[3], 1,
+        ];
+
+        const positionsDecodeMatrix = state.positionsDecodeMatrix;
+
+        const origin = math.vec4();
+        origin.set(state.origin, 0);
+        origin[3] = 1;
+        math.mulMat4v4(sceneModelMatrix, origin, origin);
+
+        const indices = state.indicesBuf.getData();
+
+        const matrix = math.mulMat4(
+            portionMatrix,
+            positionsDecodeMatrix,
+            new Array(16)
+        );
+
+        math.mulMat4(
+            sceneModelMatrix,
+            matrix,
+            matrix
+        );
+
+        matrix[12] += origin[0];
+        matrix[13] += origin[1];
+        matrix[14] += origin[2];
+
+        const positionsQuantized = state.positionsBuf.getData();
+
+        const positions = math.transformPositions3(
+            matrix,
+            positionsQuantized,
+            new Array(positionsQuantized.length)
+        );
+
+        // const aabb = math.positions3ToAABB3(positions);
+        // console.log({aabbToniInstancing: aabb});
+
+        return { indices, positions };
     }
 
     // ---------------------- COLOR RENDERING -----------------------------------

--- a/src/viewer/scene/model/vbo/instancing/triangles/VBOInstancingTrianglesLayer.js
+++ b/src/viewer/scene/model/vbo/instancing/triangles/VBOInstancingTrianglesLayer.js
@@ -785,6 +785,17 @@ export class VBOInstancingTrianglesLayer {
         this._state.modelMatrixCol2Buf.setData(tempFloat32Vec4, offset);
     }
 
+    getData(_portionId) {
+        if (!this._finalized) {
+            throw "Not finalized";
+        }
+
+        return {
+            indices: this._state.indicesBuf.getData(),
+            positions: this._state.positionsBuf.getData()
+        }
+    }
+
     // ---------------------- COLOR RENDERING -----------------------------------
 
     drawColorOpaque(renderFlags, frameCtx) {

--- a/src/viewer/scene/webgl/ArrayBuf.js
+++ b/src/viewer/scene/webgl/ArrayBuf.js
@@ -10,6 +10,7 @@ class ArrayBuf {
         this._gl = gl;
         this.type = type;
         this.allocated = false;
+        this.ConstructorType = data.constructor;
 
         switch (data.constructor) {
 
@@ -92,6 +93,25 @@ class ArrayBuf {
             }
             this._gl.bindBuffer(this.type, null);
         }
+    }
+
+    getData(baseIndex = 0, length = (this.numItems) - baseIndex) {
+        if (!this.allocated) {
+            return [];
+        }
+
+        const array = new (this.ConstructorType)(length * this.itemSize);
+
+        this._gl.bindBuffer(this.type, this._handle);
+        this._gl.getBufferSubData(
+            this.type,
+            baseIndex * this.itemByteSize * this.itemSize,
+            array,
+            0,
+            length * this.itemSize
+        );
+
+        return array;
     }
 
     bind() {

--- a/types/viewer/scene/Entity.d.ts
+++ b/types/viewer/scene/Entity.d.ts
@@ -395,6 +395,11 @@ export declare abstract class Entity {
   getEachVertex(callback: any): void;
 
   /**
+   * Gets the complete geometry of this entity.
+   */
+  getGeometryData(): {indices: number[],positions:number[]}
+
+  /**
    * Destroys this Entity.
    */
   destroy(): void;

--- a/types/viewer/scene/models/SceneModelEntity.d.ts
+++ b/types/viewer/scene/models/SceneModelEntity.d.ts
@@ -446,7 +446,7 @@ export declare abstract class SceneModelEntity implements Entity {
     /**
      * Gets the complete geometry of this entity.
      */
-    readGeometryData(): {indices: number[],positions:number[]}
+    getGeometryData(): {indices: number[],positions:number[]}
 
     /**
      * Returns the volume of this SceneModelEntity.

--- a/types/viewer/scene/models/SceneModelEntity.d.ts
+++ b/types/viewer/scene/models/SceneModelEntity.d.ts
@@ -444,6 +444,11 @@ export declare abstract class SceneModelEntity implements Entity {
     getEachIndex(callback: any): void;
 
     /**
+     * Gets the complete geometry of this entity.
+     */
+    readGeometryData(): {indices: number[],positions:number[]}
+
+    /**
      * Returns the volume of this SceneModelEntity.
      *
      * Only works when {@link Scene.readableGeometryEnabled | Scene.readableGeometryEnabled} is `true` and the


### PR DESCRIPTION
## Context

This is the result of some fantastic conversation with @MathiasTribia and based on the initial code he did in `ArrayBuf.js` but that was not public 😎. Big Kudos Mathias! 🥂 

Now I took the opportunity to work out some details and leave it in a really good working state 🎉. Perfectly working for VBO batching/instancing triangles layers!

## Description

This PR allows to read back geometry data DIRECTLY from the GPU without needing to store all the geometry of loaded models into browser RAM.

Completely avoid the need for `Scene::readableGeometryEnabled`!

It's a tremendous RAM saver in case of needing to read back entities' geometry in order to do further processing/analysis on the Javascript side.

It's very simple to use! Use it like this::

```javascript
const entity = ...;
const { indices, positions } = e.getGeometryData();

// now, have some fun with the geometry in `indices` / `positions` 🎉 
```

The fetch time is independent of the model complexity, and only dependant on the amount of fetched geometry.

Some tests fetching the geometry of around 3k objects indicate the geometry can be fetched for all 3k of them in less than 0.5s! 🚀 

At the moment this is supported by both batching and instancing layers of VBO-Triangles implementations!

What do you think @xeolabs?

