### PR TITLE
XEOK-286 Local Playwright tests and example fixes

### DIFF
--- a/examples/scenegraph/index.html
+++ b/examples/scenegraph/index.html
@@ -317,6 +317,7 @@
 
             ["materials_PhongMaterial", "PhongMaterial"],
             ["materials_MetallicMaterial", "Physically-based metallic/roughness material"],
+            ["materials_MetallicMaterialLightReflection", "PBR material with LightMap and ReflectionMap"],
             ["materials_LambertMaterial", "LambertMaterial"],
             ["materials_EdgeMaterial", "EdgeMaterial"],
             ["materials_EmphasisMaterial", "EmphasisMaterial"],

--- a/examples/scenegraph/materials_MetallicMaterial.html
+++ b/examples/scenegraph/materials_MetallicMaterial.html
@@ -53,6 +53,7 @@
     //------------------------------------------------------------------------------------------------------------------
 
     import {
+        sRGBEncoding,
         Viewer,
         Mesh,
         loadOBJGeometry,
@@ -123,7 +124,7 @@
 
                         baseColorMap: new Texture(viewer.scene, {
                             src: "../../assets/models/obj/fireHydrant/fire_hydrant_Base_Color.png",
-                            encoding: "sRGB"
+                            encoding: sRGBEncoding
                         }),
                         normalMap: new Texture(viewer.scene, {
                             src: "../../assets/models/obj/fireHydrant/fire_hydrant_Normal_OpenGL.png"

--- a/examples/scenegraph/materials_MetallicMaterialLightReflection.html
+++ b/examples/scenegraph/materials_MetallicMaterialLightReflection.html
@@ -1,0 +1,178 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>xeokit Example</title>
+    <link href="../css/pageStyle.css" rel="stylesheet"/>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
+</head>
+<body>
+<input type="checkbox" id="info-button"/>
+<label for="info-button" class="info-button"><i class="far fa-3x fa-question-circle"></i></label>
+<canvas id="myCanvas"></canvas>
+<div class="slideout-sidebar">
+    <h1>MetallicMaterial</h1>
+    <p>A physically-correct metallic/roughness material that renders with Cook-Torrance, GGX & Shlick's Fresnel
+        approximation.</p>
+    <h3>Components used</h3>
+    <ul>
+        <li>
+            <a href="../../docs/class/src/viewer/Viewer.js~Viewer.html"
+               target="_other">Viewer</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/viewer/scene/mesh/Mesh.js~Mesh.html"
+               target="_other">Mesh</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/viewer/scene/geometry/ReadableGeometry.js~ReadableGeometry.html"
+               target="_other">ReadableGeometry</a>
+        </li>
+        <li>
+            <a href="../../docs/function/index.html#static-function-loadOBJGeometry"
+               target="_other">loadOBJGeometry()</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/viewer/scene/materials/MetallicMaterial.js~MetallicMaterial.html"
+               target="_other">MetallicMaterial</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/viewer/scene/materials/Texture.js~Texture.html"
+               target="_other">Texture</a>
+        </li>
+    </ul>
+</div>
+</body>
+
+<script id="source" type="module">
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Import the modules we need for this example
+    //------------------------------------------------------------------------------------------------------------------
+
+    import {
+        LinearEncoding,
+        sRGBEncoding,
+        Viewer,
+        Mesh,
+        loadOBJGeometry,
+        ReadableGeometry,
+        MetallicMaterial,
+        Texture,
+        DirLight,
+        LightMap,
+        ReflectionMap
+    } from "../../dist/xeokit-sdk.min.es.js";
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a Viewer and arrange the camera
+    //------------------------------------------------------------------------------------------------------------------
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas"
+    });
+
+    new ReflectionMap(viewer.scene, {
+        src: [
+            "../../assets/textures/reflect/Uffizi_Gallery/Uffizi_Gallery_Radiance_PX.png",
+            "../../assets/textures/reflect/Uffizi_Gallery/Uffizi_Gallery_Radiance_NX.png",
+            "../../assets/textures/reflect/Uffizi_Gallery/Uffizi_Gallery_Radiance_PY.png",
+            "../../assets/textures/reflect/Uffizi_Gallery/Uffizi_Gallery_Radiance_NY.png",
+            "../../assets/textures/reflect/Uffizi_Gallery/Uffizi_Gallery_Radiance_PZ.png",
+            "../../assets/textures/reflect/Uffizi_Gallery/Uffizi_Gallery_Radiance_NZ.png"
+        ],
+        encoding: sRGBEncoding
+    });
+
+    new LightMap(viewer.scene, {
+        src: [
+            "../../assets/textures/light/Uffizi_Gallery/Uffizi_Gallery_Irradiance_PX.png",
+            "../../assets/textures/light/Uffizi_Gallery/Uffizi_Gallery_Irradiance_NX.png",
+            "../../assets/textures/light/Uffizi_Gallery/Uffizi_Gallery_Irradiance_PY.png",
+            "../../assets/textures/light/Uffizi_Gallery/Uffizi_Gallery_Irradiance_NY.png",
+            "../../assets/textures/light/Uffizi_Gallery/Uffizi_Gallery_Irradiance_PZ.png",
+            "../../assets/textures/light/Uffizi_Gallery/Uffizi_Gallery_Irradiance_NZ.png"
+        ],
+        encoding: sRGBEncoding
+    });
+
+    viewer.scene.camera.eye = [0.57, 1.37, 1.14];
+    viewer.scene.camera.look = [0.04, 0.58, 0.00];
+    viewer.scene.camera.up = [-0.22, 0.84, -0.48];
+
+    viewer.scene.gammaOutput = true;
+    viewer.scene.gammaFactor = 2.0;
+
+    viewer.scene.clearLights();
+
+    new DirLight(viewer.scene, {
+        dir: [0.8, -0.6, -0.8],
+        color: [1.0, 1.0, 1.0],
+        intensity: 1.0,
+        space: "view"
+    });
+
+    new DirLight(viewer.scene, {
+        dir: [-0.8, -0.4, -0.4],
+        color: [1.0, 1.0, 1.0],
+        intensity: 1.0,
+        space: "view"
+    });
+
+    new DirLight(viewer.scene, {
+        dir: [0.2, -0.8, 0.8],
+        color: [1.0, 1.0, 1.0],
+        intensity: 1.0,
+        space: "view"
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a mesh with torus shape
+    //------------------------------------------------------------------------------------------------------------------
+
+    loadOBJGeometry(viewer.scene, {
+        src: "../../assets/models/obj/fireHydrant/FireHydrantMesh.obj"
+    })
+        .then(function (geometry) {
+
+                // Success
+
+                new Mesh(viewer.scene, {
+
+                    geometry: new ReadableGeometry(viewer.scene, geometry),
+
+                    material: new MetallicMaterial(viewer.scene, {
+
+                        baseColor: [1, 1, 1],
+                        metallic: 1.0,
+                        roughness: 1.0,
+
+                        baseColorMap: new Texture(viewer.scene, {
+                            src: "../../assets/models/obj/fireHydrant/fire_hydrant_Base_Color.png",
+                            encoding: sRGBEncoding
+                        }),
+                        normalMap: new Texture(viewer.scene, {
+                            src: "../../assets/models/obj/fireHydrant/fire_hydrant_Normal_OpenGL.png"
+                        }),
+                        roughnessMap: new Texture(viewer.scene, {
+                            src: "../../assets/models/obj/fireHydrant/fire_hydrant_Roughness.png"
+                        }),
+                        metallicMap: new Texture(viewer.scene, {
+                            src: "../../assets/models/obj/fireHydrant/fire_hydrant_Metallic.png"
+                        }),
+                        occlusionMap: new Texture(viewer.scene, {
+                            src: "../../assets/models/obj/fireHydrant/fire_hydrant_Mixed_AO.png"
+                        }),
+
+                        specularF0: 0.7
+                    })
+                });
+            },
+            function () {
+                // Error
+            });
+
+</script>
+</html>

--- a/examples/scenemodel/dtx_batching_geometries.html
+++ b/examples/scenemodel/dtx_batching_geometries.html
@@ -277,16 +277,11 @@
         i++;
     }
 
-    sceneModel.createGeometry({
-        id: "pointsGeometry",
-        primitive: "points",
-        positions: positions,
-        colors: colors
-    });
-
     sceneModel.createMesh({
         id: "pointsMesh",
-        geometryId: "pointsGeometry",
+        primitive: "points",
+        positions: positions,
+        colors: colors,
         position: [-7, 0, 0],
         scale: [4, 4, 4],
         rotation: [0, 0, 0]

--- a/examples/scenemodel/vbo_batching_geometries.html
+++ b/examples/scenemodel/vbo_batching_geometries.html
@@ -276,16 +276,11 @@
         i++;
     }
 
-    sceneModel.createGeometry({
-        id: "pointsGeometry",
-        primitive: "points",
-        positions: positions,
-        colors: colors
-    });
-
     sceneModel.createMesh({
         id: "pointsMesh",
-        geometryId: "pointsGeometry",
+        primitive: "points",
+        positions: positions,
+        colors: colors,
         position: [-7, 0, 0],
         scale: [4, 4, 4],
         rotation: [0, 0, 0]

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -32,6 +32,10 @@ export default defineConfig({
     trace: 'on-first-retry',
   },
 
+  snapshotPathTemplate: ((process.env.PLAYWRIGHT_LOCAL && (process.env.PLAYWRIGHT_LOCAL !== "0"))
+                         ? '{testDir}/snapshots/{testFilePath}_{arg}_{projectName}{ext}'
+                         : undefined),
+
   /* Configure projects for major browsers */
   projects: [
     {

--- a/test-scenes/scenegraph/materials_Fresnel.html
+++ b/test-scenes/scenegraph/materials_Fresnel.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="../css/pageStyle.css" rel="stylesheet" />
+  </head>
+  <body>
+    <canvas id="myCanvas"></canvas>
+  </body>
+
+  <script id="source" type="module">
+
+    import { signalTestComplete } from "../lib/utils.js";
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Import the modules we need for this example
+    //------------------------------------------------------------------------------------------------------------------
+
+    import {
+        Viewer,
+        Mesh,
+        buildTorusGeometry,
+        ReadableGeometry,
+        PhongMaterial,
+        Texture,
+        Fresnel
+    } from "../../dist/xeokit-sdk.min.es.js";
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a Viewer and arrange the camera
+    //------------------------------------------------------------------------------------------------------------------
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas",
+        transparent: true
+    });
+
+    viewer.scene.camera.eye = [0, 0, 5];
+    viewer.scene.camera.look = [0, 0, 0];
+    viewer.scene.camera.up = [0, 1, 0];
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a mesh with torus shape and PhongMaterial
+    //------------------------------------------------------------------------------------------------------------------
+
+    new Mesh(viewer.scene, {
+        geometry: new ReadableGeometry(viewer.scene, buildTorusGeometry({
+            center: [0, 0, 0],
+            radius: 1.5,
+            tube: 0.5,
+            radialSegments: 32,
+            tubeSegments: 24,
+            arc: Math.PI * 2.0
+        })),
+        material: new PhongMaterial(viewer.scene, {
+            alpha: 0.9,
+            alphaMode: "blend",
+            ambient: [0.0, 0.0, 0.0],
+            shininess: 30,
+            diffuseMap: new Texture(viewer.scene, {
+                src: "../../assets/textures/diffuse/uvGrid2.jpg"
+            }),
+            alphaFresnel: new Fresnel(viewer.scene, {
+                edgeBias: 0.2,
+                centerBias: 0.8,
+                edgeColor: [1.0, 1.0, 1.0],
+                centerColor: [0.0, 0.0, 0.0],
+                power: 2
+            })
+        })
+    });
+
+    signalTestComplete(viewer);
+
+  </script>
+</html>

--- a/test-scenes/scenegraph/materials_LambertMaterial.html
+++ b/test-scenes/scenegraph/materials_LambertMaterial.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="../css/pageStyle.css" rel="stylesheet" />
+  </head>
+  <body>
+    <canvas id="myCanvas"></canvas>
+  </body>
+
+  <script id="source" type="module">
+
+    import { signalTestComplete } from "../lib/utils.js";
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Import the modules we need for this example
+    //------------------------------------------------------------------------------------------------------------------
+
+    import {Viewer, Mesh, buildTorusGeometry, ReadableGeometry, LambertMaterial} from "../../dist/xeokit-sdk.min.es.js";
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a Viewer and arrange the camera
+    //------------------------------------------------------------------------------------------------------------------
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas"
+    });
+
+    viewer.scene.camera.eye = [0, 0, 5];
+    viewer.scene.camera.look = [0, 0, 0];
+    viewer.scene.camera.up = [0, 1, 0];
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a mesh with torus shape and LambertMaterial
+    //------------------------------------------------------------------------------------------------------------------
+
+    new Mesh(viewer.scene, {
+        geometry: new ReadableGeometry(viewer.scene, buildTorusGeometry({
+            center: [0, 0, 0],
+            radius: 1.5,
+            tube: 0.5,
+            radialSegments: 12,
+            tubeSegments: 8,
+            arc: Math.PI * 2.0
+        })),
+        material: new LambertMaterial(viewer.scene, {
+            ambient: [0.3, 0.3, 0.3],
+            color: [0.5, 0.5, 0.0],
+            alpha: 1.0, // Default
+            lineWidth: 1,
+            pointSize: 1,
+            backfaces: false,
+            frontFace: "ccw"
+        })
+    });
+
+    signalTestComplete(viewer);
+
+  </script>
+</html>

--- a/test-scenes/scenegraph/materials_MetallicMaterial.html
+++ b/test-scenes/scenegraph/materials_MetallicMaterial.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="../css/pageStyle.css" rel="stylesheet" />
+  </head>
+  <body>
+    <canvas id="myCanvas"></canvas>
+  </body>
+
+  <script id="source" type="module">
+
+    import { signalTestComplete } from "../lib/utils.js";
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Import the modules we need for this example
+    //------------------------------------------------------------------------------------------------------------------
+
+    import {
+        sRGBEncoding,
+        Viewer,
+        Mesh,
+        loadOBJGeometry,
+        ReadableGeometry,
+        MetallicMaterial,
+        Texture,
+        DirLight
+    } from "../../dist/xeokit-sdk.min.es.js";
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a Viewer and arrange the camera
+    //------------------------------------------------------------------------------------------------------------------
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas"
+    });
+
+    viewer.scene.camera.eye = [0.57, 1.37, 1.14];
+    viewer.scene.camera.look = [0.04, 0.58, 0.00];
+    viewer.scene.camera.up = [-0.22, 0.84, -0.48];
+
+    viewer.scene.gammaOutput = true;
+    viewer.scene.gammaFactor = 2.0;
+
+    viewer.scene.clearLights();
+
+    new DirLight(viewer.scene, {
+        dir: [0.8, -0.6, -0.8],
+        color: [1.0, 1.0, 1.0],
+        intensity: 1.0,
+        space: "view"
+    });
+
+    new DirLight(viewer.scene, {
+        dir: [-0.8, -0.4, -0.4],
+        color: [1.0, 1.0, 1.0],
+        intensity: 1.0,
+        space: "view"
+    });
+
+    new DirLight(viewer.scene, {
+        dir: [0.2, -0.8, 0.8],
+        color: [1.0, 1.0, 1.0],
+        intensity: 1.0,
+        space: "view"
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a mesh with torus shape
+    //------------------------------------------------------------------------------------------------------------------
+
+    loadOBJGeometry(viewer.scene, {
+        src: "../../assets/models/obj/fireHydrant/FireHydrantMesh.obj"
+    })
+    .then(function (geometry) {
+
+        // Success
+
+        new Mesh(viewer.scene, {
+
+            geometry: new ReadableGeometry(viewer.scene, geometry),
+
+            material: new MetallicMaterial(viewer.scene, {
+
+                baseColor: [1, 1, 1],
+                metallic: 1.0,
+                roughness: 1.0,
+
+                baseColorMap: new Texture(viewer.scene, {
+                    src: "../../assets/models/obj/fireHydrant/fire_hydrant_Base_Color.png",
+                    encoding: sRGBEncoding
+                }),
+                normalMap: new Texture(viewer.scene, {
+                    src: "../../assets/models/obj/fireHydrant/fire_hydrant_Normal_OpenGL.png"
+                }),
+                roughnessMap: new Texture(viewer.scene, {
+                    src: "../../assets/models/obj/fireHydrant/fire_hydrant_Roughness.png"
+                }),
+                metallicMap: new Texture(viewer.scene, {
+                    src: "../../assets/models/obj/fireHydrant/fire_hydrant_Metallic.png"
+                }),
+                occlusionMap: new Texture(viewer.scene, {
+                    src: "../../assets/models/obj/fireHydrant/fire_hydrant_Mixed_AO.png"
+                }),
+
+                specularF0: 0.7
+            })
+        });
+    },
+          function () {
+              // Error
+          });
+
+    signalTestComplete(viewer);
+
+  </script>
+</html>

--- a/test-scenes/scenegraph/materials_MetallicMaterialLightReflection.html
+++ b/test-scenes/scenegraph/materials_MetallicMaterialLightReflection.html
@@ -1,0 +1,146 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="../css/pageStyle.css" rel="stylesheet" />
+  </head>
+  <body>
+    <canvas id="myCanvas"></canvas>
+  </body>
+
+  <script id="source" type="module">
+
+    import { signalTestComplete } from "../lib/utils.js";
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Import the modules we need for this example
+    //------------------------------------------------------------------------------------------------------------------
+
+    import {
+        LinearEncoding,
+        sRGBEncoding,
+        Viewer,
+        Mesh,
+        loadOBJGeometry,
+        ReadableGeometry,
+        MetallicMaterial,
+        Texture,
+        DirLight,
+        LightMap,
+        ReflectionMap
+    } from "../../dist/xeokit-sdk.min.es.js";
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a Viewer and arrange the camera
+    //------------------------------------------------------------------------------------------------------------------
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas"
+    });
+
+    new ReflectionMap(viewer.scene, {
+        src: [
+            "../../assets/textures/reflect/Uffizi_Gallery/Uffizi_Gallery_Radiance_PX.png",
+            "../../assets/textures/reflect/Uffizi_Gallery/Uffizi_Gallery_Radiance_NX.png",
+            "../../assets/textures/reflect/Uffizi_Gallery/Uffizi_Gallery_Radiance_PY.png",
+            "../../assets/textures/reflect/Uffizi_Gallery/Uffizi_Gallery_Radiance_NY.png",
+            "../../assets/textures/reflect/Uffizi_Gallery/Uffizi_Gallery_Radiance_PZ.png",
+            "../../assets/textures/reflect/Uffizi_Gallery/Uffizi_Gallery_Radiance_NZ.png"
+        ],
+        encoding: sRGBEncoding
+    });
+
+    new LightMap(viewer.scene, {
+        src: [
+            "../../assets/textures/light/Uffizi_Gallery/Uffizi_Gallery_Irradiance_PX.png",
+            "../../assets/textures/light/Uffizi_Gallery/Uffizi_Gallery_Irradiance_NX.png",
+            "../../assets/textures/light/Uffizi_Gallery/Uffizi_Gallery_Irradiance_PY.png",
+            "../../assets/textures/light/Uffizi_Gallery/Uffizi_Gallery_Irradiance_NY.png",
+            "../../assets/textures/light/Uffizi_Gallery/Uffizi_Gallery_Irradiance_PZ.png",
+            "../../assets/textures/light/Uffizi_Gallery/Uffizi_Gallery_Irradiance_NZ.png"
+        ],
+        encoding: sRGBEncoding
+    });
+
+    viewer.scene.camera.eye = [0.57, 1.37, 1.14];
+    viewer.scene.camera.look = [0.04, 0.58, 0.00];
+    viewer.scene.camera.up = [-0.22, 0.84, -0.48];
+
+    viewer.scene.gammaOutput = true;
+    viewer.scene.gammaFactor = 2.0;
+
+    viewer.scene.clearLights();
+
+    new DirLight(viewer.scene, {
+        dir: [0.8, -0.6, -0.8],
+        color: [1.0, 1.0, 1.0],
+        intensity: 1.0,
+        space: "view"
+    });
+
+    new DirLight(viewer.scene, {
+        dir: [-0.8, -0.4, -0.4],
+        color: [1.0, 1.0, 1.0],
+        intensity: 1.0,
+        space: "view"
+    });
+
+    new DirLight(viewer.scene, {
+        dir: [0.2, -0.8, 0.8],
+        color: [1.0, 1.0, 1.0],
+        intensity: 1.0,
+        space: "view"
+    });
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a mesh with torus shape
+    //------------------------------------------------------------------------------------------------------------------
+
+    loadOBJGeometry(viewer.scene, {
+        src: "../../assets/models/obj/fireHydrant/FireHydrantMesh.obj"
+    })
+    .then(function (geometry) {
+
+        // Success
+
+        new Mesh(viewer.scene, {
+
+            geometry: new ReadableGeometry(viewer.scene, geometry),
+
+            material: new MetallicMaterial(viewer.scene, {
+
+                baseColor: [1, 1, 1],
+                metallic: 1.0,
+                roughness: 1.0,
+
+                baseColorMap: new Texture(viewer.scene, {
+                    src: "../../assets/models/obj/fireHydrant/fire_hydrant_Base_Color.png",
+                    encoding: sRGBEncoding
+                }),
+                normalMap: new Texture(viewer.scene, {
+                    src: "../../assets/models/obj/fireHydrant/fire_hydrant_Normal_OpenGL.png"
+                }),
+                roughnessMap: new Texture(viewer.scene, {
+                    src: "../../assets/models/obj/fireHydrant/fire_hydrant_Roughness.png"
+                }),
+                metallicMap: new Texture(viewer.scene, {
+                    src: "../../assets/models/obj/fireHydrant/fire_hydrant_Metallic.png"
+                }),
+                occlusionMap: new Texture(viewer.scene, {
+                    src: "../../assets/models/obj/fireHydrant/fire_hydrant_Mixed_AO.png"
+                }),
+
+                specularF0: 0.7
+            })
+        });
+    },
+          function () {
+              // Error
+          });
+
+    signalTestComplete(viewer);
+
+  </script>
+</html>

--- a/test-scenes/slicing/SectionCaps_at_distance.html
+++ b/test-scenes/slicing/SectionCaps_at_distance.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="../css/pageStyle.css" rel="stylesheet" />
+  </head>
+  <body>
+    <canvas id="myCanvas"></canvas>
+  </body>
+
+  <script type="module">
+
+    import { signalTestComplete } from "../lib/utils.js";
+
+    // Without the fix introduced for XCD-306 the SectionCaps will render off
+    const testOrigin = [10000000.5, -10000000.5, -10000000.5];
+
+    import { buildBoxGeometry, math, PhongMaterial, SceneModel, SectionPlanesPlugin, Texture, Viewer } from "../../dist/xeokit-sdk.min.es.js";
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas",
+        transparent: true,
+        readableGeometryEnabled: true
+    });
+
+    const cameraControl = viewer.cameraControl;
+    cameraControl.navMode = "orbit";
+    cameraControl.followPointer = true;
+
+    const sceneModel = new SceneModel(viewer.scene, { isModel: true });
+
+    const box = buildBoxGeometry({ center: testOrigin });
+
+    const boxMesh = sceneModel.createMesh({
+        id: "box",
+        primitive: "solid",
+        indices:   box.indices,
+        positions: box.positions,
+        uv:        box.uvs,
+        color:     [0,1,0]
+    });
+
+    sceneModel.createEntity({
+        id: boxMesh.id + "_Entity",
+        isObject: true,
+        meshIds: [ boxMesh.id ]
+    });
+
+    sceneModel.finalize();
+
+    const capMaterial = new PhongMaterial(viewer.scene, {
+        backfaces: true,
+        diffuseMap: new Texture(viewer.scene, {
+            src: "../../assets/textures/diffuse/uvGrid2.jpg"
+        }),
+    });
+    Object.values(sceneModel.objects).forEach(entity => { entity.capMaterial = capMaterial; });
+
+    const sectionPlanes = new SectionPlanesPlugin(viewer);
+
+    const sectionPlane2 = sectionPlanes.createSectionPlane({
+        id: "mySectionPlane2",
+        pos: math.addVec3([5,4.7,-5], testOrigin),
+        dir: [0.3419620945030424, -0.8758176019282808, -0.3405957340832203]
+    });
+    sectionPlanes.showControl(sectionPlane2.id);
+
+    const camera = viewer.camera;
+    camera.eye  = math.addVec3([-3,3,3], testOrigin);
+    camera.look = math.addVec3([0,0,0], testOrigin);
+    camera.up   = [0,1,0];
+
+    signalTestComplete(viewer);
+
+  </script>
+</html>

