### PR TITLE
XCD-491 Unwanted additional rotations

### DIFF
--- a/src/viewer/scene/CameraControl/lib/CameraUpdater.js
+++ b/src/viewer/scene/CameraControl/lib/CameraUpdater.js
@@ -117,22 +117,18 @@ class CameraUpdater {
 
             if (updates.rotateDeltaY !== 0 || updates.rotateDeltaX !== 0) {
 
-                if ((!configs.firstPerson) && configs.followPointer && pivotController.getPivoting()) {
-                    pivotController.continuePivot(updates.rotateDeltaY, updates.rotateDeltaX);
-                    pivotController.showPivot();
-
-                } else {
-
+                if (configs.firstPerson) {
                     if (updates.rotateDeltaX !== 0) {
-                        if (configs.firstPerson) {
-                            camera.pitch(-updates.rotateDeltaX);
-                        }
+                        camera.pitch(-updates.rotateDeltaX);
                     }
-
                     if (updates.rotateDeltaY !== 0) {
-                        if (configs.firstPerson) {
-                            camera.yaw(updates.rotateDeltaY);
-                        }
+                        camera.yaw(updates.rotateDeltaY);
+                    }
+                }
+                else {
+                    if (configs.followPointer && pivotController.getPivoting()){
+                        pivotController.continuePivot(updates.rotateDeltaY, updates.rotateDeltaX);
+                        pivotController.showPivot();
                     }
                 }
 

--- a/src/viewer/scene/CameraControl/lib/CameraUpdater.js
+++ b/src/viewer/scene/CameraControl/lib/CameraUpdater.js
@@ -126,16 +126,12 @@ class CameraUpdater {
                     if (updates.rotateDeltaX !== 0) {
                         if (configs.firstPerson) {
                             camera.pitch(-updates.rotateDeltaX);
-                        } else {
-                            camera.orbitPitch(updates.rotateDeltaX);
                         }
                     }
 
                     if (updates.rotateDeltaY !== 0) {
                         if (configs.firstPerson) {
                             camera.yaw(updates.rotateDeltaY);
-                        } else {
-                            camera.orbitYaw(updates.rotateDeltaY);
                         }
                     }
                 }


### PR DESCRIPTION
Hello @MichalDybizbanskiCreoox and @xeolabs,

This change:
1. removes the additional setting of the yaw and pitch in the CameraUpdater for non-FirstPerson mode (https://github.com/xeokit/xeokit-sdk/commit/644737c3a72fd1bcc6255e2b2928a333ef168e78)
2. refactors this part of code to make it clearer (https://github.com/xeokit/xeokit-sdk/commit/939d76571baab48f5f235ffd86f7efd1767e9df3)

For some mouse interactions user recieved tiny extra camera rotations (when pivotController.getPivoting() = false but when updates.rotateDeltaY !== 0 || updates.rotateDeltaX !== 0).

These tiny extra rotations were barely visible, but in the specific case when you are looking straight at the Top of the cube, then once you received this tiny extra rotation it ignored the limits of the PivotController: https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/scene/CameraControl/lib/controllers/PivotController.js#L309-L320, and let you be above the Top. And once you are above the Top the next mouse interaction will lead to 180 flip of the model (Top upside-down), which is the result of the lookAt matrix calculation.

This PR tries to remove these additional extra camera rotations in the CameraUpdater, as they seem to be unintentional, and in the end lead to this bug. However: if you know the reason that they should stay there - please let me know.

Wojciech