### PR TITLE
fix: lose unused WebGL context after Canvas destroy

### DIFF
--- a/src/viewer/scene/canvas/Canvas.js
+++ b/src/viewer/scene/canvas/Canvas.js
@@ -1,7 +1,7 @@
 
-import {math} from '../math/math.js';
-import {Component} from '../Component.js';
-import {Spinner} from './Spinner.js';
+import { Component } from '../Component.js';
+import { math } from '../math/math.js';
+import { Spinner } from './Spinner.js';
 
 const WEBGL_CONTEXT_NAMES = [
     "webgl2",
@@ -482,9 +482,12 @@ class Canvas extends Component {
         // Memory leak avoidance
         this.canvas.removeEventListener("webglcontextlost", this._webglcontextlostListener);
         this.canvas.removeEventListener("webglcontextrestored", this._webglcontextrestoredListener);
+        
+        this.gl.getExtension("WEBGL_lose_context").loseContext();
         this.gl = null;
+        
         super.destroy();
     }
 }
 
-export {Canvas};
+export { Canvas };


### PR DESCRIPTION
**I'm adding it again, the changes have disappeared somewhere.**

This PR fix memory leak by explicitly releasing unused WebGL contexts when the canvas element is destroyed.

Why?
Because unused WebGL contexts can continue consuming GPU resources even after the canvas element has been removed from the DOM. Without explicitly releasing these contexts, this leads to memory leaks and increased GPU resource usage, potentially degrading application performance and stability over time.

This fix ensures that WebGL contexts are properly released when the canvas element is destroyed, preventing GPU memory leaks.