--- a/tests/lib.js
+++ b/tests/lib.js
@@ -2,25 +2,35 @@ import percySnapshot from "@percy/playwright";
 import { test, expect } from "@playwright/test";
 import "dotenv/config";
 
-async function testPage(pageName, callWithPage) {
-    return test(`should check if scene loaded for ${pageName}`, async ({ page }) => {
-        const loadedContent = page.locator("#percyLoaded");
-        await page.goto(`http://localhost:8080/test-scenes/${pageName}.html`);
+const testPage = ((process.env.PLAYWRIGHT_LOCAL && (process.env.PLAYWRIGHT_LOCAL !== "0"))
+                  ? async (pageName, callWithPage) => {
+                      return test(`should check if scene loaded for ${pageName}`, async ({ page }) => {
+                          await page.goto(`http://localhost:8081/test-scenes/${pageName}.html`);
+                          await expect(page.locator("#percyLoaded")).toBeAttached({ timeout: 10000 });
 
-        await expect(loadedContent).toBeAttached();
+                          if (callWithPage) {
+                              await callWithPage(page);
+                          }
 
-        if (callWithPage) {
-            await callWithPage(page);
-        }
+                          await expect(page).toHaveScreenshot();
+                      });
+                  }
+                  : (function() {
+                      test.beforeAll("wait", async () => new Promise((resolve) => setTimeout(() => resolve("Waited 3 seconds"), 3000)));
+                      return async (pageName, callWithPage) => {
+                          return test(`should check if scene loaded for ${pageName}`, async ({ page }) => {
+                              const loadedContent = page.locator("#percyLoaded");
+                              await page.goto(`http://localhost:8080/test-scenes/${pageName}.html`);
 
-        await percySnapshot(page, pageName, { widths: [1280] });
-    });
-}
+                              await expect(loadedContent).toBeAttached();
 
-async function wait() {
-    return new Promise((resolve) => setTimeout(() => resolve("Waited 3 seconds"), 3000));
-}
+                              if (callWithPage) {
+                                  await callWithPage(page);
+                              }
 
-test.beforeAll("wait", async () => await wait());
+                              await percySnapshot(page, pageName, { widths: [1280] });
+                          });
+                      };
+                  })());
 
 export { test, testPage };

