### PR TITLE
IFC examples list refactor

### DIFF
--- a/examples/buildings/index.html
+++ b/examples/buildings/index.html
@@ -259,15 +259,15 @@
 
             "#XKT + VBOs",
 
-            ["xkt_vbo_RACHouse", "IFC4 RAC model loaded from XKT into SceneModel"],
-            ["xkt_vbo_IfcOpenHouse4", "IFC4 OpenHouse model loaded from XKT into SceneModel"],
-            ["xkt_vbo_Schependomlaan", "IFC4 Schependomlaan model loaded from XKT into SceneModel"],
-            ["xkt_vbo_Duplex", "IFC4 Duplex model loaded from XKT into SceneModel"],
-            ["xkt_vbo_HolterTower", "IFC4 Holter Tower model loaded from XKT into SceneModel"],
-            ["xkt_vbo_MAP", "IFC4 MAP model loaded from XKT into SceneModel"],
-            ["xkt_vbo_RAC", "IFC4 RAC model loaded from XKT into SceneModel"],
-            ["xkt_vbo_RME", "IFC4 RME model loaded from XKT into SceneModel"],
-            ["xkt_vbo_WaterLock", "IFC4 WaterLock model loaded from XKT into SceneModel"],
+            ["xkt_vbo_RACHouse", "IFC RAC model loaded from XKT into SceneModel"],
+            ["xkt_vbo_IfcOpenHouse4", "IFC OpenHouse model loaded from XKT into SceneModel"],
+            ["xkt_vbo_Schependomlaan", "IFC Schependomlaan model loaded from XKT into SceneModel"],
+            ["xkt_vbo_Duplex", "IFC Duplex model loaded from XKT into SceneModel"],
+            ["xkt_vbo_HolterTower", "IFC Holter Tower model loaded from XKT into SceneModel"],
+            ["xkt_vbo_MAP", "IFC MAP model loaded from XKT into SceneModel"],
+            ["xkt_vbo_RAC", "IFC RAC model loaded from XKT into SceneModel"],
+            ["xkt_vbo_RME", "IFC RME model loaded from XKT into SceneModel"],
+            ["xkt_vbo_WaterLock", "IFC WaterLock model loaded from XKT into SceneModel"],
             ["xkt_vbo_HousePlan", "House Plan model without textures loaded from XKT into SceneModel"],
             ["xkt_vbo_textures_HousePlan", "House Plan model with textures loaded from XKT into SceneModel"],
             ["xkt_vbo_federated_Clinic", "Viewing a federated BIM model loaded from XKT into SceneModels"],
@@ -277,22 +277,22 @@
 
             "#XKT + Data Textures",
 
-            ["xkt_dtx_RACHouse", "IFC4 RAC model loaded from XKT into SceneModel"],
-            ["xkt_dtx_IfcOpenHouse4", "IFC4 OpenHouse model loaded from XKT into SceneModel (data textures enabled)"],
-            ["xkt_dtx_Schependomlaan", "IFC4 Schependomlaan model loaded from XKT into SceneModel (data textures enabled)"],
-            ["xkt_dtx_HolterTower", "IFC4 Holter Tower model loaded from XKT into SceneModel (data textures enabled)"],
-            ["xkt_dtx_RAC", "IFC4 RAC model loaded from XKT into SceneModel (data textures enabled)"],
-            ["xkt_dtx_MAP", "IFC4 MAP model loaded from XKT into SceneModel (data textures enabled)"],
-            ["xkt_dtx_Store", "IFC4 Store model loaded from XKT into SceneModel (data textures enabled)"],
+            ["xkt_dtx_RACHouse", "IFC RAC model loaded from XKT into SceneModel"],
+            ["xkt_dtx_IfcOpenHouse4", "IFC OpenHouse model loaded from XKT into SceneModel (data textures enabled)"],
+            ["xkt_dtx_Schependomlaan", "IFC Schependomlaan model loaded from XKT into SceneModel (data textures enabled)"],
+            ["xkt_dtx_HolterTower", "IFC Holter Tower model loaded from XKT into SceneModel (data textures enabled)"],
+            ["xkt_dtx_RAC", "IFC RAC model loaded from XKT into SceneModel (data textures enabled)"],
+            ["xkt_dtx_MAP", "IFC MAP model loaded from XKT into SceneModel (data textures enabled)"],
+            ["xkt_dtx_Store", "IFC Store model loaded from XKT into SceneModel (data textures enabled)"],
             ["xkt_dtx_APHS", "APHS BIM model loaded from XKT into SceneModel (data textures enabled)"],
-            ["xkt_dtx_WestRiverSideHospital", "Viewing seven IFC4 BIM models (data textures enabled)"],
+            ["xkt_dtx_WestRiverSideHospital", "Viewing seven IFC BIM models (data textures enabled)"],
 
-            // ["BIMOffline_XKT_includeTypes", "Loading only IfcWalls from an IFC4 BIM model"],
-            // ["BIMOffline_XKT_objectDefaults", "Viewing an IFC2x3 BIM model, providing custom colors for IFC types"],
+            // ["BIMOffline_XKT_includeTypes", "Loading only IfcWalls from an IFC BIM model"],
+            // ["BIMOffline_XKT_objectDefaults", "Viewing an IFC BIM model, providing custom colors for IFC types"],
             ["xkt_dtx_metadata_Schependomlaan", "Using IFC metadata to X-ray an IfcBuildingStorey"],
             ["xkt_dtx_metadata_moveStoreys", "Using IFC metadata to separate IfcBuildingStoreys"],
