### PR TITLE
Fixing colors in BCFViewpointsPlugin.js, related to XCD-314

### DIFF
--- a/src/plugins/BCFViewpointsPlugin/BCFViewpointsPlugin.js
+++ b/src/plugins/BCFViewpointsPlugin/BCFViewpointsPlugin.js
@@ -796,7 +796,7 @@ class BCFViewpointsPlugin extends Plugin {
                     let alphaDefined = false;
 
                     if (color.length === 8) {
-                        alpha = parseInt(color.substring(0, 2), 16) / 256;
+                        alpha = parseInt(color.substring(0, 2), 16) / 255;
                         if (alpha <= 1.0 && alpha >= 0.95) {
                             alpha = 1.0;
                         }
@@ -805,9 +805,9 @@ class BCFViewpointsPlugin extends Plugin {
                     }
 
                     const colorize = [
-                        parseInt(color.substring(0, 2), 16) / 256,
-                        parseInt(color.substring(2, 4), 16) / 256,
-                        parseInt(color.substring(4, 6), 16) / 256
+                        parseInt(color.substring(0, 2), 16) / 255,
+                        parseInt(color.substring(2, 4), 16) / 255,
+                        parseInt(color.substring(4, 6), 16) / 255
                     ];
 
                     coloring.components.map(component =>


### PR DESCRIPTION
Bug related to report from XCD-314

On the left previous behaviour, on the right current
![2025-06-19_19h15_50](https://github.com/user-attachments/assets/ca2bda3a-6005-4674-82c4-fa76a8229334)