--- a/tests/lib.js
+++ b/tests/lib.js
@@ -28,7 +28,7 @@ const testPage = ((process.env.PLAYWRIGHT_LOCAL && (process.env.PLAYWRIGHT_LOCAL
                                   await callWithPage(page);
                               }
 
-                              await percySnapshot(page, pageName, { widths: [1280] });
+                              await percySnapshot(page, pageName.replaceAll("/", "_"), { widths: [1280] });
                           });
                       };
                   })());

--- a/tests/lib.js
+++ b/tests/lib.js
@@ -1,0 +1,26 @@
+import percySnapshot from "@percy/playwright";
+import { test, expect } from "@playwright/test";
+import "dotenv/config";
+
+async function testPage(pageName, callWithPage) {
+    return test(`should check if scene loaded for ${pageName}`, async ({ page }) => {
+        const loadedContent = page.locator("#percyLoaded");
+        await page.goto(`http://localhost:8080/test-scenes/${pageName}.html`);
+
+        await expect(loadedContent).toBeAttached();
+
+        if (callWithPage) {
+            await callWithPage(page);
+        }
+
+        await percySnapshot(page, pageName, { widths: [1280] });
+    });
+}
+
+async function wait() {
+    return new Promise((resolve) => setTimeout(() => resolve("Waited 3 seconds"), 3000));
+}
+
+test.beforeAll("wait", async () => await wait());
+
+export { test, testPage };

