### PR TITLE
XCD-514 Remove getLogDepth from OcclusionProgram.js

### DIFF
--- a/src/viewer/scene/model/layer/Layer.js
+++ b/src/viewer/scene/model/layer/Layer.js
@@ -338,7 +338,7 @@ export const getRenderers = (function() {
             if (primitive === "points") {
                 cache[sceneId] = {
                     colorRenderers:     { "sao-": { "vertex": lazy((vars, geo, c) => c(makeColorProgram(vars, geo, null, null))) } },
-                    occlusionRenderer:  lazy((vars, geo, c) => c(OcclusionProgram(vars, scene.logarithmicDepthBufferEnabled))),
+                    occlusionRenderer:  lazy((vars, geo, c) => c(OcclusionProgram(vars))),
                     pickDepthRenderer:  lazy(makePickDepthProgram),
                     pickMeshRenderer:   lazy(makePickMeshProgram),
                     // VBOBatchingPointsShadowRenderer has been implemented by 14e973df6268369b00baef60e468939e062ac320,
@@ -400,7 +400,7 @@ export const getRenderers = (function() {
                         uniform: lazy((vars, geo, c) => c(EdgesProgram(vars, geo, scene.logarithmicDepthBufferEnabled, true)),  { vertices: false }),
                         vertex:  lazy((vars, geo, c) => c(EdgesProgram(vars, geo, scene.logarithmicDepthBufferEnabled, false)), { vertices: false })
                     },
-                    occlusionRenderer:       lazy((vars, geo, c) => c(OcclusionProgram(vars, scene.logarithmicDepthBufferEnabled))),
+                    occlusionRenderer:       lazy((vars, geo, c) => c(OcclusionProgram(vars))),
                     pickDepthRenderer:       eager(makePickDepthProgram),
                     pickMeshRenderer:        eager(makePickMeshProgram),
                     pickNormalsFlatRenderer: eager((vars, geo, c) => makePickNormalsProgram(vars, geo, c, true)),

--- a/src/viewer/scene/model/layer/programs/OcclusionProgram.js
+++ b/src/viewer/scene/model/layer/programs/OcclusionProgram.js
@@ -1,11 +1,7 @@
-export const OcclusionProgram = function(programVariables, logarithmicDepthBufferEnabled) {
+export const OcclusionProgram = function(programVariables) {
     const outColor = programVariables.createOutput("vec4", "outColor");
     return {
         programName: "Occlusion",
-        // Logarithmic depth buffer involves an accuracy tradeoff, sacrificing
-        // accuracy at close range to improve accuracy at long range. This can
-        // mess up accuracy for occlusion tests, so we'll disable for now.
-        getLogDepth: false && logarithmicDepthBufferEnabled && (vFragDepth => vFragDepth),
         renderPassFlag: 0,  // COLOR_OPAQUE // Only opaque objects can be occluders
         appendFragmentOutputs: (src) => src.push(`${outColor} = vec4(0.0, 0.0, 1.0, 1.0);`) // Occluders are blue
     };

--- a/src/viewer/scene/webgl/occlusion/OcclusionTester.js
+++ b/src/viewer/scene/webgl/occlusion/OcclusionTester.js
@@ -132,13 +132,12 @@ export class OcclusionTester {
                 "OcclusionTester",
                 {
                     sectionPlanesState: sectionPlanesState,
-                    getLogDepth: scene.logarithmicDepthBufferEnabled && (vFragDepth => vFragDepth),
                     clippableTest: () => "true",
                     getVertexData: () => {
                         const src = [ ];
                         src.push(`vec4 worldPosition = vec4(${position}, 1.0);`);
                         src.push(`vec4 ${clipPos} = ${projMatrix} * ${viewMatrix} * worldPosition;`);
-                        if ((! scene.logarithmicDepthBufferEnabled) && (scene.markerZOffset < 0.000)) {
+                        if (scene.markerZOffset < 0.000) {
                             src.push(`${clipPos}.z += ${scene.markerZOffset};`);
                         }
                         return src;


### PR DESCRIPTION
Hey @xeolabs and @MichalDybizbanskiCreoox,

This PR removes getLogDepth from OcclusionProgram.js to enable culling of Annotations also when logarithmicDepthBufferEnabled is true.

Please have a look at this one, give it a test, and let me know if it's what you had in mind during the call.

Thank you, Wojciech