### PR TITLE
#1949 SceneModelMesh's layer reference removal

### DIFF
--- a/src/viewer/scene/model/SceneModelMesh.js
+++ b/src/viewer/scene/model/SceneModelMesh.js
@@ -415,5 +415,7 @@ export class SceneModelMesh {
      */
     _destroy() {
         this.model.scene._renderer.putPickID(this.pickId);
+
+        this.layer = null;
     }
 }


### PR DESCRIPTION
Hey,

after memory trouble shooting I've noticed big difference only after this layer reference removal from SceneModelMesh so far.

For dtx WestRiverSideHospital heap snapshot after viewer.destroy():
- before this change : 905 MB
- after this change : 92 MB

For federated Clinic model heap snapthot after viewer.destroy():
- before this change: 143 MB
- after this change: 29 MB