### PR TITLE
XEOK-385 Make VBO vClippable non-flat to fix stability issue

### DIFF
--- a/src/viewer/scene/model/layer/DTXLayer.js
+++ b/src/viewer/scene/model/layer/DTXLayer.js
@@ -812,9 +812,13 @@ const makeDTXRenderingAttributes = function(programVariables, isTriangle) {
     const colorsAndFlags = (offset) => perObjColsFlags(`ivec2(objectIndexCoords.x*8+${offset}, objectIndexCoords.y)`);
 
     return {
+        clippableTest: (function() {
+            const vClippable = programVariables.createVarying("uint", "vClippable", () => "flags2.r", "flat");
+            return () => `${vClippable} > 0u`;
+        })(),
+
         geometryParameters: {
             attributes: {
-                clippable:         "(flags2.r > 0u)",
                 color:             colorA,
                 flags:             iota(4).map(i => `int(flags[${i}])`),
                 metallicRoughness: null,

--- a/src/viewer/scene/model/layer/Layer.js
+++ b/src/viewer/scene/model/layer/Layer.js
@@ -156,10 +156,7 @@ export const getRenderers = (function() {
                                     appendFragmentOutputs:          programSetup.appendFragmentOutputs,
                                     cleanerEdges:                   programSetup.cleanerEdges,
                                     clipPos:                        clipPos,
-                                    clippableTest:                  (function() {
-                                        const vClippable = programVariables.createVarying("float", "vClippable", () => `${attributes.clippable} ? 1.0 : 0.0`, "flat");
-                                        return () => `${vClippable} > 0.0`;
-                                    })(),
+                                    clippableTest:                  renderingAttributes.clippableTest,
                                     clippingCaps:                   programSetup.clippingCaps,
                                     crossSections:                  scene.crossSections,
                                     discardPoints:                  setupPoints && pointsMaterial.roundPoints,

--- a/src/viewer/scene/model/layer/VBOLayer.js
+++ b/src/viewer/scene/model/layer/VBOLayer.js
@@ -970,9 +970,13 @@ const makeVBORenderingAttributes = function(programVariables, instancing, entity
     return {
         dontCullOnAlphaZero: true,
 
+        clippableTest: (function() {
+            const vClippable = programVariables.createVarying("float", "vClippable", () => `${`((int(${attributes.flags}) >> 16 & 0xF) == 1)`} ? 1.0 : 0.0`); // Using `flat uint` for vClippable causes an instability - see XEOK-385
+            return () => `${vClippable} != 0.0`;
+        })(),
+
         geometryParameters: {
             attributes: {
-                clippable:         `((int(${attributes.flags}) >> 16 & 0xF) == 1)`,
                 color:             attributes.color,
                 flags:             iota(4).map(i => ({ toString: () => `(int(${attributes.flags}) >> ${i * 4} & 0xF)` })),
                 metallicRoughness: attributes.metallicRoughness,


### PR DESCRIPTION
Fixes the instability described at XEOK-385 (using `flat uint` for vClippable).
To be investigated why the instability occurs...