### PR TITLE
XEOK-402 Pass GLTFLoaderPlugin::load::params::parseOptions to loaders.gl::parse

### DIFF
--- a/src/plugins/GLTFLoaderPlugin/GLTFLoaderPlugin.js
+++ b/src/plugins/GLTFLoaderPlugin/GLTFLoaderPlugin.js
@@ -323,6 +323,7 @@ class GLTFLoaderPlugin extends Plugin {
      * primitives. Only works while {@link DTX#enabled} is also ````true````.
      * @param {Boolean} [params.autoMetaModel] When supplied, creates a default MetaModel with a single MetaObject.
      * @param {Boolean} [params.globalizeObjectIds=false] Indicates whether to globalize each {@link Entity#id} and {@link MetaObject#id}, in case you need to prevent ID clashes with other models.
+     * @param {*} [params.parseOptions={}] Options to pass to loaders.gl parse method, eg. ````{ gltf: { excludeExtensions: { "KHR_texture_transform": false } } }````.
      * @returns {Entity} Entity representing the model, which will have {@link Entity#isModel} set ````true```` and will be registered by {@link Entity#id} in {@link Scene#models}
      */
     load(params = {}) {

--- a/src/plugins/GLTFLoaderPlugin/GLTFSceneModelLoader.js
+++ b/src/plugins/GLTFLoaderPlugin/GLTFSceneModelLoader.js
@@ -102,6 +102,7 @@ function parseGLTF(plugin, src, gltf, metaModelJSON, options, sceneModel, ok, er
     const spinner = plugin.viewer.scene.canvas.spinner;
     spinner.processes++;
     parse(gltf, GLTFLoader, {
+        ...(options.parseOptions || { }),
         baseUri: options.basePath
     }).then((gltfData) => {
         const processedGLTF = postProcessGLTF(gltfData);

--- a/types/plugins/GLTFLoaderPlugin/GLTFLoaderPlugin.d.ts
+++ b/types/plugins/GLTFLoaderPlugin/GLTFLoaderPlugin.d.ts
@@ -83,6 +83,8 @@ export declare type LoadGLTFModel = {
   performance?: boolean;
   /** When true, generate a single MetaObject that represents the entire glTF model, and a MetaObject for each entity within it. */
   autoMetaModel?: boolean;
+  /** Options to pass to loaders.gl parse method, eg. ````{ gltf: { excludeExtensions: { "KHR_texture_transform": false } } }````. */
+  parseOptions?: any;
 };
 
 /**


### PR DESCRIPTION
Example use that helps to work around https://github.com/visgl/loaders.gl/issues/3225 discovered through https://github.com/xeokit/xeokit-sdk/issues/1985:
`const model = new GLTFLoaderPlugin(viewer).load({ src: <SRC>, parseOptions: { gltf: { excludeExtensions: { "KHR_texture_transform": false } } } });` - 