### PR TITLE
Adds ".js" extension in the import

### DIFF
--- a/src/viewer/scene/sectionPlane/SectionPlaneCache.js
+++ b/src/viewer/scene/sectionPlane/SectionPlaneCache.js
@@ -1,6 +1,6 @@
 import {Component} from '../Component.js';
 import {math} from "../math/math.js";
-import {SectionPlane} from "./SectionPlane";
+import {SectionPlane} from "./SectionPlane.js";
 
 const tempVec3a = math.vec3();
 


### PR DESCRIPTION
This PR is related to this patch: https://github.com/xeokit/examples/blob/main/use-from-source.patch
It could allow us to simplify this patch.
It also makes it consistent with other imports in the repo.