### PR TITLE
Update func get canvas pos from event

### DIFF
--- a/src/viewer/scene/CameraControl/lib/handlers/TouchPanRotateAndDollyHandler.js
+++ b/src/viewer/scene/CameraControl/lib/handlers/TouchPanRotateAndDollyHandler.js
@@ -9,16 +9,23 @@ const getCanvasPosFromEvent = function (event, canvasPos) {
         let element = event.target;
         let totalOffsetLeft = 0;
         let totalOffsetTop = 0;
+        let isFromCanvas = element.tagName === 'canvas'
         while (element.offsetParent) {
-            totalOffsetLeft += element.offsetLeft;
-            totalOffsetTop += element.offsetTop;
+            if (isFromCanvas) {
+                totalOffsetLeft += element.offsetLeft;
+                totalOffsetTop += element.offsetTop;
+            }
             element = element.offsetParent;
+            if (!isFromCanvas) {
+                isFromCanvas = element.tagName === 'canvas'
+            }
         }
         canvasPos[0] = event.pageX - totalOffsetLeft;
         canvasPos[1] = event.pageY - totalOffsetTop;
     }
     return canvasPos;
 };
+
 
 /**
  * @private


### PR DESCRIPTION
**Description**

When zooming on iPad, if you touch annotations or labels, the zoom level changes suddenly and causes a very uncomfortable feeling. The reason is that the function calculating the position on the canvas is incorrect.


**Before**

https://github.com/user-attachments/assets/78db64ab-4d36-4526-ac32-4ea315a86ec7


**After**

https://github.com/user-attachments/assets/42296ec5-7cad-4594-93c8-26cfe7f85d63


