### PR TITLE
XCD-475 Add camera.ortho.fitMode

### DIFF
--- a/src/viewer/scene/camera/Ortho.js
+++ b/src/viewer/scene/camera/Ortho.js
@@ -51,6 +51,7 @@ class Ortho extends Component {
         this.scale = cfg.scale;
         this.near = cfg.near;
         this.far = cfg.far;
+        this.fitMode = cfg.fitMode ?? "auto";
 
         this._onCanvasBoundary = this.scene.canvas.on("boundary", this._needUpdate, this);
     }
@@ -74,13 +75,13 @@ class Ortho extends Component {
         let top;
         let bottom;
 
-        if (boundaryWidth > boundaryHeight) {
+        if (this._fitMode === "horizontal" || ((this._fitMode !== "vertical") && (boundaryWidth > boundaryHeight))) {
             left = -halfSize;
             right = halfSize;
             top = halfSize / aspect;
             bottom = -halfSize / aspect;
-
-        } else {
+        }
+        else {
             left = -halfSize * aspect;
             right = halfSize * aspect;
             top = halfSize;
@@ -97,9 +98,45 @@ class Ortho extends Component {
         this.fire("matrix", this._state.matrix);
     }
 
+    /**
+     * Sets camera fit mode.
+     * 
+     * If it's not set = automatic fit mode is enabled.
+     *
+     * Possible fit modes:
+     *
+     * \"auto\" = adjust in both dimensions, depending on the canvas width and height,
+     *
+     * \"vertical\" = tries to keep the vertical dimension constant, while adjusting the horizontal,
+     *
+     * \"horizontal\" = tries to keep the horizontal dimension constant, while adjusting the vertical.
+     *
+     * @param {String} value New fit mode value.
+     */
+    set fitMode(value) {
+        if (value === "auto" || value === "horizontal" || value === "vertical") {
+            this._fitMode = value;
+        }
+        else {
+            console.warn("Ortho.js Camera fitMode not recognized, setting to \"auto\".");
+            this._fitMode = "auto";
+        }
+        
+        this._needUpdate(0);
+        this.fire("fitMode", this._fitMode);
+    }
 
     /**
-     * Sets scale factor for this Ortho's extents on X and Y axis.
+     * Gets fit mode.
+     *
+     * @returns {String} Fit mode.
+     */
+    get fitMode() {
+        return this._fitMode;
+    }
+
+    /**
+     * Sets scale factor for this Ortho's extents on X and/or Y axis.
      *
      * Clamps to minimum value of ````0.01```.
      *
@@ -121,7 +158,7 @@ class Ortho extends Component {
     }
 
     /**
-     * Gets scale factor for this Ortho's extents on X and Y axis.
+     * Gets scale factor for this Ortho's extents on X and/or Y axis.
      *
      * Clamps to minimum value of ````0.01```.
      *


### PR DESCRIPTION
Hello @xeolabs and @MichalDybizbanskiCreoox,

this is the proposal of the Ortho.js improvement.

The idea is to allow the user to choose different behaviours of the ortho camera.

Currently we have an automatic fitting of the ortho view into the canvas, depending on the aspect ratio we keep the horizontal or vertical size.

This change allow the user to always keep the horizontal dimension or to always keep the vertical dimension.

This is the example of the wall 3 m high and 6 m long:
<img width="870" height="752" alt="image" src="https://github.com/user-attachments/assets/6d712c48-1d73-43d3-877f-faf24346343d" />

The existing ("auto") behavior for camera.ortho.scale = 6.0:

https://github.com/user-attachments/assets/b6313a08-ea4e-4986-8532-72b33b78db03

Optional "horizontal" behavior for camera.ortho.scale = 6.0:

https://github.com/user-attachments/assets/5cea3ee9-ef6c-422d-9a5f-38cc99f42780

Optional "vertical" behavior for camera.ortho.scale = 6.0:

https://github.com/user-attachments/assets/a5f9136c-e02b-4293-a9da-6af724fd0a9a

This is proposal, if it will be accepted I will add types.

Please let me know what you think about it.

Wojciech