### PR TITLE
XEOK-454 Fix addMousePressListener and addTouchPressListener type declarations

### DIFF
--- a/types/plugins/lib/ui/index.d.ts
+++ b/types/plugins/lib/ui/index.d.ts
@@ -2,8 +2,8 @@ import { Viewer } from "../../../viewer";
 import { PointerCircle } from "../../../extras/PointerCircle";
 import { CameraControl } from "../../../viewer/scene/CameraControl/CameraControl";
 
-type Vec2 = number[]
-type Vec3 = number[]
+type Vec2 = number[];
+type Vec3 = number[];
 type Ray2WorldPos<T> = (origin: Vec3, direction: Vec3) => T | null;
 
 type Cleanup = () => void;
@@ -15,6 +15,6 @@ type OnCommit<T> = (canvasPos: Vec2, worldPos: T | null) => void;
 
 declare function touchPointSelector<T>(viewer: Viewer, pointerCircle: PointerCircle, ray2WorldPos: Ray2WorldPos<T>): (onCancel: OnCancel, onChange: OnChange<T>, onCommit: OnCommit<T>) => Cleanup;
 
-export declare addMousePressListener(element: HTMLElement, onChange: (canvasPos: Vec2 | null) => void);
+export declare function addMousePressListener(element: HTMLElement, onChange: (canvasPos: Vec2 | null) => void): Cleanup;
 
-export declare addTouchPressListener(element: HTMLElement, cameraControl: CameraControl, pointerCircle: PointerCircle, onChange: (canvasPos: Vec2 | null) => void);
+export declare function addTouchPressListener(element: HTMLElement, cameraControl: CameraControl, pointerCircle: PointerCircle, onChange: (canvasPos: Vec2 | null) => void): Cleanup;


### PR DESCRIPTION
Similar to #2034, but doesn't remove `export` keywords.