### PR TITLE
XEOK-372 Import external deps from a common location

### DIFF
--- a/src/external.js
+++ b/src/external.js
@@ -1,0 +1,4 @@
+export { parse } from "@loaders.gl/core";
+export { GLTFLoader, postProcessGLTF } from "@loaders.gl/gltf";
+export { LASLoader } from "@loaders.gl/las";
+export { default as html2canvas } from "html2canvas/dist/html2canvas.esm.js";

--- a/src/plugins/GLTFLoaderPlugin/GLTFSceneModelLoader.js
+++ b/src/plugins/GLTFLoaderPlugin/GLTFSceneModelLoader.js
@@ -1,5 +1,5 @@
-import { parse } from '@loaders.gl/core';
-import { GLTFLoader, postProcessGLTF } from '@loaders.gl/gltf';
+import { parse } from "../../external.js";
+import { GLTFLoader, postProcessGLTF } from "../../external.js";
 import { sRGBEncoding } from "../../viewer/scene/constants/constants.js";
 import { core } from "../../viewer/scene/core.js";
 import { math } from "../../viewer/scene/math/math.js";

--- a/src/plugins/LASLoaderPlugin/LASLoaderPlugin.js
+++ b/src/plugins/LASLoaderPlugin/LASLoaderPlugin.js
@@ -3,9 +3,9 @@ import {SceneModel} from "../../viewer/scene/model/index.js";
 import {Plugin} from "../../viewer/Plugin.js";
 import {LASDefaultDataSource} from "./LASDefaultDataSource.js";
 import {math} from "../../viewer/index.js";
-import {parse} from '@loaders.gl/core';
-import {LASLoader} from '@loaders.gl/las';
-import {loadLASHeader} from "./loadLASHeader";
+import {parse} from "../../external.js";
+import {LASLoader} from "../../external.js";
+import {loadLASHeader} from "./loadLASHeader.js";
 
 const MAX_VERTICES = 500000; // TODO: Rough estimate
 

--- a/src/viewer/Viewer.js
+++ b/src/viewer/Viewer.js
@@ -3,7 +3,7 @@ import {CameraFlightAnimation} from "./scene/camera/CameraFlightAnimation.js";
 import {CameraControl} from "./scene/CameraControl/CameraControl.js";
 import {MetaScene} from "./metadata/MetaScene.js";
 import {LocaleService} from "./localization/LocaleService.js";
-import html2canvas from 'html2canvas/dist/html2canvas.esm.js';
+import {html2canvas} from '../external.js';
 import {math} from "./scene/math/math.js";
 import {transformToNode} from "../plugins/lib/ui/index.js";
 


### PR DESCRIPTION
Currently there are three source files that import external node dependencies:
`src/plugins/GLTFLoaderPlugin/GLTFSceneModelLoader.js`
`src/plugins/LASLoaderPlugin/LASLoaderPlugin.js`
`src/viewer/Viewer.js`

The rollup builder bundles the dependencies with the project source, so they can be used by a browser context from `dist` artifacts.

However, during development when importing the `src/index.js` directly from a browser context, the node dependencies are not resolved, and the page loading fails.

To make the external dependencies usable by a browser context, they can be built into a “loadable” JS file that exports them.
Provided such a file, the three source files that import external dependencies (listed above) can be changed to import from that file instead of node locations, and the page loads correctly.
This changing of multiple locations is not very convenient though in development scenarios, so a single location that refers to those dependencies is defined by the `src/external.js` file, which then during development is to be edited to refer to locally built “loadable” JS file if needed.

The advantages of this setup are:
1. Only a single file needs to be edited to make `src/index.js` loadable.
2. All dependencies are listed in a single location, making it slightly easier to manage and evaluate (minor).