--- a/tests/snapshots-build-geometries.spec.js
+++ b/tests/snapshots-build-geometries.spec.js
@@ -1,55 +1,28 @@
-import percySnapshot from "@percy/playwright";
-import { test, expect } from "@playwright/test";
-import "dotenv/config";
-
-async function testPage(pageName) {
-  return test(`should check if scene loaded for ${pageName}`, async ({
-    page,
-  }) => {
-    const loadedContent = page.locator("#percyLoaded");
-    await page.goto(`http://localhost:8080/test-scenes/${pageName}.html`);
-
-    await expect(loadedContent).toBeAttached();
-
-    await percySnapshot(page, pageName, {
-      widths: [1280],
-    });
-  });
-}
-
-async function wait() {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve("Waited 3 seconds");
-    }, 3000);
-  });
-}
-
-test.beforeAll("wait", async () => await wait());
+import { test, testPage } from "./lib.js";
 
 test.describe("Build a scene model", async () => {
-  test.describe("check with DTX enabled", async () => {
-    testPage("dtx_batching_autocompressed_triangles");
-    testPage("dtx_batching_autocompressed_triangles_rtc");
-    testPage("dtx_batching_geometries");
-    testPage("dtx_batching_precompressed_bucketed_triangles");
-    testPage("dtx_batching_precompressed_triangles");
-    testPage("dtx_instancing_autocompressed_triangles");
-    testPage("dtx_instancing_geometries");
-    testPage("dtx_instancing_precompressed_bucketed_triangles");
-    testPage("dtx_instancing_precompressed_triangles");
-  });
+    test.describe("check with DTX enabled", async () => {
+        testPage("dtx_batching_autocompressed_triangles");
+        testPage("dtx_batching_autocompressed_triangles_rtc");
+        testPage("dtx_batching_geometries");
+        testPage("dtx_batching_precompressed_bucketed_triangles");
+        testPage("dtx_batching_precompressed_triangles");
+        testPage("dtx_instancing_autocompressed_triangles");
+        testPage("dtx_instancing_geometries");
+        testPage("dtx_instancing_precompressed_bucketed_triangles");
+        testPage("dtx_instancing_precompressed_triangles");
+    });
 
-  test.describe("check with VBO", async () => {
-    testPage("vbo_batching_autocompressed_triangles");
-    testPage("vbo_batching_autocompressed_triangles_rtc");
-    testPage("vbo_batching_geometries");
-    testPage("vbo_batching_precompressed_triangles");
-    testPage("vbo_batching_precompressed_triangles_rtc");
-    testPage("vbo_instancing_autocompressed_triangles");
-    testPage("vbo_instancing_autocompressed_triangles_rtc");
-    testPage("vbo_instancing_geometries");
-    testPage("vbo_instancing_precompressed_triangles");
-    testPage("vbo_instancing_precompressed_triangles_rtc");
-  });
+    test.describe("check with VBO", async () => {
+        testPage("vbo_batching_autocompressed_triangles");
+        testPage("vbo_batching_autocompressed_triangles_rtc");
+        testPage("vbo_batching_geometries");
+        testPage("vbo_batching_precompressed_triangles");
+        testPage("vbo_batching_precompressed_triangles_rtc");
+        testPage("vbo_instancing_autocompressed_triangles");
+        testPage("vbo_instancing_autocompressed_triangles_rtc");
+        testPage("vbo_instancing_geometries");
+        testPage("vbo_instancing_precompressed_triangles");
+        testPage("vbo_instancing_precompressed_triangles_rtc");
+    });
 });

