### PR TITLE
fix(XEOK-168): DotBIMLoaderPlugin - update mesh ID generation to include dbMeshId for uniqueness

### DIFF
--- a/src/plugins/DotBIMLoaderPlugin/DotBIMLoaderPlugin.js
+++ b/src/plugins/DotBIMLoaderPlugin/DotBIMLoaderPlugin.js
@@ -432,7 +432,7 @@ export class DotBIMLoaderPlugin extends Plugin {
 
                     parseDBMesh(dbMeshId, element);
 
-                    const meshId = `${objectId}-mesh`;
+                    const meshId = `${objectId}-mesh-${dbMeshId}`;
 
                     let color = element.color ? [element.color.r / 255.0, element.color.g / 255.0, element.color.b / 255.0] : [1, 1, 1];
                     let opacity = element.color ? element.color.a / 255.0 : 1.0;
@@ -505,7 +505,7 @@ export class DotBIMLoaderPlugin extends Plugin {
                             positions: trianglesCoordinates,
                             indices: [...Array(trianglesCoordinates.length / 3).keys()]
                         });
-                        const meshId = `${objectId}-mesh-${faceColor}`;
+                        const meshId = `${objectId}-mesh-${dbMeshId}-${faceColor}`;
                         const faceColorArray = faceColor.split(',').map(Number);
 
                         let color = [faceColorArray[0] / 255.0, faceColorArray[1] / 255.0, faceColorArray[2] / 255.0];


### PR DESCRIPTION
**Issue:** 
```javascript
https://xeokit.github.io/xeokit-sdk/examples/buildings/#dotbim_SmallHouse
[ERROR] [Component 'myModel']: [createMesh] SceneModel already has a mesh with this ID: ef50c104-d824-4a21-b0f2-eba1f7c04705-mesh
error @ xeokit-sdk.es.js:8140
createMesh @ xeokit-sdk.es.js:85490
parseDotBIM @ xeokit-sdk.es.js:140604
(anonymous) @ xeokit-sdk.es.js:140743
(anonymous) @ xeokit-sdk.es.js:140147
(anonymous) @ xeokit-sdk.es.js:7114
load
loadJSON @ xeokit-sdk.es.js:7105
getDotBIM @ xeokit-sdk.es.js:140145
load @ xeokit-sdk.es.js:140735
(anonymous) @ dotbim_SmallHouse.html:274
09:43:02.239 xeokit-sdk.es.js:8140 [ERROR] [Component 'myModel']: Mesh with ID "ef50c104-d824-4a21-b0f2-eba1f7c04705-mesh" already belongs to object with ID "ef50c104-d824-4a21-b0f2-eba1f7c04705" - ignoring this mesh
```

**Changes:**
- Modified the mesh ID generation in the DotBIMLoaderPlugin to include dbMeshId, ensuring that each mesh ID is unique and avoids potential conflicts.
- Updated the mesh ID format in two locations to reflect the new structure: `${objectId}-mesh-${dbMeshId}` and `${objectId}-mesh-${dbMeshId}-${faceColor}`.

<img width="1929" height="746" alt="image" src="https://github.com/user-attachments/assets/b73a374d-b4f2-4bfd-af21-453b3aec1294" />


