### PR TITLE
Support GLTFLoaderPlugin::load::loadersGl parameter to load alternative loaders.gl version

### DIFF
--- a/examples/buildings/glb_alternative_loadersGl.html
+++ b/examples/buildings/glb_alternative_loadersGl.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>xeokit Example</title>
+    <link href="../css/pageStyle.css" rel="stylesheet"/>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.0/js/all.min.js"></script>
+</head>
+<body>
+<input type="checkbox" id="info-button"/>
+<label for="info-button" class="info-button"><i class="far fa-3x fa-question-circle"></i></label>
+<canvas id="myCanvas"></canvas>
+<div class="slideout-sidebar">
+    <img class="info-icon" src="../../assets/images/gltf_logo.png"/>
+    <h1>GLTFLoaderPlugin</h1>
+    <h2>Using an alternative loaders.gl version</h2>
+    <p>In this example, we're using a <a
+            href="../../docs/class/src/plugins/GLTFLoaderPlugin/GLTFLoaderPlugin.js~GLTFLoaderPlugin.html"
+            target="_other">GLTFLoaderPlugin</a> to load the <a
+            href="https://sketchfab.com/bimcc"
+            target="_other">House Plan</a> demo model from
+        binary glTF (.glb).</p>
+    <h3>Components used</h3>
+    <ul>
+        <li>
+            <a href="../../docs/class/src/viewer/Viewer.js~Viewer.html"
+               target="_other">Viewer</a>
+        </li>
+        <li>
+            <a href="../../docs/class/src/plugins/GLTFLoaderPlugin/GLTFLoaderPlugin.js~GLTFLoaderPlugin.html"
+               target="_other">GLTFLoaderPlugin</a>
+        </li>
+    </ul>
+    <h3>Assets</h3>
+    <ul>
+        <li>
+            <a href="https://sketchfab.com/bimcc" target="_other">Model source</a>
+        </li>
+    </ul>
+</div>
+</body>
+<script type="module">
+
+    // User-provided loaders.gl
+    import * as loadersGlCore from "https://cdn.jsdelivr.net/npm/@loaders.gl/core@4.4.1/+esm";
+    import * as loadersGlGltf from "https://cdn.jsdelivr.net/npm/@loaders.gl/gltf@4.4.1/+esm";
+
+    // Alternatively e.g.
+    // import * as loadersGlCore from "https://esm.sh/@loaders.gl/core@4.4.1";
+    // import * as loadersGlGltf from "https://esm.sh/@loaders.gl/gltf@4.4.1";
+
+    import {Viewer, GLTFLoaderPlugin} from "../../dist/xeokit-sdk.min.es.js";
+
+    const viewer = new Viewer({
+        canvasId: "myCanvas",
+        transparent: true,
+        dtxEnabled: false
+    });
+
+    viewer.camera.eye = [1394.38, 3.78, -247.05];
+    viewer.camera.look = [1391.46, 0.89, -244.24];
+    viewer.camera.up = [-0.41, 0.81, 0.40];
+
+    const gltfLoader = new GLTFLoaderPlugin(viewer);
+
+    const sceneModel = gltfLoader.load({
+        id: "myHousePlan",
+        src: "../../assets/models/gltf/HousePlan/glTF-Binary/HousePlan.glb",
+        loadersGl: { core: loadersGlCore, gltf: loadersGlGltf }
+    });
+
+    sceneModel.on("loaded", () => viewer.cameraFlight.jumpTo(sceneModel));
+
+    window.viewer = viewer;
+</script>
+</html>

--- a/examples/buildings/index.html
+++ b/examples/buildings/index.html
@@ -319,7 +319,8 @@
 
             ["glb_autoMetaModel_MAP", "IFC MAP model loaded from glTF into SceneModel using autoMetaModel option"],
             ["glb_HousePlan", "House plan model loaded from GLB into SceneModel using GLTFLoaderPlugin"],
