### PR TITLE
XCD-341 Apply x and y scale for billboards

### DIFF
--- a/src/viewer/scene/mesh/draw/DrawRenderer.js
+++ b/src/viewer/scene/mesh/draw/DrawRenderer.js
@@ -571,6 +571,7 @@ DrawRenderer.prototype.drawMesh = function (frameCtx, mesh) {
     }
 
     gl.uniform3fv(this._uOffset, meshState.offset);
+    gl.uniform3fv(this._uScale, mesh.scale);
 
     // Bind VBOs
 
@@ -890,6 +891,7 @@ DrawRenderer.prototype._allocate = function (mesh) {
     this._uClippable = program.getLocation("clippable");
     this._uColorize = program.getLocation("colorize");
     this._uOffset = program.getLocation("offset");
+    this._uScale = program.getLocation("scale");
 
     this._lastMaterialId = null;
     this._lastVertexBufsId = null;

--- a/src/viewer/scene/mesh/draw/DrawShaderSource.js
+++ b/src/viewer/scene/mesh/draw/DrawShaderSource.js
@@ -83,6 +83,7 @@ function buildVertexLambert(mesh) {
     src.push("uniform mat4 projMatrix;");
     src.push("uniform vec4 colorize;");
     src.push("uniform vec3 offset;");
+    src.push("uniform vec3 scale;");
     if (quantizedGeometry) {
         src.push("uniform mat4 positionsDecodeMatrix;");
     }
@@ -137,12 +138,12 @@ function buildVertexLambert(mesh) {
     }
     if (billboard === "spherical" || billboard === "cylindrical") {
         src.push("void billboard(inout mat4 mat) {");
-        src.push("   mat[0][0] = 1.0;");
+        src.push("   mat[0][0] = scale[0];");
         src.push("   mat[0][1] = 0.0;");
         src.push("   mat[0][2] = 0.0;");
         if (billboard === "spherical") {
             src.push("   mat[1][0] = 0.0;");
-            src.push("   mat[1][1] = 1.0;");
+            src.push("   mat[1][1] = scale[1];");
             src.push("   mat[1][2] = 0.0;");
         }
         src.push("   mat[2][0] = 0.0;");
@@ -351,6 +352,7 @@ function buildVertexDraw(mesh) {
     src.push("uniform  mat4 projMatrix;");
     src.push("out  vec3 vViewPosition;");
     src.push("uniform  vec3 offset;");
+    src.push("uniform  vec3 scale;");
     if (clipping) {
         src.push("out vec4 vWorldPosition;");
     }
@@ -415,12 +417,12 @@ function buildVertexDraw(mesh) {
     }
     if (billboard === "spherical" || billboard === "cylindrical") {
         src.push("void billboard(inout mat4 mat) {");
-        src.push("   mat[0][0] = 1.0;");
+        src.push("   mat[0][0] = scale[0];");
         src.push("   mat[0][1] = 0.0;");
         src.push("   mat[0][2] = 0.0;");
         if (billboard === "spherical") {
             src.push("   mat[1][0] = 0.0;");
-            src.push("   mat[1][1] = 1.0;");
+            src.push("   mat[1][1] = scale[1];");
             src.push("   mat[1][2] = 0.0;");
         }
         src.push("   mat[2][0] = 0.0;");

--- a/src/viewer/scene/mesh/emphasis/EmphasisEdgesShaderSource.js
+++ b/src/viewer/scene/mesh/emphasis/EmphasisEdgesShaderSource.js
@@ -26,6 +26,7 @@ function buildVertex(mesh) {
     src.push("uniform mat4 projMatrix;");
     src.push("uniform vec4 edgeColor;");
     src.push("uniform vec3 offset;");
+    src.push("uniform vec3 scale;");
     if (quantizedGeometry) {
         src.push("uniform mat4 positionsDecodeMatrix;");
     }
@@ -43,12 +44,12 @@ function buildVertex(mesh) {
     src.push("out vec4 vColor;");
     if (billboard === "spherical" || billboard === "cylindrical") {
         src.push("void billboard(inout mat4 mat) {");
-        src.push("   mat[0][0] = 1.0;");
+        src.push("   mat[0][0] = scale[0];");
         src.push("   mat[0][1] = 0.0;");
         src.push("   mat[0][2] = 0.0;");
         if (billboard === "spherical") {
             src.push("   mat[1][0] = 0.0;");
-            src.push("   mat[1][1] = 1.0;");
+            src.push("   mat[1][1] = scale[1];");
             src.push("   mat[1][2] = 0.0;");
         }
         src.push("   mat[2][0] = 0.0;");

--- a/src/viewer/scene/mesh/emphasis/EmphasisFillShaderSource.js
+++ b/src/viewer/scene/mesh/emphasis/EmphasisFillShaderSource.js
@@ -29,6 +29,7 @@ function buildVertex(mesh) {
     src.push("uniform mat4 projMatrix;");
     src.push("uniform vec4 colorize;");
     src.push("uniform vec3 offset;");
+    src.push("uniform vec3 scale;");
     if (quantizedGeometry) {
         src.push("uniform mat4 positionsDecodeMatrix;");
     }
@@ -78,12 +79,12 @@ function buildVertex(mesh) {
     src.push("out vec4 vColor;");
     if (billboard === "spherical" || billboard === "cylindrical") {
         src.push("void billboard(inout mat4 mat) {");
-        src.push("   mat[0][0] = 1.0;");
+        src.push("   mat[0][0] = scale[0];");
         src.push("   mat[0][1] = 0.0;");
         src.push("   mat[0][2] = 0.0;");
         if (billboard === "spherical") {
             src.push("   mat[1][0] = 0.0;");
-            src.push("   mat[1][1] = 1.0;");
+            src.push("   mat[1][1] = scale[1];");
             src.push("   mat[1][2] = 0.0;");
         }
         src.push("   mat[2][0] = 0.0;");

--- a/src/viewer/scene/mesh/occlusion/OcclusionShaderSource.js
+++ b/src/viewer/scene/mesh/occlusion/OcclusionShaderSource.js
@@ -29,6 +29,7 @@ function buildVertex(mesh) {
     src.push("uniform mat4 viewMatrix;");
     src.push("uniform mat4 projMatrix;");
     src.push("uniform vec3 offset;");
+    src.push("uniform vec3 scale;");
     if (quantizedGeometry) {
         src.push("uniform mat4 positionsDecodeMatrix;");
     }
@@ -45,12 +46,12 @@ function buildVertex(mesh) {
     }
     if (billboard === "spherical" || billboard === "cylindrical") {
         src.push("void billboard(inout mat4 mat) {");
-        src.push("   mat[0][0] = 1.0;");
+        src.push("   mat[0][0] = scale[0];");
         src.push("   mat[0][1] = 0.0;");
         src.push("   mat[0][2] = 0.0;");
         if (billboard === "spherical") {
             src.push("   mat[1][0] = 0.0;");
-            src.push("   mat[1][1] = 1.0;");
+            src.push("   mat[1][1] = scale[1];");
             src.push("   mat[1][2] = 0.0;");
         }
         src.push("   mat[2][0] = 0.0;");

--- a/src/viewer/scene/mesh/pick/PickMeshShaderSource.js
+++ b/src/viewer/scene/mesh/pick/PickMeshShaderSource.js
@@ -28,6 +28,7 @@ function buildVertex(mesh) {
     src.push("uniform mat4 projMatrix;");
     src.push("out vec4 vViewPosition;");
     src.push("uniform vec3 offset;");
+    src.push("uniform vec3 scale;");
     if (quantizedGeometry) {
         src.push("uniform mat4 positionsDecodeMatrix;");
     }
@@ -44,12 +45,12 @@ function buildVertex(mesh) {
     }
     if (billboard === "spherical" || billboard === "cylindrical") {
         src.push("void billboard(inout mat4 mat) {");
-        src.push("   mat[0][0] = 1.0;");
+        src.push("   mat[0][0] = scale[0];");
         src.push("   mat[0][1] = 0.0;");
         src.push("   mat[0][2] = 0.0;");
         if (billboard === "spherical") {
             src.push("   mat[1][0] = 0.0;");
-            src.push("   mat[1][1] = 1.0;");
+            src.push("   mat[1][1] = scale[1];");
             src.push("   mat[1][2] = 0.0;");
         }
         src.push("   mat[2][0] = 0.0;");


### PR DESCRIPTION
This fix adds the scale for billboards. Before we couldn't scale the billboards correctly (even though in examples scale is applied), so the result of the scale was looking like this for:

1. spherical (https://xeokit.github.io/xeokit-sdk/examples/scenegraph/#billboarding_Mesh_spherical)
<img width="1081" height="525" alt="2025-07-24_21h28_53" src="https://github.com/user-attachments/assets/78ea151a-1f0b-4508-bf35-eb1146a9fa93" />

2. cylindrical (https://xeokit.github.io/xeokit-sdk/examples/scenegraph/#billboarding_Mesh_cylindrical)
<img width="1054" height="576" alt="2025-07-24_21h28_45" src="https://github.com/user-attachments/assets/73137582-567c-4a91-ba9d-2b0a6f04ec86" />

After this change these examples look like this:
<img width="1166" height="646" alt="2025-07-24_21h26_42" src="https://github.com/user-attachments/assets/53313024-4b0c-4b31-ad10-7c445417b576" />

Ready to be reviewed before the merge.