### PR TITLE
refactor: update type definitions for touchPointSelector to be generic

### DIFF
--- a/types/plugins/lib/ui/index.d.ts
+++ b/types/plugins/lib/ui/index.d.ts
@@ -1,12 +1,15 @@
 import { Viewer } from "../../../viewer";
 import { PointerCircle } from "../../../extras/PointerCircle";
 
+type Vec2 = number[]
+type Vec3 = number[]
+type Ray2WorldPos<T> = (origin: Vec3, direction: Vec3) => T | null;
+
 type Cleanup = () => void;
 
 type OnCancel = () => void;
-type OnChange = () => void;
-type OnCommit = () => void;
+type OnChange<T> = (canvasPos: Vec2, worldPos: T | null) => void;
+type OnCommit<T> = (canvasPos: Vec2, worldPos: T | null) => void;
 
-type Ray2WorldPos = (origin: number[], direction: number[]) => boolean | number[];
 
-declare function touchPointSelector(viewer: Viewer, pointerCircle: PointerCircle, ray2WorldPos: Ray2WorldPos): (onCancel: OnCancel, onChange: OnChange, onCommit: OnCommit) => Cleanup;
+declare function touchPointSelector<T>(viewer: Viewer, pointerCircle: PointerCircle, ray2WorldPos: Ray2WorldPos<T>): (onCancel: OnCancel, onChange: OnChange<T>, onCommit: OnCommit<T>) => Cleanup;


### PR DESCRIPTION
@MichalDybizbanskiCreoox 
I got hint, which initially comes from you that:

> the type returned by `Ray2WorldPos` should be arbitrary but compatible with the type passed as the second parameter to `onChange` and `onCommit`

that is what I tried to introduce in type declarations.

****
Shall we narrow down generic type `<T>` to `<T extends Vec3 | PickResult>`, based on available examples:
- `Vec3` - `annotations_createWithTouch.html`
- `PickResult` - `SectionPlanesPlugin_createWithTouch.html`

or left in more generic?