--- a/tests/snapshots-lighting.spec.js
+++ b/tests/snapshots-lighting.spec.js
@@ -1,32 +1,5 @@
-import percySnapshot from "@percy/playwright";
-import { test, expect } from "@playwright/test";
-import "dotenv/config";
-
-async function testPage(pageName) {
-  return test(`should check if scene loaded for ${pageName}`, async ({
-    page,
-  }) => {
-    const loadedContent = page.locator("#percyLoaded");
-    await page.goto(`http://localhost:8080/test-scenes/${pageName}.html`);
-
-    await expect(loadedContent).toBeAttached();
-
-    await percySnapshot(page, pageName, {
-      widths: [1280],
-    });
-  });
-}
-
-async function wait() {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve("Waited 3 seconds");
-    }, 3000);
-  });
-}
-
-test.beforeAll("wait", async () => await wait());
+import { test, testPage } from "./lib.js";
 
 test.describe("Lighting visual test", async () => {
-  testPage("lighting_vbo_view_dir");
+    testPage("lighting_vbo_view_dir");
 });

--- a/tests/snapshots-loading-textures.spec.js
+++ b/tests/snapshots-loading-textures.spec.js
@@ -1,41 +1,13 @@
-import percySnapshot from "@percy/playwright";
-import { test, expect } from "@playwright/test";
-import "dotenv/config";
-
-async function testPage(pageName) {
-  return test(`should check if scene loaded for ${pageName}`, async ({
-    page,
-  }) => {
-    const loadedContent = page.locator("#percyLoaded");
-    await page.goto(`http://localhost:8080/test-scenes/${pageName}.html`);
-
-    await expect(loadedContent).toBeAttached();
-
-    await page.waitForTimeout(5000);
-
-    await percySnapshot(page, pageName, {
-      widths: [1280],
-    });
-  });
-}
-
-async function wait() {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve("Waited 3 seconds");
-    }, 3000);
-  });
-}
-
-test.beforeAll("wait", async () => await wait());
+import { test, testPage } from "./lib.js";
 
 test.describe("Lighting visual test", async () => {
-  testPage("vbo_batching_autocompressed_triangles_textures_jpg");
-  testPage("vbo_batching_autocompressed_triangles_textures_ktx2");
-  testPage("vbo_batching_precompressed_triangles_textures_jpg");
-  testPage("vbo_batching_precompressed_triangles_textures_ktx2");
-  testPage("vbo_instancing_autocompressed_triangles_textures_jpg");
-  testPage("vbo_instancing_autocompressed_triangles_textures_ktx2");
-  testPage("vbo_instancing_precompressed_triangles_textures_jpg");
-  testPage("vbo_instancing_precompressed_triangles_textures_ktx2");
+    const testWithTimeout = (pageName) => testPage(pageName, async (page) => await page.waitForTimeout(5000));
+    testWithTimeout("vbo_batching_autocompressed_triangles_textures_jpg");
+    testWithTimeout("vbo_batching_autocompressed_triangles_textures_ktx2");
+    testWithTimeout("vbo_batching_precompressed_triangles_textures_jpg");
+    testWithTimeout("vbo_batching_precompressed_triangles_textures_ktx2");
+    testWithTimeout("vbo_instancing_autocompressed_triangles_textures_jpg");
+    testWithTimeout("vbo_instancing_autocompressed_triangles_textures_ktx2");
+    testWithTimeout("vbo_instancing_precompressed_triangles_textures_jpg");
+    testWithTimeout("vbo_instancing_precompressed_triangles_textures_ktx2");
 });

