### PR TITLE
XCD-349 Remove rootNode when destroy

### DIFF
--- a/src/plugins/SectionPlanesPlugin/SectionPlanesPlugin.js
+++ b/src/plugins/SectionPlanesPlugin/SectionPlanesPlugin.js
@@ -329,7 +329,8 @@ class SectionPlanesPlugin extends Plugin {
                                      })(),
                                      setQuaternion: q => { rootNode.quaternion = q; },
                                      setScale: s => { rootNode.scale = s; },
-                                     setVisible: v => { rootNode.visible = v; }
+                                     setVisible: v => { rootNode.visible = v; },
+                                     destroy: () => { rootNode.destroy() }
                                  };
                              })();
                              let unbindSectionPlane = () => { };
@@ -348,6 +349,7 @@ class SectionPlanesPlugin extends Plugin {
                                  _destroy: () => {
                                      unbindSectionPlane();
                                      ctrl.destroy();
+                                     planeRoot.destroy();
                                  },
                                  setCulled:  c => { culled = c;  updateVisible(); },
                                  setVisible: v => { visible = v; updateVisible(); },


### PR DESCRIPTION
Currently once we destroy the SectionPlanePlugin it leaves rootNode elements in the scene. For each new SectionPlane it will create again the new such Nodes and later it will keep them inside the scene even when destroy is used.

This PR removes the rootNode from the Scene when the destroy is called.