-            ["glb_VianneyHouse", "Vianney house model loaded from GLB into SceneModel using GLTFLoaderPlugin"]
+            ["glb_VianneyHouse", "Vianney house model loaded from GLB into SceneModel using GLTFLoaderPlugin"],
+            ["glb_alternative_loadersGl", "Alternative loaders.gl library version"]
         ],
 
         "dotbim": [

--- a/src/plugins/GLTFLoaderPlugin/GLTFLoaderPlugin.js
+++ b/src/plugins/GLTFLoaderPlugin/GLTFLoaderPlugin.js
@@ -323,6 +323,7 @@ class GLTFLoaderPlugin extends Plugin {
      * @param {Boolean} [params.globalizeObjectIds=false] Indicates whether to globalize each {@link Entity#id} and {@link MetaObject#id}, in case you need to prevent ID clashes with other models.
      * @param {*} [params.parseOptions={}] Options to pass to loaders.gl parse method, eg. ````{ gltf: { excludeExtensions: { "KHR_texture_transform": false } } }````.
      * @param {Boolean} [params.entityPerMesh=false] Create an entity for each mesh, instead of grouping leaf meshes under their common entity.
+     * @param {*} [params.loadersGl={core,gltf}] Alternative user-provided loaders.gl library.
      * @returns {Entity} Entity representing the model, which will have {@link Entity#isModel} set ````true```` and will be registered by {@link Entity#id} in {@link Scene#models}
      */
     load(params = {}) {

--- a/src/plugins/GLTFLoaderPlugin/GLTFLoaderPlugin.js
+++ b/src/plugins/GLTFLoaderPlugin/GLTFLoaderPlugin.js
@@ -323,6 +323,9 @@ class GLTFLoaderPlugin extends Plugin {
      * @param {Boolean} [params.globalizeObjectIds=false] Indicates whether to globalize each {@link Entity#id} and {@link MetaObject#id}, in case you need to prevent ID clashes with other models.
      * @param {*} [params.parseOptions={}] Options to pass to loaders.gl parse method, eg. ````{ gltf: { excludeExtensions: { "KHR_texture_transform": false } } }````.
      * @param {Boolean} [params.entityPerMesh=false] Create an entity for each mesh, instead of grouping leaf meshes under their common entity.
+     * @param {*} [params.loadersGl={core,gltf}] Alternative user-provided loaders.gl library.
+     * This feature has been tested with loaders.gl 4.3.4 version.
+     * Because loaders.gl is supplied externally, xeokit cannot guarantee compatibility with all loaders.gl versions.
      * @returns {Entity} Entity representing the model, which will have {@link Entity#isModel} set ````true```` and will be registered by {@link Entity#id} in {@link Scene#models}
      */
     load(params = {}) {

--- a/src/plugins/GLTFLoaderPlugin/GLTFSceneModelLoader.js
+++ b/src/plugins/GLTFLoaderPlugin/GLTFSceneModelLoader.js
@@ -101,11 +101,12 @@ function getBasePath(src) {
 function parseGLTF(plugin, src, gltf, metaModelJSON, options, sceneModel, ok, error) {
     const spinner = plugin.viewer.scene.canvas.spinner;
     spinner.processes++;
-    parse(gltf, GLTFLoader, {
+    const loadersGl = options.loadersGl;
+    (loadersGl ? loadersGl.core.parse : parse)(gltf, loadersGl ? loadersGl.gltf.GLTFLoader : GLTFLoader, {
         ...(options.parseOptions || { }),
         baseUri: options.basePath
     }).then((gltfData) => {
-        const processedGLTF = postProcessGLTF(gltfData);
+        const processedGLTF = (loadersGl ? loadersGl.gltf.postProcessGLTF : postProcessGLTF)(gltfData);
         const ctx = {
             src: src,
             entityId: options.entityId,

--- a/src/plugins/GLTFLoaderPlugin/GLTFSceneModelLoader.js
+++ b/src/plugins/GLTFLoaderPlugin/GLTFSceneModelLoader.js
@@ -108,11 +108,12 @@ function getBasePath(src) {
 function parseGLTF(plugin, src, gltf, metaModelJSON, options, sceneModel, ok, error) {
     const spinner = plugin.viewer.scene.canvas.spinner;
     spinner.processes++;
-    parse(gltf, GLTFLoader, {
+    const loadersGl = options.loadersGl;
+    (loadersGl ? loadersGl.core.parse : parse)(gltf, loadersGl ? loadersGl.gltf.GLTFLoader : GLTFLoader, {
         ...(options.parseOptions || { }),
         baseUri: options.basePath
     }).then((gltfData) => {
-        const processedGLTF = postProcessGLTF(gltfData);
+        const processedGLTF = (loadersGl ? loadersGl.gltf.postProcessGLTF : postProcessGLTF)(gltfData);
         const ctx = {
             src: src,
             entityId: options.entityId,

--- a/types/plugins/GLTFLoaderPlugin/GLTFLoaderPlugin.d.ts
+++ b/types/plugins/GLTFLoaderPlugin/GLTFLoaderPlugin.d.ts
@@ -87,6 +87,16 @@ export declare type LoadGLTFModel = {
   parseOptions?: any;
   /** Create an entity for each mesh, instead of grouping leaf meshes under their common entity. */
   entityPerMesh?: boolean;
+  /** Alternative user-provided loaders.gl library. */
+  loadersGl?: {
+    core: {
+      parse: (...args: any[]) => any;
+    };
+    gltf: {
+      GLTFLoader: any;
+      postProcessGLTF: (...args: any[]) => any;
+    };
+  };
 };
 
 /**

--- a/types/plugins/GLTFLoaderPlugin/GLTFLoaderPlugin.d.ts
+++ b/types/plugins/GLTFLoaderPlugin/GLTFLoaderPlugin.d.ts
@@ -87,6 +87,20 @@ export declare type LoadGLTFModel = {
   parseOptions?: any;
   /** Create an entity for each mesh, instead of grouping leaf meshes under their common entity. */
   entityPerMesh?: boolean;
+  /**
+   * Alternative user-provided loaders.gl library.
+   * This feature has been tested with loaders.gl 4.3.4 version.
+   * Because loaders.gl is supplied externally, xeokit cannot guarantee compatibility with all loaders.gl versions.
+   */
+  loadersGl?: {
+    core: {
+      parse: (...args: any[]) => any;
+    };
+    gltf: {
+      GLTFLoader: any;
+      postProcessGLTF: (...args: any[]) => any;
+    };
+  };
 };
 
 /**


### PR DESCRIPTION
The PR makes it possible for users to inject their own loaders.gl library of any version to be used by `GLTFLoaderPlugin`.
The `GLTFLoaderPlugin::load::loadersGl` can be passed as a `{ core, gltf }` object that contains loader.gl’s core and gltf modules respectively.
If `loadersGl` object is provided, the `GLTFLoaderPlugin` will use it instead of the default v4.3.4 version.