### PR TITLE
Fix the reuseGeometries param description

### DIFF
--- a/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
+++ b/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
@@ -920,9 +920,9 @@ class XKTLoaderPlugin extends Plugin {
      * Viewer will hide backfaces on watertight meshes, show backfaces on open meshes, and always show backfaces on meshes when we slice them open with {@link SectionPlane}s.
      * @param {Boolean} [params.excludeUnclassifiedObjects=false] When loading metadata and this is ````true````, will only load {@link Entity}s that have {@link MetaObject}s (that are not excluded). This is useful when we don't want Entitys in the Scene that are not represented within IFC navigation components, such as {@link TreeViewPlugin}.
      * @param {Boolean} [params.globalizeObjectIds=false] Indicates whether to globalize each {@link Entity#id} and {@link MetaObject#id}, in case you need to prevent ID clashes with other models. See {@link XKTLoaderPlugin#globalizeObjectIds} for more info.
-     * @param {Boolean|Function} [params.reuseGeometries=true] Indicates whether to enable geometry reuse (````true```` by default) or whether to expand, a function will be called with a `{ instanceCount: <number> }` argument.
-     * all geometry instances into batches (````false````), and not use instancing to render them. Setting this ````false```` can significantly
-     * improve Viewer performance for models that have excessive geometry reuse, but may also increases the amount of
+     * @param {Boolean|Function} [params.reuseGeometries=true] Indicates whether to enable geometry reuse (````true```` by default) or whether to expand
+     * all geometry instances into batches (````false````), and not use instancing to render them. A function will be called with a `{ instanceCount: <number> }` argument. Setting this ````false```` can significantly
+     * improve Viewer performance for models that have excessive geometry reuse, but may also increase the amount of
      * browser and GPU memory used by the model. See [#769](https://github.com/xeokit/xeokit-sdk/issues/769) for more info.
      * @param {Boolean} [params.dtxEnabled=true] When ````true```` (default) use data textures (DTX), where appropriate, to
      * represent the returned model. Set false to always use vertex buffer objects (VBOs). Note that DTX is only applicable


### PR DESCRIPTION
This PR moves new comment into the new sentence to not mess with existing one and fixes one typo.