### PR TITLE
Adding example of camera.perspective.far change during navigation

### DIFF
--- a/examples/performance/FastNavPlugin_changeCameraPerspectiveFar.html
+++ b/examples/performance/FastNavPlugin_changeCameraPerspectiveFar.html
@@ -1,0 +1,231 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>xeokit Example</title>
+    <link href="../css/pageStyle.css" rel="stylesheet"/>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
+    <script src="../libs/dat.gui.min.js" type="text/javascript"></script>
+    <link href="../css/dat-gui-light-style.css" rel="stylesheet"/>
+</head>
+<body>
+<input type="checkbox" id="info-button"/>
+<label for="info-button" class="info-button"><i class="far fa-3x fa-question-circle"></i></label>
+<canvas id="myCanvas"></canvas>
+<div class="slideout-sidebar">
+    <img class="info-icon" src="../../assets/images/performance_icon.png"/>
+    <h1>FastNavPlugin</h1>
+    <h2>Makes interaction smoother</h2>
+    <p>Whenever the camera moves, <a href="../../docs/class/src/plugins/FastNavPlugin/FastNavPlugin.js~FastNavPlugin.html"
+                                     target="_other">FastNavPlugin</a> it uses callback to change camera.perspective.far during navigation.</p>
+    <h3>Stats</h3>
+    <ul>
+        <li>
+            <div id="time">Loading JavaScript modules...</div>
+        </li>
+    </ul>
+    <h3>Customize</h3>
+    <div id="myDatGuiContainer"></div>
+    <h3>Components Used</h3>
+    <ul>
+        <li>
+            <a href="../../docs/class/src/viewer/Viewer.js~Viewer.html"
+               target="_other">Viewer</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js~XKTLoaderPlugin.html"
+               target="_other">XKTLoaderPlugin</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/FastNavPlugin/FastNavPlugin.js~FastNavPlugin.html"
+               target="_other">FastNavPlugin</a>
+        </li>
+        <li>
+            <a href="http://openifcmodel.cs.auckland.ac.nz/Model/Details/316"
+               target="_other">Model source</a>
+        </li>
+    </ul>
+</div>
+</body>
+<script type="module">
+
+    import {
+        FastNavPlugin,
+        Viewer,
+        XKTLoaderPlugin,
+    } from "../../dist/xeokit-sdk.min.es.js";
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a Viewer
+    //------------------------------------------------------------------------------------------------------------------
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas",
+        transparent: true,
+        pbrEnabled: false
+    });
+
+    viewer.scene.camera.eye = [1844213.5706688855,263.435007378793,-5174747.600668465];
+    viewer.scene.camera.look = [1843946.9437705153,185.07615356281406,-5174906.670642107];
+    viewer.scene.camera.up = [-0.21015345043981642,0.9695957535179334,-0.12537783706951888];
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Create a callback function that changes FAR value and returns callback which reverts that behaviour
+    //------------------------------------------------------------------------------------------------------------------
+
+    const lowQualityCameraPerspectiveFar = 2000;
+    const highQualityCameraPerspectiveFar = 100000;
+    let cameraChangedDuringRevert = false;
+
+    function changeCameraPerspectiveFar() {
+        if (cameraChangedDuringRevert) {
+            cameraChangedDuringRevert = false;
+            return null;
+        }
+        else {
+            viewer.camera.perspective.far = lowQualityCameraPerspectiveFar;
+
+            return function revert() {
+                viewer.camera.perspective.far = highQualityCameraPerspectiveFar;
+                cameraChangedDuringRevert = true;
+            }
+        }
+    }
+
+    //------------------------------------------------------------------------------------------------------------------
+    // Install FastNavPlugin
+    //------------------------------------------------------------------------------------------------------------------
+
+    const fastNavPlugin = new FastNavPlugin(viewer, {
+        hideEdges: false,
+        delayBeforeRestore: true,
+        delayBeforeRestoreSeconds: 0.2,
+        onMoved: changeCameraPerspectiveFar,
+    });
+
+    //----------------------------------------------------------------------------------------------------------------------
+    // Load nine CityGML models
+    //----------------------------------------------------------------------------------------------------------------------
+
+    const xktLoader = new XKTLoaderPlugin(viewer);
+
+    const t0 = performance.now();
+
+    document.getElementById("time").innerHTML = "Loading model 1 of 9";
+
+    xktLoader.load({
+        id: "lyon1",
+        src: "../../assets/models/xkt/v7/Lyon/Lyon1.xkt",
+        edges: true,
+        saoEnabled: true,
+        dtxEnabled: true
+    }).on("loaded", () => {
+
+        document.getElementById("time").innerHTML = "Loading model 2 of 9";
+
+        xktLoader.load({
+            id: "lyon2",
+            src: "../../assets/models/xkt/v7/Lyon/Lyon2.xkt",
+            edges: true,
+            saoEnabled: true,
+            dtxEnabled: true
+        }).on("loaded", () => {
+
+            document.getElementById("time").innerHTML = "Loading model 3 of 9";
+
+            xktLoader.load({
+                id: "lyon3",
+                src: "../../assets/models/xkt/v7/Lyon/Lyon3.xkt",
+                edges: true,
+                saoEnabled: true,
+                dtxEnabled: true
+            }).on("loaded", () => {
+
+                document.getElementById("time").innerHTML = "Loading model 4 of 9";
+
+                xktLoader.load({
+                    id: "lyon4",
+                    src: "../../assets/models/xkt/v7/Lyon/Lyon4.xkt",
+                    edges: true,
+                    saoEnabled: true,
+                    dtxEnabled: true
+                }).on("loaded", () => {
+
+                    document.getElementById("time").innerHTML = "Loading model 5 of 9";
+
+                    xktLoader.load({
+                        id: "Lyon5",
+                        src: "../../assets/models/xkt/v7/Lyon/Lyon5.xkt",
+                        edges: true,
+                        saoEnabled: true,
+                        dtxEnabled: true
+                    }).on("loaded", () => {
+
+                        document.getElementById("time").innerHTML = "Loading model 6 of 9";
+
+                        xktLoader.load({
+                            id: "Lyon6",
+                            src: "../../assets/models/xkt/v7/Lyon/Lyon6.xkt",
+                            edges: true,
+                            saoEnabled: true,
+                            dtxEnabled: true
+                        }).on("loaded", () => {
+
+                            document.getElementById("time").innerHTML = "Loading model 7 of 9";
+
+                            xktLoader.load({
+                                id: "Lyon7",
+                                src: "../../assets/models/xkt/v7/Lyon/Lyon7.xkt",
+                                edges: true,
+                                saoEnabled: true,
+                                dtxEnabled: true
+                            }).on("loaded", () => {
+
+                                document.getElementById("time").innerHTML = "Loading model 8 of 9";
+
+                                xktLoader.load({
+                                    id: "Lyon8",
+                                    src: "../../assets/models/xkt/v7/Lyon/Lyon8.xkt",
+                                    edges: true,
+                                    saoEnabled: true,
+                                    dtxEnabled: true
+                                }).on("loaded", () => {
+
+                                    document.getElementById("time").innerHTML = "Loading model 9 of 9";
+
+                                    const lyon9 = xktLoader.load({
+                                        id: "Lyon9",
+                                        src: "../../assets/models/xkt/v7/Lyon/Lyon9.xkt",
+                                        edges: true,
+                                        saoEnabled: true
+                                    });
+
+                                    lyon9.on("loaded", () => {
+
+                                        let numEntities = 0;
+
+                                        for (let id in viewer.scene.models) {
+                                            const sceneModel = viewer.scene.models[id];
+                                            numEntities += sceneModel.numEntities;
+                                        }
+
+                                        const t1 = performance.now();
+
+                                        document.getElementById("time").innerHTML = "Loaded 9 models in " + Math.floor((t1 - t0)) / 1000 + " seconds<br>Objects: " + numEntities;
+
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    window.viewer = viewer;
+
+</script>
+</html>

--- a/examples/performance/index.html
+++ b/examples/performance/index.html
@@ -264,6 +264,7 @@
             ["FastNavPlugin_hideElementsWithComplexGeometry", "FastNavPlugin - hiding elements with complex geometries while user interacts"],
             ["FastNavPlugin_hideElementsWithTypes", "FastNavPlugin - hiding elements with specific type while user interacts"],
             ["FastNavPlugin_showElementsWithTypes", "FastNavPlugin - show elements with specific type only while user interacts"],
+            ["FastNavPlugin_changeCameraPerspectiveFar", "FastNavPlugin - changes camera.perspective.far while user interacts"],
         ],
 
         "Experiments": [


### PR DESCRIPTION
This example presents the FAR value changing during interaction.

My personal opinion is it would be better user experience to generally have a control of the FAR value available for the end user e.g. by the slider. FAR changing during navigation has a poor UX when the camera is far from the model.

Still it might be used generally to point out that decreasing FAR can make performance better.