### PR TITLE
#1949 Component's _renderer reference removal

### DIFF
--- a/src/viewer/scene/Component.js
+++ b/src/viewer/scene/Component.js
@@ -909,6 +909,7 @@ class Component {
         this._eventCallDepth = 0;
         this._ownedComponents = null;
         this._updateScheduled = false;
+        this._renderer = null;
     }
 }
 


### PR DESCRIPTION
Hey,

I think this is the sticky reference which was causing this memory leak. Different objects (derived from Component base class) were holding the _renderer reference, while Renderer was also pointing at some of these objects, causing the GC to not delete these. After the change dtx WestRiverSideHospital heap snapshot after destroy is 18.3 MB, federated Clinic 15.5 MB.