--- a/tests/snapshots-material-effects-on-mouseover.spec.js
+++ b/tests/snapshots-material-effects-on-mouseover.spec.js
@@ -1,47 +1,19 @@
-import percySnapshot from '@percy/playwright';
-import { test, expect } from '@playwright/test';
-import 'dotenv/config';
-
-async function testPage(pageName) {
-
-    return test(`should check if scene loaded for ${pageName}`, async ({ page }) => {
-
-        const loadedContent = page.locator('#percyLoaded');
-        await page.goto(`http://localhost:8080/test-scenes/${pageName}.html`);
-
-        await expect(loadedContent).toBeAttached();
-
-        await page.mouse.move(640, 350);
-
-        await percySnapshot(page, pageName, {
-            widths: [1280]
-        });
-    });
-}
-
-async function wait() {
-    return new Promise((resolve) => { setTimeout(() => { resolve("Waited 3 seconds"); }, 3000); })
-}
-
-test.beforeAll("wait", async () => await wait());
+import { test, testPage } from "./lib.js";
 
 test.describe("Add visual effect to picked entity on mouseover", async () => {
-    testPage('effects_dtx_batching_colorize');
-    testPage('effects_dtx_batching_highlight');
-    testPage('effects_dtx_batching_opacity');
-    testPage('effects_dtx_batching_select');
-    testPage('effects_vbo_batching_colorize');
-    testPage('effects_vbo_batching_highlight');
-    testPage('effects_vbo_batching_opacity');      
-    testPage('effects_vbo_batching_select');
-    testPage('effects_vbo_batching_xray');
-    testPage('effects_vbo_instancing_colorize');
-    testPage('effects_vbo_instancing_highlight');
-    testPage('effects_vbo_instancing_opacity');
-    testPage('effects_vbo_instancing_select');
-    testPage('effects_vbo_instancing_xray');
+    const testWithMouseMove = pageName => testPage(pageName, async page => await page.mouse.move(640, 350));
+    testWithMouseMove("effects_dtx_batching_colorize");
+    testWithMouseMove("effects_dtx_batching_highlight");
+    testWithMouseMove("effects_dtx_batching_opacity");
+    testWithMouseMove("effects_dtx_batching_select");
+    testWithMouseMove("effects_vbo_batching_colorize");
+    testWithMouseMove("effects_vbo_batching_highlight");
+    testWithMouseMove("effects_vbo_batching_opacity");
+    testWithMouseMove("effects_vbo_batching_select");
+    testWithMouseMove("effects_vbo_batching_xray");
+    testWithMouseMove("effects_vbo_instancing_colorize");
+    testWithMouseMove("effects_vbo_instancing_highlight");
+    testWithMouseMove("effects_vbo_instancing_opacity");
+    testWithMouseMove("effects_vbo_instancing_select");
+    testWithMouseMove("effects_vbo_instancing_xray");
 });