-            // ["BIMOffline_XKT_authorMetadata", "Viewing an IFC4 BIM model with authoring data"],
-            // ["BIMOffline_XKT_Duplex_originalIFCColors", "Viewing an IFC2x3 BIM model, with colors loaded from file"],
+            // ["BIMOffline_XKT_authorMetadata", "Viewing an IFC BIM model with authoring data"],
+            // ["BIMOffline_XKT_Duplex_originalIFCColors", "Viewing an IFC BIM model, with colors loaded from file"],
             ["xkt_dtx_DemoProjekt", "Viewing a BIM model exported from ArchiCAD (data textures enabled)"],
         
             "#XKT + IfcAxisLabels",
@@ -317,7 +317,7 @@
 
             "#Binary glTF + VBOs",
 
-            ["glb_autoMetaModel_MAP", "IFC4 MAP model loaded from glTF into SceneModel using autoMetaModel option"],
+            ["glb_autoMetaModel_MAP", "IFC MAP model loaded from glTF into SceneModel using autoMetaModel option"],
             ["glb_HousePlan", "House plan model loaded from GLB into SceneModel using GLTFLoaderPlugin"],
             ["glb_VianneyHouse", "Vianney house model loaded from GLB into SceneModel using GLTFLoaderPlugin"]
         ],
@@ -337,7 +337,7 @@
         
         "cxConverterIFC": [
             "#cxConverterIFC + VBOs",
-            ["cxConverterIFC_vbo_Duplex", "IFC4 Duplex model loaded from IFC into SceneModel using CxConverterIFCPlugin"]
+            ["cxConverterIFC_vbo_Duplex", "IFC Duplex model loaded from IFC into SceneModel using CxConverterIFCPlugin"]
         ],
 
         "IfcOpenShell": [
@@ -350,15 +350,15 @@
 
             "#web-ifc + VBOs",
 
-            ["web-ifc_vbo_Duplex", "IFC4 Duplex model loaded from IFC into SceneModel using WebIFCLoaderPlugin"],
-            ["web-ifc_vbo_ignoreMetadata", "IFC4 RAC model loaded from IFC into SceneModel using WebIFCLoaderPlugin, without metadata"],
-            ["web-ifc_vbo_isolateStorey", "IFC4 Duplex model single storey loaded from IFC into SceneModel using WebIFCLoaderPlugin"],
-            ["web-ifc_vbo_MAPGroundFloor", "IFC4 MAP model ground floor loaded from IFC into SceneModel using WebIFCLoaderPlugin"],
+            ["web-ifc_vbo_Duplex", "IFC Duplex model loaded from IFC into SceneModel using WebIFCLoaderPlugin"],
+            ["web-ifc_vbo_ignoreMetadata", "IFC RAC model loaded from IFC into SceneModel using WebIFCLoaderPlugin, without metadata"],
+            ["web-ifc_vbo_isolateStorey", "IFC Duplex model single storey loaded from IFC into SceneModel using WebIFCLoaderPlugin"],
+            ["web-ifc_vbo_MAPGroundFloor", "IFC MAP model ground floor loaded from IFC into SceneModel using WebIFCLoaderPlugin"],
 
             "#web-ifc + DTX",
 
-            ["web-ifc_dtx_Duplex", "IFC4 Duplex model loaded from IFC into SceneModel using WebIFCLoaderPlugin (data textures enabled)"],
-            ["web-ifc_dtx_MAPGroundFloor", "IFC4 MAP model ground floor loaded from IFC into SceneModel using WebIFCLoaderPlugin (data textures enabled)"]
+            ["web-ifc_dtx_Duplex", "IFC Duplex model loaded from IFC into SceneModel using WebIFCLoaderPlugin (data textures enabled)"],
+            ["web-ifc_dtx_MAPGroundFloor", "IFC MAP model ground floor loaded from IFC into SceneModel using WebIFCLoaderPlugin (data textures enabled)"]
         ],
 
         "glTF": [
@@ -366,9 +366,9 @@
             "#glTF + VBOs",
 
             ["glTF_VianneyHouse", "Vianney house model loaded from glTF into SceneModel using GLTFLoaderPlugin"],
-            ["glTF_Duplex_transform", "IFC4 Duplex house model loaded from glTF into SceneModel using GLTFLoaderPlugin"],
-            ["glTF_embedded_MAP", "IFC4 MAP model loaded from glTF into SceneModel using GLTFLoaderPlugin"],
-            ["glTF_Schependomlaan", "IFC2x3 Schependomlaan house model loaded from glTF into SceneModel using GLTFLoaderPlugin"],
+            ["glTF_Duplex_transform", "IFC Duplex house model loaded from glTF into SceneModel using GLTFLoaderPlugin"],
+            ["glTF_embedded_MAP", "IFC MAP model loaded from glTF into SceneModel using GLTFLoaderPlugin"],
+            ["glTF_Schependomlaan", "IFC Schependomlaan house model loaded from glTF into SceneModel using GLTFLoaderPlugin"],
             ["glTF_DuckQuantized", "Duck model loaded from glTF with quantized vertex attributes"]
         ],
 


### PR DESCRIPTION
This PR contains 2 changes:
1. It makes the IfcOpenShellLoaderPlugin visible on the list of examples (XEOK-400)
2. It removes the version of IFCs from examples' descriptions, because it was sometimes not matching the actual ones in the files, so decided to make it simpler