### PR TITLE
XCD-426 Change "entity-" prefix into nodeName

### DIFF
--- a/src/plugins/GLTFLoaderPlugin/GLTFSceneModelLoader.js
+++ b/src/plugins/GLTFLoaderPlugin/GLTFSceneModelLoader.js
@@ -427,11 +427,10 @@ function loadDefaultScene(ctx) {
             const nodeName = node.name;
             let entityId = (((nodeName !== undefined) && (nodeName !== null) && nodeName)
                             ||
-                            ((depth === 0) && ("entity-" + ctx.nextId++)));
-
+                            ((depth === 0) && ("Node." + String(ctx.nextId++).padStart(4, "0"))));
             if (entityId) {
                 while (ctx.sceneModel.objects[entityId]) {
-                    entityId = "entity-" + ctx.nextId++;
+                    entityId = nodeName + "." + String(ctx.nextId++).padStart(4, "0");
                 }
                 meshIdsStack.push(meshIds);
                 meshIds = [];


### PR DESCRIPTION
Hey,

this PR fixes the issue suggested in XCD-426,
currently when we have a duplicate names e.g. two "Cube"s, we will have one "Cube" and one "entity-0".

After this change it should be "Cube" and "Cube-0".

You can test it on e.g. public model called HousePlan.

One thing to remember is that after this change, when the name of the element is missing, then the name will be "undefined" (previously it was "entity" in such case). Please share your opinion on that.