-
-
-
-

--- a/tests/snapshots-materials.spec.js
+++ b/tests/snapshots-materials.spec.js
@@ -1,0 +1,9 @@
+import { test, testPage } from "./lib.js";
+
+test.describe("Materials test", async () => {
+    const testWithTimeout = (pageName) => testPage(pageName, async (page) => await page.waitForTimeout(5000));
+    testWithTimeout("scenegraph/materials_Fresnel");
+    testWithTimeout("scenegraph/materials_LambertMaterial");
+    testWithTimeout("scenegraph/materials_MetallicMaterial");
+    testWithTimeout("scenegraph/materials_MetallicMaterialLightReflection");
+});

--- a/tests/snapshots-sao.spec.js
+++ b/tests/snapshots-sao.spec.js
@@ -1,41 +1,13 @@
-import percySnapshot from '@percy/playwright';
-import { test, expect } from '@playwright/test';
-import 'dotenv/config';
-
-async function testPage(pageName) {
-
-    return test(`should check if scene loaded for ${pageName}`, async ({ page }) => {
-
-        const loadedContent = page.locator('#percyLoaded');
-        await page.goto(`http://localhost:8080/test-scenes/${pageName}.html`);
-
-        await expect(loadedContent).toBeAttached();
-
-        await percySnapshot(page, pageName, {
-            widths: [1280]
-        });
-
-    });
-}
-
-async function wait() {
-    return new Promise((resolve) => { setTimeout(() => { resolve("Waited 3 seconds"); }, 3000); })
-}
-
-test.beforeAll("wait", async () => await wait());
+import { test, testPage } from "./lib.js";
 
 test.describe("Build a scene model", async () => {
     test.describe("check with DTX enabled", async () => {
-        testPage('effects_dtx_batching_SAO');
-        testPage('effects_dtx_instancing_SAO');
+        testPage("effects_dtx_batching_SAO");
+        testPage("effects_dtx_instancing_SAO");
     });
 
     test.describe("check with VBO", async () => {
-        testPage('effects_vbo_batching_SAO');
-        testPage('effects_vbo_instancing_SAO');
+        testPage("effects_vbo_batching_SAO");
+        testPage("effects_vbo_instancing_SAO");
     });
 });
