### PR TITLE
fix pivotController position when explorer pane opens and closes

### DIFF
--- a/src/viewer/scene/CameraControl/lib/controllers/PivotController.js
+++ b/src/viewer/scene/CameraControl/lib/controllers/PivotController.js
@@ -119,19 +119,11 @@ class PivotController {
             this._pivotCanvasPos[0] = Math.floor((1 + this._pivotProjPos[0] / this._pivotProjPos[3]) * canvasWidth / 2);
             this._pivotCanvasPos[1] = Math.floor((1 - this._pivotProjPos[1] / this._pivotProjPos[3]) * canvasHeight / 2);
 
-            // data-textures: avoid to do continuous DOM layout calculations            
-            let canvasBoundingRect = canvas._lastBoundingClientRect;
-
-            if (!canvasBoundingRect || canvas._canvasSizeChanged)
-            {
-                const canvasElem = canvas.canvas;
-
-                canvasBoundingRect = canvas._lastBoundingClientRect = canvasElem.getBoundingClientRect ();
-            }
+            let canvasBoundingRect = canvas.canvas;
 
             if (this._pivotElement) {
-                this._pivotElement.style.left = (Math.floor(canvasBoundingRect.left + this._pivotCanvasPos[0]) - (this._pivotElement.clientWidth / 2) + window.scrollX) + "px";
-                this._pivotElement.style.top = (Math.floor(canvasBoundingRect.top + this._pivotCanvasPos[1]) - (this._pivotElement.clientHeight / 2) + window.scrollY) + "px";
+                this._pivotElement.style.left = (Math.floor(canvasBoundingRect.offsetParent.offsetLeft + this._pivotCanvasPos[0]) - (this._pivotElement.clientWidth / 2) + window.scrollX) + "px";
+                this._pivotElement.style.top = (Math.floor(canvasBoundingRect.offsetParent.offsetTop + this._pivotCanvasPos[1]) - (this._pivotElement.clientHeight / 2) + window.scrollY) + "px";
             }
             this._cameraDirty = false;
         }


### PR DESCRIPTION
fix pivotController position when explorer pane opens and closes