### PR TITLE
XCD-505 Adding _renderer to Canvas

### DIFF
--- a/src/viewer/scene/scene/Scene.js
+++ b/src/viewer/scene/scene/Scene.js
@@ -636,6 +636,8 @@ class Scene extends Component {
             alphaDepthMask: alphaDepthMask
         });
 
+        this.canvas._renderer = this._renderer;
+
         this._sectionPlanesState = new (function () {
 
             this.sectionPlanes = [];


### PR DESCRIPTION
Hello @xeolabs and @MichalDybizbanskiCreoox,

this PR adds _renderer to the Canvas.

The reason behind is the fact that currently Canvas has undefined reference for _renderer.
Canvas extends Component which relies on _renderer for glRedraw.
It seems to me that the reason for it being undefined is the fact that Canvas is created here first: https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/scene/scene/Scene.js#L610-L620. And only then later renderer is created here: https://github.com/xeokit/xeokit-sdk/blob/master/src/viewer/scene/scene/Scene.js#L634-L637.

This existing behaviour ends up with the fact, that once you want to do e.g. this:
`viewer.scene.canvas.resolutionScale = 0.5;`
Then model disappears. You have to additionally call:
`viewer.scene.glRedraw()` to update it properly.

This PR tries to fix this issue, so there is no need to additionally call `viewer.scene.glRedraw()` after such operation.

Wojciech