### PR TITLE
Link to viewer submodule with a full path

### DIFF
--- a/src/plugins/IFCOpenShellLoaderPlugin/IFCOpenShellLoaderPlugin.js
+++ b/src/plugins/IFCOpenShellLoaderPlugin/IFCOpenShellLoaderPlugin.js
@@ -1,4 +1,4 @@
-import {math, Plugin, SceneModel, worldToRTCPositions} from "../../viewer";
+import {math, Plugin, SceneModel, worldToRTCPositions} from "../../viewer/index.js";
 
 import {IFCOpenShellDefaultDataSource} from "./IFCOpenShellDefaultDataSource.js";
 


### PR DESCRIPTION
This lets a browser resolve `viewer` imports from `IFCOpenShellLoaderPlugin`.
It'd be best to squash all #1984 commits together with this one, otherwise we'll be left with not working `master` branch commits, which is a serious obstacle to e.g. `git bisect`.