### PR TITLE
[FIX] SceneModelEntity primitive count broken (NaN) 

### DIFF
--- a/src/viewer/scene/model/SceneModelEntity.js
+++ b/src/viewer/scene/model/SceneModelEntity.js
@@ -55,7 +55,7 @@ export class SceneModelEntity {
             const mesh = this.meshes[i];
             mesh.parent = this;
             mesh.entity = this;
-            this._numPrimitives += mesh.numPrimitives;
+            this._numPrimitives += mesh.numTriangles;
         }
 
         /**


### PR DESCRIPTION
Use [`mesh.numTriangles`](https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/scene/model/SceneModelMesh.js) instead of unknown `mesh.numPrimitives` to compute `sceneModelEntity.numPrimitives`. Maybe it works in some scenario if `numPrimitives` was added by parser or something else, but in my case it was broken loading LAZ (point cloud) models. Indeed, as `sceneModelMesh` is `undefined`, the computed `numPrimitives` is `NaN` .

