### PR TITLE
XEOK-295 Prevent errors after context loss (see XCD-306)

### DIFF
--- a/src/viewer/scene/canvas/Canvas.js
+++ b/src/viewer/scene/canvas/Canvas.js
@@ -483,7 +483,7 @@ class Canvas extends Component {
         this.canvas.removeEventListener("webglcontextlost", this._webglcontextlostListener);
         this.canvas.removeEventListener("webglcontextrestored", this._webglcontextrestoredListener);
         
-        this.gl.getExtension("WEBGL_lose_context").loseContext();
+        // this.gl.getExtension("WEBGL_lose_context").loseContext(); // disabled because of XCD-306 and XEOK-295
         this.gl = null;
         
         super.destroy();


### PR DESCRIPTION
This PR temporarily disables explicit `this.gl.getExtension("WEBGL_lose_context").loseContext()` call, as it's causing issues on some environments (e.g. React in strict mode).
Another PR will be provided later that reintroduces the behavior, but without causing those problems.
For more details see the comments starting from:
https://creoox.atlassian.net/browse/XCD-306?focusedCommentId=16444