### PR TITLE
XCD-485 Handle GLTF loops, strips, fans

### DIFF
--- a/src/plugins/GLTFLoaderPlugin/GLTFSceneModelLoader.js
+++ b/src/plugins/GLTFLoaderPlugin/GLTFSceneModelLoader.js
@@ -590,6 +590,26 @@ function parseNodeMesh(node, ctx, matrix, meshIds) {
                 meshCfg.color = new Float32Array([1.0, 1.0, 1.0]);
                 meshCfg.opacity = 1.0;
             }
+            const POSITION = primitive.attributes.POSITION;
+            if (!POSITION) {
+                continue;
+            }
+            meshCfg.localPositions = POSITION.value;
+            meshCfg.positions = new Float64Array(meshCfg.localPositions.length);
+            if (primitive.attributes.NORMAL) {
+                meshCfg.normals = primitive.attributes.NORMAL.value;
+            }
+            if (primitive.attributes.TEXCOORD_0) {
+                meshCfg.uv = primitive.attributes.TEXCOORD_0.value;
+            }
+            if (primitive.indices) {
+                meshCfg.indices = primitive.indices.value;
+            }
+            if (matrix) {
+                math.transformPositions3(matrix, meshCfg.localPositions, meshCfg.positions);
+            } else { // eqiv to math.transformPositions3(math.identityMat4(), meshCfg.localPositions, meshCfg.positions);
+                meshCfg.positions.set(meshCfg.localPositions);
+            }
             const backfaces = ((ctx.backfaces !== false) || (material && material.doubleSided !== false));
             switch (primitive.mode) {
                 case 0: // POINTS
@@ -615,26 +635,6 @@ function parseNodeMesh(node, ctx, matrix, meshIds) {
                     break;
                 default:
                     meshCfg.primitive = backfaces ? "triangles" : "solid";
-            }
-            const POSITION = primitive.attributes.POSITION;
-            if (!POSITION) {
-                continue;
-            }
-            meshCfg.localPositions = POSITION.value;
-            meshCfg.positions = new Float64Array(meshCfg.localPositions.length);
-            if (primitive.attributes.NORMAL) {
-                meshCfg.normals = primitive.attributes.NORMAL.value;
-            }
-            if (primitive.attributes.TEXCOORD_0) {
-                meshCfg.uv = primitive.attributes.TEXCOORD_0.value;
-            }
-            if (primitive.indices) {
-                meshCfg.indices = primitive.indices.value;
-            }
-            if (matrix) {
-                math.transformPositions3(matrix, meshCfg.localPositions, meshCfg.positions);
-            } else { // eqiv to math.transformPositions3(math.identityMat4(), meshCfg.localPositions, meshCfg.positions);
-                meshCfg.positions.set(meshCfg.localPositions);
             }
             const origin = math.vec3();
             const rtcNeeded = worldToRTCPositions(meshCfg.positions, meshCfg.positions, origin); // Small cellsize guarantees better accuracy

--- a/src/plugins/GLTFLoaderPlugin/GLTFSceneModelLoader.js
+++ b/src/plugins/GLTFLoaderPlugin/GLTFSceneModelLoader.js
@@ -18,6 +18,13 @@ import {
     RepeatWrapping
 } from "../../viewer/scene/constants/constants.js";
 
+const iota = n => {
+    const ret = [ ];
+    for (let i = 0; i < n; ++i)
+        ret.push(i);
+    return ret;
+};
+
 /**
  * @private
  */
@@ -610,6 +617,31 @@ function parseNodeMesh(node, ctx, matrix, meshIds) {
             } else { // eqiv to math.transformPositions3(math.identityMat4(), meshCfg.localPositions, meshCfg.positions);
                 meshCfg.positions.set(meshCfg.localPositions);
             }
+            const linearize = closeLoop => {
+                const indices = meshCfg.indices || iota(meshCfg.localPositions.length / 3);
+                const len = indices.length;
+                const cnt = closeLoop ? len : (len - 1);
+                const linesIndices = new Uint32Array(cnt * 2);
+                for (let i = 0; i < cnt; ++i) {
+                    const idx = i * 2;
+                    linesIndices[idx]   = indices[i];
+                    linesIndices[idx+1] = indices[(i+1) % len];
+                }
+                meshCfg.indices = linesIndices;
+            };
+            const triangularize = getFirstPoint => {
+                const indices = meshCfg.indices || iota(meshCfg.localPositions.length / 3);
+                const len = indices.length;
+                const cnt = len - 2;
+                const trianglesIndices = new Uint32Array(cnt * 3);
+                for (let i = 0; i < cnt; ++i) {
+                    const idx = i * 3;
+                    trianglesIndices[idx]   = getFirstPoint(indices, i);
+                    trianglesIndices[idx+1] = indices[(i+1) % len];
+                    trianglesIndices[idx+2] = indices[(i+2) % len];
+                }
+                meshCfg.indices = trianglesIndices;
+            };
             const backfaces = ((ctx.backfaces !== false) || (material && material.doubleSided !== false));
             switch (primitive.mode) {
                 case 0: // POINTS
@@ -620,18 +652,22 @@ function parseNodeMesh(node, ctx, matrix, meshIds) {
                     break;
                 case 2: // LINE_LOOP
                     meshCfg.primitive = "lines";
+                    linearize(true);
                     break;
                 case 3: // LINE_STRIP
                     meshCfg.primitive = "lines";
+                    linearize(false);
                     break;
                 case 4: // TRIANGLES
                     meshCfg.primitive = backfaces ? "triangles" : "solid";
                     break;
                 case 5: // TRIANGLE_STRIP
                     meshCfg.primitive = backfaces ? "triangles" : "solid";
+                    triangularize((indices, i) => indices[i]);
                     break;
                 case 6: // TRIANGLE_FAN
                     meshCfg.primitive = backfaces ? "triangles" : "solid";
+                    triangularize((indices, i) => indices[0]);
                     break;
                 default:
                     meshCfg.primitive = backfaces ? "triangles" : "solid";


### PR DESCRIPTION
The change converts loops, strips, and fans into corresponding individual primitives.
This could be improved in the future by handling original primitive modes in the SceneModel.