### PR TITLE
XEOK-505 Extend XKTLoaderPlugin with optional metadata adapter

### DIFF
--- a/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
+++ b/src/plugins/XKTLoaderPlugin/XKTLoaderPlugin.js
@@ -896,7 +896,7 @@ class XKTLoaderPlugin extends Plugin {
      * @param {ArrayBuffer} [params.xkt] The *````.xkt````* file data, as an alternative to the ````src```` parameter.
      * @param {String} [params.metaModelSrc] Path or URL to an optional metadata file, as an alternative to the ````metaModelData```` parameter.
      * @param {*} [params.metaModelData] JSON model metadata, as an alternative to the ````metaModelSrc```` parameter.
-     * @param {Boolean} [params.loadIntoMetaScene=true] Whether to load metadata into MetaScene, otherwise expose as SceneModel::metadata.
+     * @param {Boolean|Function} [params.loadIntoMetaScene=true] Whether to load metadata into ````MetaScene````, otherwise expose as ````SceneModel::metadata````. If provided as a function, it will be called with either ````metaModelSrc````'s contents, ````metaModelData```` value, or xkt's embedded metadata, and the function's return value will be used as ````metaModel.loadData````'s input.
      * @param {String} [params.manifestSrc] Path or URL to a JSON manifest file that provides paths to ````.xkt```` files to load as parts of the model. Use this option to load models that have been split into
      * multiple XKT files. See [tutorial](https://xeokit.io/blog/automatically-splitting-large-models-for-better-performance) for more info.
      * @param {Object} [params.manifest] A JSON manifest object (as an alternative to a path or URL) that provides paths to ````.xkt```` files to load as parts of the model. Use this option to load models that have been split into
@@ -995,10 +995,19 @@ class XKTLoaderPlugin extends Plugin {
 
         const loadIntoMetaScene = (! ("loadIntoMetaScene" in params)) || params.loadIntoMetaScene;
         const metaModel = (loadIntoMetaScene
-                           ? new MetaModel({
-                               id: modelId,
-                               metaScene: this.viewer.metaScene
-                           })
+                           ? (() => {
+                               const metaModel = new MetaModel({
+                                   id: modelId,
+                                   metaScene: this.viewer.metaScene
+                               });
+                               if (typeof loadIntoMetaScene === "function") {
+                                   const origLoadData = metaModel.loadData;
+                                   metaModel.loadData = function(metaModelData, options = {}) {
+                                       return origLoadData.call(this, loadIntoMetaScene(metaModelData), options);
+                                   };
+                               }
+                               return metaModel;
+                           })()
                            : (function() {
                                let firstMetadata = null;
                                let modelMetadata = null;

--- a/types/plugins/XKTLoaderPlugin/XKTLoaderPlugin.d.ts
+++ b/types/plugins/XKTLoaderPlugin/XKTLoaderPlugin.d.ts
@@ -36,8 +36,8 @@ export declare type LoadXKTModel = {
     metaModelSrc?: string;
     /** JSON model metadata, as an alternative to the ````metaModelSrc```` parameter. */
     metaModelData?: any;
-    /** Whether to load metadata into MetaScene, otherwise expose as SceneModel::metadata. Defaults to `true`. */
-    loadIntoMetaScene?: boolean;
+    /** Whether to load metadata into ````MetaScene````, otherwise expose as ````SceneModel::metadata````. If provided a function, the function will be called with either ````metaModelSrc````'s contents, ````metaModelData```` value, or xkt's embedded metadata, and the function's return value will be used as ````metaModel.loadData````'s input. Defaults to `true`. */
+    loadIntoMetaScene?: boolean | ((metadata: any) => any);
     /** Path or URL to a JSON manifest file that provides paths or URLs to ````.xkt```` files to load as parts of the model. Use this option to load models that have been split into multiple XKT files. See [tutorial](https://xeokit.io/blog/automatically-splitting-large-models-for-better-performance) for more info.*/
     manifestSrc?: any;
     /** A JSON manifest object (as an alternative to a path or URL) that provides paths or URLs to ````.xkt```` files to load as parts of the model. Use this option to load models that have been split into multiple XKT files. See [tutorial](https://xeokit.io/blog/automatically-splitting-large-models-for-better-performance) for more info. */


### PR DESCRIPTION
Extends the `XKTLoader::load` `loadIntoMetaScene` parameter’s semantics to handle an integrator-defined `function` value as an adapter that takes the loader’s input metadata as an argument, and returns metadata compatible with `TreeViewPlugin` and other IFC-specific features.
The `loadIntoMetaScene` retains original semantics if a non-functional value (e.g. a `bool`) provided.

Simple example of xeoRvt data adapter:
```js
const sceneModel = xktLoader.load({
    src: xktSrc,
    loadIntoMetaScene: function(metadata) {
        const baseId     = xktSrc;
        const projectId  = `${baseId}-project`;
        const buildingId = `${baseId}-building`;
        return {
            metaObjects: [
                {
                    id:   projectId,
                    name: xktSrc,
                    type: "IfcProject"
                },
                {
                    id:     buildingId,
                    name:   `${xktSrc} Building`,
                    type:   "IfcBuilding",
                    parent: projectId
                }
            ].concat(
                metadata.Elements.filter(e => e.class === "Level").map(e => ({
                    id:     e.Id,
                    name:   e.Name,
                    type:   "IfcBuildingStorey",
                    parent: buildingId
                }))
            ).concat(
                metadata.Elements.map(e => {
                    const drawableId = e.appearances && (e.appearances.length > 0) && e.appearances[0];
                    return drawableId && {
                        id:     drawableId,
                        name:   `${e.Name} [#${e.Id}]`,
                        type:   ("Type" in e) ? metadata.Elements[e.Type].Name : e.class,
                        parent: ("Level" in e) ? metadata.Elements[e.Level].Id : buildingId
                    };
                }).filter(v => v))
        };
    }
});
```