### PR TITLE
XEOK-465 Extend reuseGeometries to function type

### DIFF
--- a/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
+++ b/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
@@ -610,7 +610,7 @@ class XKTLoaderPlugin extends Plugin {
      * @param {String[]} [cfg.includeTypes] When loading metadata, only loads objects that have {@link MetaObject}s with {@link MetaObject#type} values in this list.
      * @param {String[]} [cfg.excludeTypes] When loading metadata, never loads objects that have {@link MetaObject}s with {@link MetaObject#type} values in this list.
      * @param {Boolean} [cfg.excludeUnclassifiedObjects=false] When loading metadata and this is ````true````, will only load {@link Entity}s that have {@link MetaObject}s (that are not excluded). This is useful when we don't want Entitys in the Scene that are not represented within IFC navigation components, such as {@link TreeViewPlugin}.
-     * @param {Boolean} [cfg.reuseGeometries=true] Indicates whether to enable geometry reuse (````true```` by default) or whether to internally expand
+     * @param {Boolean|Function} [cfg.reuseGeometries=true] Indicates whether to enable geometry reuse (````true```` by default) or whether to internally expand, a function will be called with a `{ instanceCount: <number> }` argument.
      * all geometry instances into batches (````false````), and not use instancing to render them. Setting this ````false```` can significantly
      * improve Viewer performance for models that have a lot of geometry reuse, but may also increase the amount of
      * browser and GPU memory they require. See [#769](https://github.com/xeokit/xeokit-sdk/issues/769) for more info.
@@ -878,7 +878,7 @@ class XKTLoaderPlugin extends Plugin {
      * @type {Boolean}
      */
     set reuseGeometries(value) {
-        this._reuseGeometries = value !== false;
+        this._reuseGeometries = value;
     }
 
     /**
@@ -920,7 +920,7 @@ class XKTLoaderPlugin extends Plugin {
      * Viewer will hide backfaces on watertight meshes, show backfaces on open meshes, and always show backfaces on meshes when we slice them open with {@link SectionPlane}s.
      * @param {Boolean} [params.excludeUnclassifiedObjects=false] When loading metadata and this is ````true````, will only load {@link Entity}s that have {@link MetaObject}s (that are not excluded). This is useful when we don't want Entitys in the Scene that are not represented within IFC navigation components, such as {@link TreeViewPlugin}.
      * @param {Boolean} [params.globalizeObjectIds=false] Indicates whether to globalize each {@link Entity#id} and {@link MetaObject#id}, in case you need to prevent ID clashes with other models. See {@link XKTLoaderPlugin#globalizeObjectIds} for more info.
-     * @param {Boolean} [params.reuseGeometries=true] Indicates whether to enable geometry reuse (````true```` by default) or whether to expand
+     * @param {Boolean|Function} [params.reuseGeometries=true] Indicates whether to enable geometry reuse (````true```` by default) or whether to expand, a function will be called with a `{ instanceCount: <number> }` argument.
      * all geometry instances into batches (````false````), and not use instancing to render them. Setting this ````false```` can significantly
      * improve Viewer performance for models that have excessive geometry reuse, but may also increases the amount of
      * browser and GPU memory used by the model. See [#769](https://github.com/xeokit/xeokit-sdk/issues/769) for more info.
@@ -949,7 +949,8 @@ class XKTLoaderPlugin extends Plugin {
         const includeIds = params.includeIds || this._includeIds;
         const objectDefaults = params.objectDefaults || this._objectDefaults;
 
-        options.reuseGeometries = (params.reuseGeometries !== null && params.reuseGeometries !== undefined) ? params.reuseGeometries : (this._reuseGeometries !== false);
+        const reuseGeometries = params.reuseGeometries ?? this._reuseGeometries;
+        options.reuseGeometries = (typeof reuseGeometries !== "function") ? (() => reuseGeometries) : reuseGeometries;
 
         if (includeTypes) {
             options.includeTypesMap = {};

--- a/src/plugins/XKTLoaderPlugin/parsers/ParserV10.js
+++ b/src/plugins/XKTLoaderPlugin/parsers/ParserV10.js
@@ -391,7 +391,7 @@ function load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx)
 
                     if (!geometryArrays) {
                         geometryArrays = {
-                            batchThisMesh: (!options.reuseGeometries)
+                            batchThisMesh: (!options.reuseGeometries({ instanceCount: geometryReuseCount }))
                         };
                         const primitiveType = eachGeometryPrimitiveType[geometryIndex];
                         let geometryValid = false;

--- a/src/plugins/XKTLoaderPlugin/parsers/ParserV11.js
+++ b/src/plugins/XKTLoaderPlugin/parsers/ParserV11.js
@@ -384,7 +384,7 @@ function load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx)
 
                     if (!geometryArrays) {
                         geometryArrays = {
-                            batchThisMesh: (!options.reuseGeometries)
+                            batchThisMesh: (!options.reuseGeometries({ instanceCount: geometryReuseCount }))
                         };
                         const primitiveType = eachGeometryPrimitiveType[geometryIndex];
                         let geometryValid = false;

--- a/src/plugins/XKTLoaderPlugin/parsers/ParserV12.js
+++ b/src/plugins/XKTLoaderPlugin/parsers/ParserV12.js
@@ -469,7 +469,7 @@ function load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx)
 
                     if (!geometryArrays) {
                         geometryArrays = {
-                            batchThisMesh: (!options.reuseGeometries)
+                            batchThisMesh: (!options.reuseGeometries({ instanceCount: geometryReuseCount }))
                         };
                         const primitiveType = eachGeometryPrimitiveType[geometryIndex];
                         const axisLabel = eachGeometryAxisLabel[geometryIndex];

--- a/src/plugins/XKTLoaderPlugin/parsers/ParserV8.js
+++ b/src/plugins/XKTLoaderPlugin/parsers/ParserV8.js
@@ -341,7 +341,7 @@ function load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx)
                     if (!geometryArrays) {
 
                         geometryArrays = {
-                            batchThisMesh: (!options.reuseGeometries)
+                            batchThisMesh: (!options.reuseGeometries({ instanceCount: geometryReuseCount }))
                         };
 
                         const primitiveType = eachGeometryPrimitiveType[geometryIndex];

--- a/src/plugins/XKTLoaderPlugin/parsers/ParserV9.js
+++ b/src/plugins/XKTLoaderPlugin/parsers/ParserV9.js
@@ -297,7 +297,7 @@ function load(viewer, options, inflatedData, sceneModel, metaModel, manifestCtx)
 
                     if (!geometryArrays) {
                         geometryArrays = {
-                            batchThisMesh: (!options.reuseGeometries)
+                            batchThisMesh: (!options.reuseGeometries({ instanceCount: geometryReuseCount }))
                         };
                         const primitiveType = eachGeometryPrimitiveType[geometryIndex];
                         let geometryValid = false;

--- a/types/plugins/XKTLoaderPlugin/XKTLoaderPlugin.d.ts
+++ b/types/plugins/XKTLoaderPlugin/XKTLoaderPlugin.d.ts
@@ -1,5 +1,9 @@
 import {IFCObjectDefaults, Plugin, VBOSceneModel, Viewer} from "../../viewer";
 
+type ReuseGeometries =
+    | boolean
+    | ((geometryConfig: { instanceCount: number }) => boolean);
+
 export declare type XKTLoaderPluginConfiguration = {
     /** Optional ID for this plugin, so that we can find it within {@link Viewer.plugins}. */
     id?: string;
@@ -16,7 +20,7 @@ export declare type XKTLoaderPluginConfiguration = {
     /** When loading metadata and this is ````true````, will only load {@link Entity}s that have {@link MetaObject}s (that are not excluded). This is useful when we don't want Entitys in the Scene that are not represented within IFC navigation components, such as {@link TreeViewPlugin}. */
     excludeUnclassifiedObjects?: boolean;
     /** Indicates whether to enable geometry reuse */
-    reuseGeometries?: boolean;
+    reuseGeometries?: ReuseGeometries;
     /** Maximum geometry batch size, as number of vertices. */
     maxGeometryBatchSize?: number;
 };
@@ -74,7 +78,7 @@ export declare type LoadXKTModel = {
      * all geometry instances into batches (````false````), and not use instancing to render them. Setting this ````false```` can significantly
      * improve Viewer performance for models that have excessive geometry reuse, but may also increases the amount of
      * browser and GPU memory used by the model. See [#769](https://github.com/xeokit/xeokit-sdk/issues/769) for more info. */
-    reuseGeometries?: boolean;
+    reuseGeometries?: ReuseGeometries;
     /** When ````true```` (default) use data textures (DTX), where appropriate, to
      * represent the returned model. Set false to always use vertex buffer objects (VBOs). Note that DTX is only applicable
      * to non-textured triangle meshes, and that VBOs are always used for meshes that have textures, line segments, or point
@@ -267,7 +271,7 @@ export declare class XKTLoaderPlugin extends Plugin {
      *
      * @type {Boolean}
      */
-    set reuseGeometries(arg: boolean);
+    set reuseGeometries(arg: ReuseGeometries);
 
     /**
      * Gets whether XKTLoaderPlugin enables geometry reuse when loading models.
@@ -276,7 +280,7 @@ export declare class XKTLoaderPlugin extends Plugin {
      *
      * @type {Boolean}
      */
-    get reuseGeometries(): boolean;
+    get reuseGeometries(): ReuseGeometries;
 
     /**
      * Gets the ````.xkt```` format versions supported by this XKTLoaderPlugin/


### PR DESCRIPTION
Accept a function as the `XKTLoaderPlugin::load::reuseGeometries` parameter, to allow expressing a conditional strategy for whether a geometry should be instanced or not.