### PR TITLE
Add `rendering` property to control xeokit scene render loop

### DIFF
--- a/src/viewer/scene/core.js
+++ b/src/viewer/scene/core.js
@@ -1,7 +1,7 @@
-import {Queue} from './utils/Queue.js';
-import {Map} from './utils/Map.js';
-import {stats} from './stats.js';
-import {utils} from './utils.js';
+import { stats } from './stats.js';
+import { utils } from './utils.js';
+import { Map } from './utils/Map.js';
+import { Queue } from './utils/Queue.js';
 
 const scenesRenderInfo = {}; // Used for throttling FPS for each Scene
 const sceneIDMap = new Map(); // Ensures unique scene IDs
@@ -237,9 +237,10 @@ function renderScenes() {
     let id;
     for (id in scenes) {
         if (scenes.hasOwnProperty(id)) {
-
             scene = scenes[id];
             renderInfo = scenesRenderInfo[id];
+
+            if (!scene.rendering) return;
 
             if (!renderInfo) {
                 renderInfo = scenesRenderInfo[id] = {}; // FIXME
@@ -268,4 +269,4 @@ function renderScenes() {
     }
 }
 
-export {core};
+export { core };

--- a/src/viewer/scene/scene/Scene.js
+++ b/src/viewer/scene/scene/Scene.js
@@ -1,25 +1,25 @@
-import {core} from '../core.js';
-import {utils} from '../utils.js';
-import {math} from '../math/math.js';
-import {Component} from '../Component.js';
-import {Canvas} from '../canvas/Canvas.js';
-import {Renderer} from '../webgl/Renderer.js';
-import {Input} from '../input/Input.js';
-import {Viewport} from '../viewport/Viewport.js';
-import {Camera} from '../camera/Camera.js';
-import {DirLight} from '../lights/DirLight.js';
-import {AmbientLight} from '../lights/AmbientLight.js';
-import {ReadableGeometry} from "../geometry/ReadableGeometry.js";
-import {buildBoxGeometry} from '../geometry/builders/buildBoxGeometry.js';
-import {PhongMaterial} from '../materials/PhongMaterial.js';
-import {EmphasisMaterial} from '../materials/EmphasisMaterial.js';
-import {EdgeMaterial} from '../materials/EdgeMaterial.js';
-import {Metrics} from "../metriqs/Metriqs.js";
-import {SAO} from "../postfx/SAO.js";
-import {CrossSections} from "../postfx/CrossSections.js";
-import {PointsMaterial} from "../materials/PointsMaterial.js";
-import {LinesMaterial} from "../materials/LinesMaterial.js";
-import {SectionCaps} from '../sectionCaps/SectionCaps.js';
+import { Component } from '../Component.js';
+import { Camera } from '../camera/Camera.js';
+import { Canvas } from '../canvas/Canvas.js';
+import { core } from '../core.js';
+import { ReadableGeometry } from "../geometry/ReadableGeometry.js";
+import { buildBoxGeometry } from '../geometry/builders/buildBoxGeometry.js';
+import { Input } from '../input/Input.js';
+import { AmbientLight } from '../lights/AmbientLight.js';
+import { DirLight } from '../lights/DirLight.js';
+import { EdgeMaterial } from '../materials/EdgeMaterial.js';
+import { EmphasisMaterial } from '../materials/EmphasisMaterial.js';
+import { LinesMaterial } from "../materials/LinesMaterial.js";
+import { PhongMaterial } from '../materials/PhongMaterial.js';
+import { PointsMaterial } from "../materials/PointsMaterial.js";
+import { math } from '../math/math.js';
+import { Metrics } from "../metriqs/Metriqs.js";
+import { CrossSections } from "../postfx/CrossSections.js";
+import { SAO } from "../postfx/SAO.js";
+import { SectionCaps } from '../sectionCaps/SectionCaps.js';
+import { utils } from '../utils.js';
+import { Viewport } from '../viewport/Viewport.js';
+import { Renderer } from '../webgl/Renderer.js';
 
 // Enables runtime check for redundant calls to object state update methods, eg. Scene#_objectVisibilityUpdated
 const ASSERT_OBJECT_STATE_UPDATE = false;
@@ -601,6 +601,13 @@ class Scene extends Component {
          * @type {Number[]}
          */
         this.realWorldOffset = cfg.realWorldOffset || new Float64Array([0, 0, 0]);
+
+        /**
+         * Rendering state. Set to ````false```` to pause rendering.
+         * 
+         * @type {Boolean}
+         */
+        this.rendering = true;
 
         /**
          * Manages the HTML5 canvas for this Scene.
@@ -2871,4 +2878,5 @@ class Scene extends Component {
     }
 }
 
-export {Scene};
+export { Scene };
+

--- a/types/viewer/scene/scene/Scene.d.ts
+++ b/types/viewer/scene/scene/Scene.d.ts
@@ -1,16 +1,16 @@
 import { Component } from "../Component";
-import { Camera } from "../camera/Camera";
-import { PickResult } from "../webgl/PickResult";
-import { SAO } from "../postfx/SAO";
 import { Entity } from "../Entity";
+import { Camera } from "../camera/Camera";
 import { ReadableGeometry } from "../geometry";
-import { EdgeMaterial, EmphasisMaterial, PhongMaterial, PointsMaterial, LinesMaterial } from "../materials";
-import { Viewport } from "../viewport/Viewport";
-import { VBOSceneModel } from "../models/VBOSceneModel/VBOSceneModel";
-import { Mesh } from "../mesh";
-import { Node } from "../nodes";
 import { Input } from "../input/input";
+import { EdgeMaterial, EmphasisMaterial, LinesMaterial, PhongMaterial, PointsMaterial } from "../materials";
+import { Mesh } from "../mesh";
+import { VBOSceneModel } from "../models/VBOSceneModel/VBOSceneModel";
+import { Node } from "../nodes";
+import { SAO } from "../postfx/SAO";
 import { SectionPlane } from "../sectionPlane/SectionPlane";
+import { Viewport } from "../viewport/Viewport";
+import { PickResult } from "../webgl/PickResult";
 
 export declare type TickEvent = {
   /** The ID of this Scene. */
@@ -489,6 +489,24 @@ export declare class Scene extends Component {
   * @type {Number}
   */
   get passes(): number;
+
+  /**
+   * Gets whether or not to render this Scene.
+   * 
+   * Default value is ````true````.
+   * 
+   * @type {Boolean}
+   */
+  get rendering(): boolean;
+
+  /**
+   * Sets whether or not to render this Scene.
+   *
+   * Default value is ````true````.
+   *
+   * @type {Boolean}
+   */
+  set rendering(value: boolean);
 
   /**
   * When {@link Scene.passes} is greater than ````1````, indicates whether or not to clear the canvas before each pass (````true````) or just before the first pass (````false````).


### PR DESCRIPTION
This PR introduces a new `rendering` property to the scene, allowing the render loop to be paused and resumed as needed.

Reasoning:
Currently, xeokit renders the scene continuously, even when there are no changes to geometry, camera, or user interaction. This behavior is inefficient, especially in static scenes where continuous rendering is unnecessary.

Adding the ability to pause rendering enables:
- reduced CPU and GPU usage,
- energy savings, particularly in desktop and mobile applications,
- better performance in apps managing multiple viewers (e.g., via iframes),
- improved efficiency when dealing with large or complex models.

Example usage:
```js
viewer.scene.rendering = false; // Pause rendering
viewer.scene.rendering = true;  // Resume rendering
```

This change is non-breaking and preserves the current default behavior (rendering enabled). It also lays the groundwork for potential on-demand rendering features.

Let me know if you want it tailored more to a specific codebase or implementation.
