### PR TITLE
XCD-463 Allow edges rendering for DTX & Logarithmic depth buffers

### DIFF
--- a/src/viewer/scene/model/layer/DTXLayer.js
+++ b/src/viewer/scene/model/layer/DTXLayer.js
@@ -586,17 +586,6 @@ export class DTXLayer extends Layer {
         };
 
         return {
-            edgesColorOpaqueAllowed: () => {
-                if (scene.logarithmicDepthBufferEnabled) {
-                    if (!scene._loggedWarning) {
-                        console.log("Edge enhancement for SceneModel data texture layers currently disabled with logarithmic depth buffer");
-                        scene._loggedWarning = true;
-                    }
-                    return false;
-                } else {
-                    return true;
-                }
-            },
             sortId: sortId,
             setClippableFlags: setFlags2,
             setFlags: (portionId, flags, transparent, deferred = false) => {

--- a/src/viewer/scene/model/layer/Layer.js
+++ b/src/viewer/scene/model/layer/Layer.js
@@ -617,9 +617,7 @@ export class Layer {
     }
 
     drawEdgesColorOpaque(renderFlags, frameCtx) {
-        if (this._compiledPortions.edgesColorOpaqueAllowed()) {
-            this.__drawVertexEdges(renderFlags, frameCtx, RENDER_PASSES.EDGES_COLOR_OPAQUE);
-        }
+        this.__drawVertexEdges(renderFlags, frameCtx, RENDER_PASSES.EDGES_COLOR_OPAQUE);
     }
 
     drawEdgesColorTransparent(renderFlags, frameCtx) {

--- a/src/viewer/scene/model/layer/VBOLayer.js
+++ b/src/viewer/scene/model/layer/VBOLayer.js
@@ -570,7 +570,6 @@ export class VBOLayer extends Layer {
 
         const solid = (primitive === "solid");
         return {
-            edgesColorOpaqueAllowed: () => true,
             solid: solid,
             sortId: (((primitive === "points") ? "Points" : ((primitive === "lines") ? "Lines" : "Triangles"))
                      + (instancing ? "Instancing" : "Batching") + "Layer" +


### PR DESCRIPTION
Historically there was a check set here: https://github.com/xeokit/xeokit-sdk/commit/597e1750f8cd86edf309d4be35d4afba9bce0a75#diff-6bd72372d4d3a2a508f549e864b33547c44d86e101f8aec5834c719729dd3bc5R1184

which was not allowing edges rendering in DTX if Logarithmic depth buffers were enabled.

During the discussion the conclusion was that there is no point to keep it.

This PR removes this check.

Please check and test this one during review.