### PR TITLE
XCD-482 Add information about plugin container being necessary for the getSnapshotWithPlugins

### DIFF
--- a/src/plugins/AngleMeasurementsPlugin/AngleMeasurementsPlugin.js
+++ b/src/plugins/AngleMeasurementsPlugin/AngleMeasurementsPlugin.js
@@ -251,7 +251,7 @@ export class AngleMeasurementsPlugin extends Plugin {
      * @param {Viewer} viewer The Viewer.
      * @param {Object} [cfg]  Plugin configuration.
      * @param {String} [cfg.id="AngleMeasurements"] Optional ID for this plugin, so that we can find it within {@link Viewer#plugins}.
-     * @param {HTMLElement} [cfg.container] Container DOM element for markers and labels. Defaults to ````document.body````.
+     * @param {HTMLElement} [cfg.container] Container DOM element for markers and labels. Defaults to ````document.body````, but different element should be specified to capture it with {@link Viewer.getSnapshotWithPlugins}.
      * @param {string} [cfg.defaultColor=null] The default color of the dots, wire and label.
      * @param {boolean} [cfg.defaultLabelsVisible=true] The default value of {@link AngleMeasurement.labelsVisible}.
      * @param {number} [cfg.zIndex] If set, the wires, dots and labels will have this zIndex (+1 for dots and +2 for labels).

--- a/src/plugins/AnnotationsPlugin/AnnotationsPlugin.js
+++ b/src/plugins/AnnotationsPlugin/AnnotationsPlugin.js
@@ -375,7 +375,7 @@ class AnnotationsPlugin extends Plugin {
      * @param {String} [cfg.id="Annotations"] Optional ID for this plugin, so that we can find it within {@link Viewer#plugins}.
      * @param {String} [cfg.markerHTML] HTML text template for Annotation markers. Defaults to ````<div></div>````. Ignored on {@link Annotation}s configured with a ````markerElementId````.
      * @param {String} [cfg.labelHTML] HTML text template for Annotation labels. Defaults to ````<div></div>````.  Ignored on {@link Annotation}s configured with a ````labelElementId````.
-     * @param {HTMLElement} [cfg.container] Container DOM element for markers and labels. Defaults to ````document.body````.
+     * @param {HTMLElement} [cfg.container] Container DOM element for markers and labels. Defaults to ````document.body````, but different element should be specified to capture it with {@link Viewer.getSnapshotWithPlugins}.
      * @param {{String:(String|Number)}} [cfg.values={}] Map of default values to insert into the HTML templates for the marker and label.
      * @param {Number}  [cfg.surfaceOffset=0.3] The amount by which each {@link Annotation} is offset from the surface of
      * its {@link Entity} when we create the Annotation by supplying a {@link PickResult} to {@link AnnotationsPlugin#createAnnotation}.

--- a/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsPlugin.js
+++ b/src/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsPlugin.js
@@ -269,7 +269,7 @@ class DistanceMeasurementsPlugin extends Plugin {
    * @param {Object} [cfg]  Plugin configuration.
    * @param {String} [cfg.id="DistanceMeasurements"] Optional ID for this plugin, so that we can find it within {@link Viewer#plugins}.
    * @param {Number} [cfg.labelMinAxisLength=25] The minimum length, in pixels, of an axis wire beyond which its label is shown.
-   * @param {HTMLElement} [cfg.container] Container DOM element for markers and labels. Defaults to ````document.body````.
+   * @param {HTMLElement} [cfg.container] Container DOM element for markers and labels. Defaults to ````document.body````, but different element should be specified to capture it with {@link Viewer.getSnapshotWithPlugins}.
    * @param {boolean} [cfg.defaultVisible=true] The default value of the DistanceMeasurements `visible` property.
    * @param {boolean} [cfg.defaultOriginVisible=true] The default value of the DistanceMeasurements `originVisible` property.
    * @param {boolean} [cfg.defaultTargetVisible=true] The default value of the DistanceMeasurements `targetVisible` property.

--- a/types/plugins/AngleMeasurementsPlugin/AngleMeasurementsPlugin.d.ts
+++ b/types/plugins/AngleMeasurementsPlugin/AngleMeasurementsPlugin.d.ts
@@ -7,7 +7,7 @@ export declare type AngleMeasurementsPluginConfiguration = {
   /** Optional ID for this plugin, so that we can find it within {@link Viewer.plugins}. */
   id?: string;
 
-  /** Container DOM element for markers and labels. Defaults to ````document.body````. */
+  /** Container DOM element for markers and labels. Defaults to ````document.body````, but different element should be specified to capture it with {@link Viewer.getSnapshotWithPlugins}. */
   container?: HTMLElement;
 
   /** The default color of the dots, wire and label. */

--- a/types/plugins/AnnotationsPlugin/AnnotationsPlugin.d.ts
+++ b/types/plugins/AnnotationsPlugin/AnnotationsPlugin.d.ts
@@ -9,7 +9,7 @@ export declare type AnnotationsPluginConfiguration = {
   markerHTML?: string;
   /** HTML text template for Annotation labels. Defaults to ````<div></div>````.  Ignored on {@link Annotation}s configured with a ````labelElementId````. */
   labelHTML?: string;
-  /** Container DOM element for markers and labels. Defaults to ````document.body````. */
+  /** Container DOM element for markers and labels. Defaults to ````document.body````, but different element should be specified to capture it with {@link Viewer.getSnapshotWithPlugins}. */
   container?: HTMLElement;
   /** Map of default values to insert into the HTML templates for the marker and label. */
   values?: { [key: string]: string | number };

--- a/types/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsPlugin.d.ts
+++ b/types/plugins/DistanceMeasurementsPlugin/DistanceMeasurementsPlugin.d.ts
@@ -10,7 +10,7 @@ export declare type DistanceMeasurementsPluginConfiguration = {
   /** The minimum length, in pixels, of an axis wire beyond which its label is shown. */
   labelMinAxisLength?: number;
 
-  /** Container DOM element for markers and labels. Defaults to ````document.body````. */
+  /** Container DOM element for markers and labels. Defaults to ````document.body````, but different element should be specified to capture it with {@link Viewer.getSnapshotWithPlugins}. */
   container?: HTMLElement;
 
   /** The default value of the DistanceMeasurements `visible` property. */


### PR DESCRIPTION
During XCD-482 investigation I've found out that without specifing the container getSnapshotWithPlugins doesn't capture the DOM elements of the plugin. Couldn't find this information anywhere, so decided to add it. If you think it should work without container being specified, or if you think this information is not necessary, please close the ticket.