-
-
-
-

--- a/tests/snapshots-slicing.spec.js
+++ b/tests/snapshots-slicing.spec.js
@@ -1,0 +1,6 @@
+import { test, testPage } from "./lib.js";
+
+test.describe("Slicing test", async () => {
+    const testWithTimeout = (pageName) => testPage(pageName, async (page) => await page.waitForTimeout(5000));
+    testWithTimeout("slicing/SectionCaps_at_distance");
+});

--- a/tests/snapshots-snap-picking.spec.js
+++ b/tests/snapshots-snap-picking.spec.js
@@ -1,37 +1,11 @@
-import percySnapshot from '@percy/playwright';
-import { test, expect } from '@playwright/test';
-import 'dotenv/config';
-
-async function testPage(pageName) {
-
-    return test(`should check if scene loaded for ${pageName}`, async ({ page }) => {
-
-        const loadedContent = page.locator('#percyLoaded');
-        await page.goto(`http://localhost:8080/test-scenes/${pageName}.html`);
-
-        await expect(loadedContent).toBeAttached();
-
-        const mousePosition = await page.evaluate(async () => {
-            return [parseInt(window.canvasPos[0] - 10), parseInt(window.canvasPos[1] - 10)];
-        })
-        await page.mouse.move(...mousePosition);
-        await page.waitForTimeout(500);
-        await percySnapshot(page, pageName, {
-            widths: [1280]
-        });
-    });
-}
-
-async function wait() {
-    return new Promise((resolve) => { setTimeout(() => { resolve("Waited 3 seconds"); }, 3000); })
-}
-
-test.beforeAll("wait", async () => await wait());
+import { test, testPage } from "./lib.js";
 
 test.describe("Add visual effect to picked entity on mouseover", async () => {
-    testPage('snapToVertex_vbo_batching_triangles');
+    testPage("snapToVertex_vbo_batching_triangles", async (page) => {
+        const mousePosition = await page.evaluate(async () => {
+            return [parseInt(window.canvasPos[0] - 10), parseInt(window.canvasPos[1] - 10)];
+        });
+        await page.mouse.move(...mousePosition);
+        await page.waitForTimeout(500);
+    });
 });
-
-
-
-


### PR DESCRIPTION
This PR add an optional playwright run mode, by checking the `PLAYWRIGHT_LOCAL` env var:
```bash
$ PLAYWRIGHT_LOCAL=1 npx playwright test
```
In this mode playwright doesn't use percy facilities, and stores snapshots inside `tests/snapshots` directory.

Additionally this PR adds new test cases and fixes a couple of examples.

The changes are meant to help better cover `renderers-refactor` migration.