### PR TITLE
Change snapshots-geometry.spec.js to rely on window.model

### DIFF
--- a/test-scenes/vbo_batching_autocompressed_triangles.html
+++ b/test-scenes/vbo_batching_autocompressed_triangles.html
@@ -940,7 +940,10 @@
     });
 
     sceneModel.finalize();
+
     window.viewer = viewer;
+    window.model = sceneModel;
+
     signalTestComplete(viewer);
   </script>
 </html>

--- a/test-scenes/vbo_batching_autocompressed_triangles_rtc.html
+++ b/test-scenes/vbo_batching_autocompressed_triangles_rtc.html
@@ -210,7 +210,10 @@
         isObject: true,
       });
     }
+
     window.viewer = viewer;
+    window.model = sceneModel;
+
     signalTestComplete(viewer);
   </script>
 </html>

--- a/test-scenes/vbo_batching_geometries.html
+++ b/test-scenes/vbo_batching_geometries.html
@@ -240,7 +240,10 @@
     });
 
     sceneModel.finalize();
+
     window.viewer = viewer;
+    window.model = sceneModel;
+
     signalTestComplete(viewer);
   </script>
 </html>

--- a/test-scenes/vbo_batching_precompressed_triangles.html
+++ b/test-scenes/vbo_batching_precompressed_triangles.html
@@ -217,6 +217,7 @@
 
     window.viewer = viewer;
     window.model = sceneModel;
+
     signalTestComplete(viewer);
   </script>
 </html>

--- a/test-scenes/vbo_batching_precompressed_triangles_rtc.html
+++ b/test-scenes/vbo_batching_precompressed_triangles_rtc.html
@@ -370,6 +370,8 @@
     }
 
     window.viewer = viewer;
+    window.model = sceneModel;
+
     signalTestComplete(viewer);
   </script>
 </html>

--- a/test-scenes/vbo_instancing_autocompressed_triangles.html
+++ b/test-scenes/vbo_instancing_autocompressed_triangles.html
@@ -153,7 +153,10 @@
     });
 
     sceneModel.finalize();
+
     window.viewer = viewer;
+    window.model = sceneModel;
+
     signalTestComplete(viewer);
   </script>
 </html>

--- a/test-scenes/vbo_instancing_autocompressed_triangles_rtc.html
+++ b/test-scenes/vbo_instancing_autocompressed_triangles_rtc.html
@@ -184,7 +184,10 @@
         isObject: true,
       });
     }
+
     window.viewer = viewer;
+    window.model = sceneModel;
+
     signalTestComplete(viewer);
   </script>
 </html>

--- a/test-scenes/vbo_instancing_geometries.html
+++ b/test-scenes/vbo_instancing_geometries.html
@@ -244,7 +244,10 @@
     });
 
     sceneModel.finalize();
+
     window.viewer = viewer;
+    window.model = sceneModel;
+
     signalTestComplete(viewer);
   </script>
 </html>

--- a/test-scenes/vbo_instancing_precompressed_triangles.html
+++ b/test-scenes/vbo_instancing_precompressed_triangles.html
@@ -159,7 +159,10 @@
     });
 
     sceneModel.finalize();
+
     window.viewer = viewer;
+    window.model = sceneModel;
+
     signalTestComplete(viewer);
   </script>
 </html>

--- a/test-scenes/vbo_instancing_precompressed_triangles_rtc.html
+++ b/test-scenes/vbo_instancing_precompressed_triangles_rtc.html
@@ -190,7 +190,10 @@
         isObject: true,
       });
     }
-    signalTestComplete(viewer);
+
     window.viewer = viewer;
+    window.model = sceneModel;
+
+    signalTestComplete(viewer);
   </script>
 </html>

--- a/tests/snapshots-geometry.spec.js
+++ b/tests/snapshots-geometry.spec.js
@@ -7,7 +7,7 @@ test.describe("Test geometry data", async () => {
             `getGeometryData_${pageName}`,
             `${pageName}.html`,
             async page => {
-                const data = await page.evaluate(() => JSON.stringify(Object.values(window.viewer.scene.models).map(model => model.entityList.map(entity => entity.getGeometryData()))));
+                const data = await page.evaluate(() => JSON.stringify(window.model.entityList.map(entity => entity.getGeometryData()), null, 4));
                 expect(data).toMatchSnapshot();
             });
     };


### PR DESCRIPTION
Using `Scene::models` was unreliable, as some of the models weren't registered on the `Scene`.
This PR makes the reliance explicit.